### PR TITLE
Stop one child and keep the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Stop one child, keep the run: every sub-agent now runs on its own signal
+  derived from the parent's (AbortSignal#derive), so the parent's abort
+  still cascades down while Child#stop ends a single worker and the parent
+  reasons on with "[the X sub-agent was stopped]". Cross-process stops ride
+  the lock adapter's flags; the lease thread turns them into the child's
+  cooperative abort within a tick.
+- A run stopped during its tool phase now reports :aborted. The final
+  assistant message is clean in that case, so the message's stop reason
+  read :completed and a user-stopped run could claim success; the signal
+  is consulted alongside the message.
+
 - The lock adapter: Mistri.locks takes an adapter for cross-process leases
   and flags (Locks::Memory built in; Locks::RailsCache as an opt-in require,
   the Stores::ActiveRecord pattern). Locks.hold keeps a lease alive on a

--- a/lib/mistri/abort_signal.rb
+++ b/lib/mistri/abort_signal.rb
@@ -32,6 +32,16 @@ module Mistri
       nil
     end
 
+    # A signal that trips when this one does, never the reverse: abort the
+    # derived signal alone and this one runs on. Returns [signal, handle];
+    # remove the handle when the derived work ends, so a finished child
+    # never leaks a callback into a later abort.
+    def derive
+      child = AbortSignal.new
+      handle = on_abort { child.abort!(reason) }
+      [child, handle]
+    end
+
     # Register a callback for the moment of abort. Fires immediately when the
     # signal is already tripped. Returns a handle for #remove_callback.
     def on_abort(&callback)

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -155,7 +155,7 @@ module Mistri
         # transcript is unpairable and replay fails.
         parked = last.tool_calls? ? run_tools(last, signal, &emit) : []
         return suspended(last, parked, usage) if parked.any?
-        return finished(last, usage) if done?(last, signal)
+        return finished(last, usage, signal) if done?(last, signal)
       end
     end
 
@@ -347,9 +347,13 @@ module Mistri
       tool ? tool.needs_approval?(call.arguments) : false
     end
 
-    def finished(message, usage)
+    # A run stopped during its tool phase ends with a clean assistant
+    # message, so the message's stop reason alone would read :completed;
+    # the signal is what knows the user stopped it.
+    def finished(message, usage, signal = nil)
       status = { StopReason::ABORTED => :aborted, StopReason::BUDGET => :budget,
                  StopReason::ERROR => :error }.fetch(message.stop_reason, :completed)
+      status = :aborted if status == :completed && signal&.aborted?
       Result.new(message: message, status: status, usage: usage)
     end
 

--- a/lib/mistri/child.rb
+++ b/lib/mistri/child.rb
@@ -22,6 +22,8 @@ module Mistri
 
     def self.lease_key(session_id) = "child:#{session_id}"
 
+    def self.stop_key(session_id) = "child-stop:#{session_id}"
+
     def initialize(name:, session_id:, store:)
       @name = name
       @session_id = session_id
@@ -54,6 +56,18 @@ module Mistri
     # child that finishes first never sees it.
     def say(text)
       session.steer(text)
+    end
+
+    # Ask a running child to stop, from any process. The child's runner sees
+    # the flag within a tick and trips the child's own signal; the parent
+    # runs on. Stop is cross-process by nature, so it needs a lock adapter;
+    # without one this returns false. An action that reports acceptance,
+    # not a predicate.
+    def stop # rubocop:disable Naming/PredicateMethod
+      return false unless Mistri.locks
+
+      Mistri.locks.set_flag(self.class.stop_key(@session_id))
+      true
     end
 
     def to_h

--- a/lib/mistri/locks.rb
+++ b/lib/mistri/locks.rb
@@ -31,26 +31,40 @@ module Mistri
     # the lease is already held elsewhere: a caller that was refused must
     # never renew or delete the real holder's key. Callers that need to
     # tell refusal apart from no-adapter use the adapter's acquire directly.
-    def hold(key, ttl: LEASE_TTL, heartbeat: HEARTBEAT)
+    #
+    # With stop_key: and signal:, the same thread watches the flag and trips
+    # the signal within a tick, so a stop request written in another process
+    # becomes this run's cooperative abort.
+    def hold(key, ttl: LEASE_TTL, heartbeat: HEARTBEAT, stop_key: nil, signal: nil)
       adapter = Mistri.locks
       return nil unless adapter
       return nil unless adapter.acquire(key, ttl: ttl)
 
-      Hold.new(adapter, key, ttl, heartbeat)
+      Hold.new(adapter, key, ttl, heartbeat, stop_key: stop_key, signal: signal)
     end
 
-    # A held lease: a renewal thread keeps it alive, release stops the
-    # thread (and joins it, so a mid-renewal tick can never re-stamp a
-    # lease that was just released) and deletes the key.
+    # A held lease: one thread renews it on the heartbeat and watches the
+    # stop flag between renewals. release stops the thread (and joins it,
+    # so a mid-renewal tick can never re-stamp a lease that was just
+    # released) and deletes the key.
     class Hold
-      def initialize(adapter, key, ttl, heartbeat)
+      def initialize(adapter, key, ttl, heartbeat, stop_key: nil, signal: nil)
         @adapter = adapter
         @key = key
         @stopping = false
+        tick = [heartbeat, 1.0].min
         @thread = Thread.new do
+          elapsed = 0.0
           until @stopping
-            sleep heartbeat
-            @adapter.renew(key, ttl: ttl) unless @stopping
+            sleep tick
+            elapsed += tick
+            break if @stopping
+
+            signal.abort!("stopped by user") if stop_key && signal && adapter.flag?(stop_key)
+            if elapsed >= heartbeat
+              adapter.renew(key, ttl: ttl)
+              elapsed = 0.0
+            end
           end
         end
       end

--- a/lib/mistri/locks.rb
+++ b/lib/mistri/locks.rb
@@ -44,26 +44,27 @@ module Mistri
     end
 
     # A held lease: one thread renews it on the heartbeat and watches the
-    # stop flag between renewals. release stops the thread (and joins it,
-    # so a mid-renewal tick can never re-stamp a lease that was just
-    # released) and deletes the key.
+    # stop flag between renewals. Renewal runs on a monotonic deadline (the
+    # last sleep before it is the remaining fraction, never a full tick, so
+    # the cadence is exact and a lease can never lapse waiting for a tick to
+    # round up). release stops the thread (and joins it, so a mid-renewal
+    # tick can never re-stamp a lease that was just released) and deletes
+    # the key.
     class Hold
       def initialize(adapter, key, ttl, heartbeat, stop_key: nil, signal: nil)
         @adapter = adapter
         @key = key
         @stopping = false
-        tick = [heartbeat, 1.0].min
         @thread = Thread.new do
-          elapsed = 0.0
+          deadline = now + heartbeat
           until @stopping
-            sleep tick
-            elapsed += tick
+            sleep (deadline - now).clamp(0.01, 1.0)
             break if @stopping
 
             signal.abort!("stopped by user") if stop_key && signal && adapter.flag?(stop_key)
-            if elapsed >= heartbeat
+            if now >= deadline
               adapter.renew(key, ttl: ttl)
-              elapsed = 0.0
+              deadline = now + heartbeat
             end
           end
         end
@@ -75,6 +76,10 @@ module Mistri
         @thread.join(2)
         @adapter.release(@key)
       end
+
+      private
+
+      def now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     # The in-process adapter: real TTL semantics over a hash, for tests,

--- a/lib/mistri/sub_agent.rb
+++ b/lib/mistri/sub_agent.rb
@@ -113,24 +113,30 @@ module Mistri
         context.session&.append("subagent", "name" => label, "session_id" => child.id)
         # From the moment the link exists, every exit writes a terminal entry,
         # setup failures included, or the child would read as running forever.
-        # The lease says "alive right now" to other processes; a child that
-        # dies without its terminal reads :interrupted once it lapses.
-        lease = Locks.hold(Child.lease_key(child.id))
+        # The child runs on its own signal: the parent's abort cascades down
+        # through the derived handle, while stopping the child alone leaves
+        # the parent running. The lease says "alive right now" to other
+        # processes and its thread watches the child's stop flag.
+        signal, cascade = context.signal ? context.signal.derive : [AbortSignal.new, nil]
+        lease = Locks.hold(Child.lease_key(child.id),
+                           stop_key: Child.stop_key(child.id), signal: signal)
         result = begin
           agent = Agent.new(provider: provider, session: child, system: system,
                             tools: tools, **agent_options)
           origin = "#{label}##{child.id[0, 8]}"
           emit = ->(event) { forward(event, origin, context) }
           if schema
-            agent.task(task, schema: schema, signal: context.signal, &emit)
+            agent.task(task, schema: schema, signal: signal, &emit)
           else
-            agent.run(task, signal: context.signal, &emit)
+            agent.run(task, signal: signal, &emit)
           end
         rescue StandardError => e
           child.append(Child::TERMINAL, "status" => "failed", "error" => "#{e.class}: #{e.message}")
           raise
         ensure
           lease&.release
+          context.signal&.remove_callback(cascade) if cascade
+          Mistri.locks&.clear_flag(Child.stop_key(child.id))
         end
         outcome = answer(result, label, child)
         child.append(Child::TERMINAL, terminal(result))
@@ -184,7 +190,7 @@ module Mistri
           ToolResult.new(content: "The #{label} sub-agent stopped: it needed human " \
                                   "approval, which sub-agents cannot wait for.", ui: link)
         when :aborted
-          ToolResult.new(content: "[the #{label} sub-agent was aborted]", ui: link)
+          ToolResult.new(content: "[the #{label} sub-agent was stopped]", ui: link)
         else
           reason = result.error_message || result.status
           ToolResult.new(content: "The #{label} sub-agent failed: #{reason}", ui: link)

--- a/test/test_child_stop.rb
+++ b/test/test_child_stop.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Stopping one child: the parent's abort cascades down, a child's stop stays
+# its own, a cross-process stop flag becomes the child's cooperative abort
+# within a tick, and every stopped child ends with a stopped terminal while
+# the parent runs on.
+class TestChildStop < Minitest::Test
+  def teardown
+    Mistri.locks = nil
+  end
+
+  def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
+
+  def test_derive_cascades_down_and_never_up
+    parent = Mistri::AbortSignal.new
+    child, _handle = parent.derive
+
+    refute_predicate child, :aborted?
+    parent.abort!(:closing)
+
+    assert_predicate child, :aborted?, "the parent's abort reaches the child"
+    assert_equal :closing, child.reason
+
+    other_parent = Mistri::AbortSignal.new
+    other_child, = other_parent.derive
+    other_child.abort!(:done_early)
+
+    refute_predicate other_parent, :aborted?, "a child's abort never climbs"
+  end
+
+  def test_a_removed_handle_stops_the_cascade
+    parent = Mistri::AbortSignal.new
+    child, handle = parent.derive
+    parent.remove_callback(handle)
+
+    parent.abort!(:late)
+
+    refute_predicate child, :aborted?, "a finished child must not hear later aborts"
+  end
+
+  def test_a_run_stopped_during_tools_reports_aborted
+    signal = Mistri::AbortSignal.new
+    stop_here = Mistri::Tool.define("stop_here", "Trips the abort.") do
+      signal.abort!(:user_stop)
+      "stopped"
+    end
+    provider = fake({ tool_calls: [{ name: "stop_here", arguments: {} }] })
+    result = Mistri::Agent.new(provider:, tools: [stop_here]).run("go", signal:)
+
+    assert_predicate result, :aborted?, "the signal knows the user stopped it, not the message"
+  end
+
+  def test_stopping_a_child_leaves_the_parent_running
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = Mistri::Stores::Memory.new
+    linger = Mistri::Tool.define("linger", "Waits long enough to be stopped.") do |_a, context|
+      # Another process asks the child to stop; the lease thread's next tick
+      # turns the flag into this run's abort.
+      Mistri::Session.new(store:, id: context.session.id)
+                     .then { |s| Mistri::Child.new(name: "x", session_id: s.id, store:).stop }
+      sleep 1.3
+      "lingered"
+    end
+    child_fake = fake({ tool_calls: [{ name: "linger", arguments: {} }] },
+                      { text: "never reached" })
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [linger])
+    parent_fake = fake({ tool_calls: [{ name: "spawn_agent",
+                                        arguments: { "name" => "Husky", "task" => "linger",
+                                                     "instructions" => "Linger." } }] },
+                       { text: "Carried on without Husky." })
+    session = Mistri::Session.new(store:)
+
+    result = Mistri::Agent.new(provider: parent_fake, tools: [spawn], session:).run("go")
+
+    assert_equal "Carried on without Husky.", result.text, "the parent finishes its own run"
+    child = session.children.first
+
+    assert_equal :stopped, child.status
+    tool_message = session.messages.select(&:tool?).last
+
+    assert_match(/was stopped/, tool_message.text)
+    refute Mistri.locks.flag?(Mistri::Child.stop_key(child.session_id)),
+           "the stop flag clears when the child ends"
+  end
+
+  def test_stopping_the_parent_stops_a_running_child_through_the_cascade
+    store = Mistri::Stores::Memory.new
+    parent_signal = Mistri::AbortSignal.new
+    pull_plug = Mistri::Tool.define("pull_plug", "Stops the whole run.") do
+      parent_signal.abort!(:user_stop)
+      "plugged"
+    end
+    child_fake = fake({ tool_calls: [{ name: "pull_plug", arguments: {} }] },
+                      { text: "never reached" })
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [pull_plug])
+    parent_fake = fake({ tool_calls: [{ name: "spawn_agent",
+                                        arguments: { "name" => "Corgi", "task" => "go",
+                                                     "instructions" => "Go." } }] })
+    session = Mistri::Session.new(store:)
+
+    result = Mistri::Agent.new(provider: parent_fake, tools: [spawn], session:)
+                          .run("go", signal: parent_signal)
+
+    assert_predicate result, :aborted?, "the parent's own run reports the stop"
+    assert_equal :stopped, session.children.first.status,
+                 "the cascade reaches the running child"
+  end
+end

--- a/test/test_locks.rb
+++ b/test/test_locks.rb
@@ -60,6 +60,26 @@ class TestLocks < Minitest::Test
     assert_nil Mistri::Locks.hold("child:x")
   end
 
+  def test_renewal_honors_a_fractional_heartbeat_above_the_tick
+    renewed_at = []
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    spy = Class.new(Mistri::Locks::Memory) do
+      define_method(:renew) do |key, ttl:|
+        renewed_at << (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started)
+        super(key, ttl: ttl)
+      end
+    end.new
+    Mistri.locks = spy
+    hold = Mistri::Locks.hold("run:1", ttl: 5, heartbeat: 1.5)
+
+    sleep 1.9
+    hold.release
+
+    assert_predicate renewed_at, :any?, "a 1.5s heartbeat must have renewed by 1.9s"
+    assert_operator renewed_at.first, :<, 1.75,
+                    "renewal follows the requested cadence, not tick rounding"
+  end
+
   def test_hold_respects_an_existing_holder
     Mistri.locks = Mistri::Locks::Memory.new
     first = Mistri::Locks.hold("run:1", ttl: 60, heartbeat: 60)


### PR DESCRIPTION
Stopping things was all-or-nothing: one abort signal flowed from the parent into every child, so you could stop the whole run but never one worker. And a run stopped during its tool phase quietly reported `:completed`, because the final assistant message is clean in that case and the message's stop reason was the only thing consulted — a user-stopped run could claim success.

## What changed

**Derived signals.** `AbortSignal#derive` returns a child signal plus a removable handle: the parent's abort cascades down, a child's abort never climbs up, and removing the handle when the child finishes means a completed child never hears a later abort. Every sub-agent now runs on a derived signal.

```ruby
child_signal, handle = parent_signal.derive
# parent aborts -> child aborts (reason carried); child aborts -> parent unaffected
parent_signal.remove_callback(handle)  # when the child's work ends
```

**`Child#stop`.** Sets the child's stop flag through the lock adapter; the lease thread (from #10) watches that flag between renewals and trips the child's signal within a tick. The child's tool call answers the parent in band — "[the X sub-agent was stopped]" — the terminal entry reads `stopped`, and the parent's run continues. Stop is cross-process by nature, so it requires an adapter; without one it returns false and nothing changes.

**Tool-phase aborts are honest.** `finished` now consults the signal alongside the message's stop reason, so a run stopped while tools were executing reports `:aborted` instead of `:completed`. This also fixes the terminal a stopped child writes: `stopped`, never a false `done` with a partial report.

## Notes for reviewers

- The one-second tick in `Locks::Hold` bounds stop latency; renewal cadence is unchanged (`elapsed >= heartbeat`). Sub-second heartbeats in tests still work because the tick is `min(heartbeat, 1)`.
- The stop flag is cleared in `run_child`'s ensure, so a stale stop can never kill the next holder of a recycled key; flags also expire on their own.
- `Child#stop` keeps its imperative name over the predicate-naming cop (documented disable): it is an action that reports acceptance.

## Testing

`test/test_child_stop.rb`: cascade down and never up, removed handle silences the cascade, tool-phase abort reports `:aborted`, a child stopped mid-run leaves the parent to finish its own turn (flag observed clearing), and stopping the parent stops a running child through the cascade. Full suite: 337 runs, 0 failures. Live integration against real providers: delegation 6/6, control surfaces 9/9, core loop 6/6, zero skips.

## Follow-ups (design doc, in order)

The management console tools (spawn_agent, list_agents, read_agent, steer_agent, stop_agent), background dispatch, report delivery.