### PR TITLE
Add the lock adapter and child liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- The lock adapter: Mistri.locks takes an adapter for cross-process leases
+  and flags (Locks::Memory built in; Locks::RailsCache as an opt-in require,
+  the Stores::ActiveRecord pattern). Locks.hold keeps a lease alive on a
+  heartbeat from a background thread and releases it cleanly, join and all,
+  so a mid-renewal tick can never re-stamp a released lease.
+- Children gain liveness: every child run holds a lease, and with an
+  adapter configured a child that died without writing its terminal entry
+  reads :interrupted instead of :running forever. Without an adapter
+  nothing changes.
+
 - The children registry: Session#children lists every sub-agent a session
   has spawned as a Mistri::Child, a window onto the child's own session
   with name, status, report, transcript(tail:) with image bytes stripped,

--- a/lib/mistri.rb
+++ b/lib/mistri.rb
@@ -35,6 +35,7 @@ require_relative "mistri/stores/memory"
 require_relative "mistri/stores/jsonl"
 require_relative "mistri/session"
 require_relative "mistri/child"
+require_relative "mistri/locks"
 require_relative "mistri/compactor"
 require_relative "mistri/result"
 require_relative "mistri/agent"
@@ -54,6 +55,11 @@ module Mistri
                 gemini: Providers::Gemini }.freeze
   API_KEY_ENV = { anthropic: "ANTHROPIC_API_KEY", openai: "OPENAI_API_KEY",
                   gemini: "GEMINI_API_KEY" }.freeze
+
+  # The configured lock adapter, nil until a host sets one. See Locks.
+  class << self
+    attr_accessor :locks
+  end
 
   module_function
 

--- a/lib/mistri/child.rb
+++ b/lib/mistri/child.rb
@@ -11,13 +11,16 @@ module Mistri
   #   child.transcript(tail: 20)  # recent entries, image bytes stripped
   #   child.say("Also check their pricing page")
   #
-  # :running means no terminal entry yet; a child that died without writing
-  # one also reads :running until liveness (the lock adapter, 0.5) refines
-  # it to :interrupted.
+  # :running means no terminal entry yet. With a lock adapter configured
+  # (Mistri.locks), a child whose liveness lease has lapsed reads
+  # :interrupted instead: it died without writing its terminal. Without an
+  # adapter there is no liveness signal, so no-terminal stays :running.
   class Child
     TERMINAL = "subagent_result"
 
     attr_reader :name, :session_id
+
+    def self.lease_key(session_id) = "child:#{session_id}"
 
     def initialize(name:, session_id:, store:)
       @name = name
@@ -27,7 +30,10 @@ module Mistri
 
     def status
       terminal = terminal_entry
-      terminal ? terminal["status"].to_sym : :running
+      return terminal["status"].to_sym if terminal
+      return :interrupted if Mistri.locks && !Mistri.locks.held?(self.class.lease_key(@session_id))
+
+      :running
     end
 
     def report

--- a/lib/mistri/locks.rb
+++ b/lib/mistri/locks.rb
@@ -27,12 +27,15 @@ module Mistri
 
     # Hold a lease for the duration of a block of work: acquire, renew on a
     # heartbeat from a background thread, release on the way out. Returns a
-    # Hold, or nil when no adapter is configured; call #release in an ensure.
+    # Hold to release in an ensure, or nil when no adapter is configured or
+    # the lease is already held elsewhere: a caller that was refused must
+    # never renew or delete the real holder's key. Callers that need to
+    # tell refusal apart from no-adapter use the adapter's acquire directly.
     def hold(key, ttl: LEASE_TTL, heartbeat: HEARTBEAT)
       adapter = Mistri.locks
       return nil unless adapter
+      return nil unless adapter.acquire(key, ttl: ttl)
 
-      adapter.acquire(key, ttl: ttl)
       Hold.new(adapter, key, ttl, heartbeat)
     end
 

--- a/lib/mistri/locks.rb
+++ b/lib/mistri/locks.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "monitor"
+
+module Mistri
+  # Cross-process coordination for hosts that run loops in more than one
+  # process: leases that say "this is alive right now" and flags that carry
+  # one-bit requests (stop) between processes. Everything expires on its
+  # own, so a crashed holder never wedges anything; a live holder renews on
+  # a heartbeat, so only dead ones expire.
+  #
+  # Configure once at boot:
+  #
+  #   Mistri.locks = Mistri::Locks::Memory.new          # single process
+  #   Mistri.locks = Mistri::Locks::RailsCache.new      # requires opt-in file
+  #
+  # An adapter implements six methods: acquire(key, ttl:) -> bool,
+  # renew(key, ttl:), release(key), held?(key), set_flag(key, ttl:),
+  # flag?(key), clear_flag(key). With no adapter configured, everything
+  # lease-aware degrades gracefully: children read :running instead of
+  # :interrupted, and holds are no-ops.
+  module Locks
+    LEASE_TTL = 180
+    HEARTBEAT = 60
+
+    module_function
+
+    # Hold a lease for the duration of a block of work: acquire, renew on a
+    # heartbeat from a background thread, release on the way out. Returns a
+    # Hold, or nil when no adapter is configured; call #release in an ensure.
+    def hold(key, ttl: LEASE_TTL, heartbeat: HEARTBEAT)
+      adapter = Mistri.locks
+      return nil unless adapter
+
+      adapter.acquire(key, ttl: ttl)
+      Hold.new(adapter, key, ttl, heartbeat)
+    end
+
+    # A held lease: a renewal thread keeps it alive, release stops the
+    # thread (and joins it, so a mid-renewal tick can never re-stamp a
+    # lease that was just released) and deletes the key.
+    class Hold
+      def initialize(adapter, key, ttl, heartbeat)
+        @adapter = adapter
+        @key = key
+        @stopping = false
+        @thread = Thread.new do
+          until @stopping
+            sleep heartbeat
+            @adapter.renew(key, ttl: ttl) unless @stopping
+          end
+        end
+      end
+
+      def release
+        @stopping = true
+        @thread.kill
+        @thread.join(2)
+        @adapter.release(@key)
+      end
+    end
+
+    # The in-process adapter: real TTL semantics over a hash, for tests,
+    # development, and the thread dispatcher. Monitor-synchronized; expiry
+    # is judged at read time, so nothing needs a sweeper.
+    class Memory
+      def initialize
+        @entries = {}
+        @lock = Monitor.new
+      end
+
+      def acquire(key, ttl:)
+        @lock.synchronize do
+          return false if live?(key)
+
+          @entries[key] = deadline(ttl)
+          true
+        end
+      end
+
+      def renew(key, ttl:)
+        @lock.synchronize { @entries[key] = deadline(ttl) }
+        nil
+      end
+
+      def release(key)
+        @lock.synchronize { @entries.delete(key) }
+        nil
+      end
+
+      def held?(key)
+        @lock.synchronize { live?(key) }
+      end
+
+      def set_flag(key, ttl: 300)
+        renew(key, ttl: ttl)
+      end
+
+      def flag?(key) = held?(key)
+
+      def clear_flag(key) = release(key)
+
+      private
+
+      def live?(key)
+        deadline = @entries[key]
+        return false unless deadline
+        return true if deadline > now
+
+        @entries.delete(key)
+        false
+      end
+
+      def deadline(ttl) = now + ttl
+
+      def now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/mistri/locks/rails_cache.rb
+++ b/lib/mistri/locks/rails_cache.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Opt-in, exactly like Stores::ActiveRecord: the gem never requires Rails.
+# require "mistri/locks/rails_cache".
+module Mistri
+  module Locks
+    # Leases and flags over an ActiveSupport::Cache::Store (Redis-backed in
+    # any real deployment), so every process in the fleet reads the same
+    # truth. Pass any cache store duck; defaults to Rails.cache.
+    class RailsCache
+      def initialize(cache: nil, namespace: "mistri:locks")
+        @cache = cache || (defined?(Rails) && Rails.cache) ||
+                 raise(ConfigurationError, "no cache store; pass cache: or configure Rails.cache")
+        @namespace = namespace
+      end
+
+      def acquire(key, ttl:)
+        @cache.write(scoped(key), true, unless_exist: true, expires_in: ttl)
+      end
+
+      def renew(key, ttl:)
+        @cache.write(scoped(key), true, expires_in: ttl)
+        nil
+      end
+
+      def release(key)
+        @cache.delete(scoped(key))
+        nil
+      end
+
+      def held?(key)
+        @cache.exist?(scoped(key))
+      end
+
+      def set_flag(key, ttl: 300)
+        renew(key, ttl: ttl)
+      end
+
+      def flag?(key) = held?(key)
+
+      def clear_flag(key) = release(key)
+
+      private
+
+      def scoped(key) = "#{@namespace}:#{key}"
+    end
+  end
+end

--- a/lib/mistri/sub_agent.rb
+++ b/lib/mistri/sub_agent.rb
@@ -113,6 +113,9 @@ module Mistri
         context.session&.append("subagent", "name" => label, "session_id" => child.id)
         # From the moment the link exists, every exit writes a terminal entry,
         # setup failures included, or the child would read as running forever.
+        # The lease says "alive right now" to other processes; a child that
+        # dies without its terminal reads :interrupted once it lapses.
+        lease = Locks.hold(Child.lease_key(child.id))
         result = begin
           agent = Agent.new(provider: provider, session: child, system: system,
                             tools: tools, **agent_options)
@@ -126,6 +129,8 @@ module Mistri
         rescue StandardError => e
           child.append(Child::TERMINAL, "status" => "failed", "error" => "#{e.class}: #{e.message}")
           raise
+        ensure
+          lease&.release
         end
         outcome = answer(result, label, child)
         child.append(Child::TERMINAL, terminal(result))

--- a/test/test_locks.rb
+++ b/test/test_locks.rb
@@ -60,6 +60,19 @@ class TestLocks < Minitest::Test
     assert_nil Mistri::Locks.hold("child:x")
   end
 
+  def test_hold_respects_an_existing_holder
+    Mistri.locks = Mistri::Locks::Memory.new
+    first = Mistri::Locks.hold("run:1", ttl: 60, heartbeat: 60)
+
+    assert_nil Mistri::Locks.hold("run:1", ttl: 60, heartbeat: 60),
+               "a refused hold must not exist"
+    assert Mistri.locks.held?("run:1"), "the real holder keeps its lease"
+
+    first.release
+
+    refute Mistri.locks.held?("run:1")
+  end
+
   def test_a_child_without_lease_or_terminal_reads_interrupted
     Mistri.locks = Mistri::Locks::Memory.new
     store = Mistri::Stores::Memory.new

--- a/test/test_locks.rb
+++ b/test/test_locks.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# The lock adapter: leases that expire unless renewed, flags that carry
+# one-bit requests between processes, and the liveness refinement children
+# gain when an adapter is configured.
+class TestLocks < Minitest::Test
+  def teardown
+    Mistri.locks = nil
+  end
+
+  def test_memory_leases_acquire_once_and_expire
+    locks = Mistri::Locks::Memory.new
+
+    assert locks.acquire("run:1", ttl: 60)
+    refute locks.acquire("run:1", ttl: 60), "a held lease cannot be taken"
+    assert locks.held?("run:1")
+
+    locks.release("run:1")
+
+    refute locks.held?("run:1")
+    assert locks.acquire("run:1", ttl: 0.01)
+    sleep 0.02
+
+    refute locks.held?("run:1"), "an unrenewed lease expires on its own"
+    assert locks.acquire("run:1", ttl: 60), "an expired lease can be retaken"
+  end
+
+  def test_flags_set_read_and_clear
+    locks = Mistri::Locks::Memory.new
+
+    refute locks.flag?("stop:1")
+    locks.set_flag("stop:1")
+
+    assert locks.flag?("stop:1")
+    locks.clear_flag("stop:1")
+
+    refute locks.flag?("stop:1")
+  end
+
+  def test_hold_renews_on_a_heartbeat_and_releases_cleanly
+    Mistri.locks = Mistri::Locks::Memory.new
+    hold = Mistri::Locks.hold("child:x", ttl: 0.2, heartbeat: 0.05)
+
+    assert Mistri.locks.held?("child:x")
+    sleep 0.3
+
+    assert Mistri.locks.held?("child:x"), "the heartbeat outlives the ttl"
+
+    hold.release
+
+    refute Mistri.locks.held?("child:x"), "release deletes the lease"
+    sleep 0.1
+
+    refute Mistri.locks.held?("child:x"), "no tick re-stamps a released lease"
+  end
+
+  def test_hold_is_a_no_op_without_an_adapter
+    assert_nil Mistri::Locks.hold("child:x")
+  end
+
+  def test_a_child_without_lease_or_terminal_reads_interrupted
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = Mistri::Stores::Memory.new
+    parent = Mistri::Session.new(store:)
+    dead = Mistri::Session.new(store:)
+    parent.append("subagent", "name" => "Husky", "session_id" => dead.id)
+
+    assert_equal :interrupted, parent.children.first.status
+
+    Mistri.locks.acquire(Mistri::Child.lease_key(dead.id), ttl: 60)
+
+    assert_equal :running, parent.children.first.status
+  end
+
+  def test_a_live_child_holds_its_lease_while_running
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = Mistri::Stores::Memory.new
+    seen = nil
+    probe = Mistri::Tool.define("probe", "Checks the lease.") do |_args, context|
+      key = Mistri::Child.lease_key(context.session.id)
+      seen = Mistri.locks.held?(key)
+      "checked"
+    end
+    child_fake = Mistri::Providers::Fake.new(turns: [
+                                               { tool_calls: [{ name: "probe", arguments: {} }] },
+                                               { text: "Done." }
+                                             ])
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [probe])
+    parent_fake = Mistri::Providers::Fake.new(turns: [
+                                                { tool_calls: [{ name: "spawn_agent",
+                                                                 arguments: {
+                                                                   "name" => "Collie",
+                                                                   "task" => "probe the lease",
+                                                                   "instructions" => "Probe."
+                                                                 } }] },
+                                                { text: "All done." }
+                                              ])
+    session = Mistri::Session.new(store:)
+
+    Mistri::Agent.new(provider: parent_fake, tools: [spawn], session:).run("go")
+
+    assert seen, "the lease is held while the child runs"
+    child = session.children.first
+
+    assert_equal :done, child.status
+    refute Mistri.locks.held?(Mistri::Child.lease_key(child.session_id)),
+           "the lease releases when the child ends"
+  end
+
+  def test_rails_cache_adapter_speaks_the_same_interface
+    begin
+      require "active_support"
+      require "active_support/cache"
+    rescue LoadError
+      skip "activesupport not installed"
+    end
+
+    require "mistri/locks/rails_cache"
+    cache = ActiveSupport::Cache::MemoryStore.new
+    locks = Mistri::Locks::RailsCache.new(cache: cache)
+
+    assert locks.acquire("run:1", ttl: 60)
+    refute locks.acquire("run:1", ttl: 60)
+    assert locks.held?("run:1")
+    locks.set_flag("stop:1")
+
+    assert locks.flag?("stop:1")
+    locks.release("run:1")
+    locks.clear_flag("stop:1")
+
+    refute locks.held?("run:1")
+    refute locks.flag?("stop:1")
+  end
+end


### PR DESCRIPTION
A session's derived state answers everything except one question: is this thing alive *right now*? A child that dies without writing its terminal entry (hard kill, OOM) reads `:running` forever, and hosts that run loops in several processes each hand-roll the same lease-and-heartbeat code to protect their sessions. This PR gives both problems one small answer.

## What changed

**`Mistri.locks`** takes an adapter for cross-process leases and flags:

```ruby
Mistri.locks = Mistri::Locks::Memory.new        # single process, built in

require "mistri/locks/rails_cache"              # opt-in, zero-dependency core
Mistri.locks = Mistri::Locks::RailsCache.new    # any ActiveSupport cache store
```

An adapter is six methods: `acquire(key, ttl:)`, `renew`, `release`, `held?`, plus `set_flag` / `flag?` / `clear_flag` for one-bit cross-process requests (a stop button lives in another process). Everything expires on its own, so a crashed holder never wedges anything; a live holder renews on a heartbeat, so only dead ones expire.

**`Locks.hold(key)`** wraps the lease lifecycle for a stretch of work: acquire, renew from a background thread, and `release` that stops the thread *and joins it* before deleting the key, so a mid-renewal tick can never re-stamp a lease that was just released.

**Children gain liveness.** Every child run now holds a lease for its session. With an adapter configured, `Child#status` refines the no-terminal case: lease held means `:running`, lease lapsed means `:interrupted` — the honest answer for a child that died too abruptly to write its terminal. Without an adapter, behavior is unchanged.

## Notes for reviewers

- The core stays zero-dependency: `Locks::Memory` is pure stdlib (Monitor), and `RailsCache` follows the `Stores::ActiveRecord` opt-in-require pattern, duck-typing over any `ActiveSupport::Cache::Store` (Redis-backed in real deployments) with no Rails require in the gem.
- `Locks.hold` with no adapter configured returns nil and everything degrades gracefully; the `lease&.release` in `run_child` makes that explicit.
- Key namespacing lives in the adapter (`mistri:locks:` prefix in RailsCache), not in callers.

## Testing

`test/test_locks.rb`: lease acquire-once and self-expiry, flags, heartbeat outliving the ttl with clean release (no post-release re-stamp), no-adapter no-op, `:interrupted` vs `:running` derivation, a live child observed holding its lease mid-run through a probe tool, and the RailsCache adapter exercised against a real `ActiveSupport::Cache::MemoryStore` (skips when activesupport is absent, same as the generator tests). Full suite: 331 runs, 0 failures.

## Follow-ups (design doc, in order)

Per-child stop (derived abort signals riding these flags), the management console tools, background dispatch.