### PR TITLE
Teach the spawner types and a headcount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Typed workers: the spawner takes types:, a host registry of Definitions
+  by name. A typed child takes its system prompt, tools, and model from
+  the definition; instructions appends; explicit tool and model args
+  override within the pool and allowlist. "general-purpose" stays the
+  built-in composable default. Types fail at construction, never
+  mid-spawn: a definition with unfilled placeholders or tools the pool
+  lacks is a boot-time ConfigurationError.
+- max_children (default 4) caps live workers per session; a spawn past
+  the cap answers in band and freed slots reopen.
+- SubAgent.pack returns the spawn tool plus the management console in one
+  call, the whole kit for a worker-running agent.
+
 - The management console: Mistri::Console.tools returns list_agents,
   read_agent (tail: to choose how much transcript, wait: to block for the
   report with an in-band timeout), steer_agent, and stop_agent. Every tool

--- a/lib/mistri/sub_agent.rb
+++ b/lib/mistri/sub_agent.rb
@@ -89,21 +89,41 @@ module Mistri
       # the host's allowlist of child model ids — without one, no model
       # choice is offered at all, so a hallucinated id can never construct a
       # provider or land children on an expensive model.
-      def spawner(provider:, tools: [], models: [], needs_approval: false, **agent_options)
+      #
+      # types: is the host's registry of curated workers, Definition by
+      # name: a typed child takes its system prompt, tools, and model from
+      # the definition (instructions appends, explicit args override within
+      # the pool and allowlist). "general-purpose" is always available: the
+      # model writes that worker's system prompt itself. max_children caps
+      # live workers per session; a spawn past the cap answers in band.
+      def spawner(provider:, tools: [], types: {}, models: [], max_children: 4,
+                  needs_approval: false, **agent_options)
         forbid_gated!(tools)
         if tools.any? { |tool| tool.name == "spawn_agent" }
           raise ConfigurationError, "the spawn tool never goes in its own pool"
         end
 
-        schema = spawner_schema(tools, models, default_model(provider))
-        Tool.define("spawn_agent", SPAWNER_DESCRIPTION,
+        validate_types!(types, tools)
+
+        schema = spawner_schema(tools, models, default_model(provider), types)
+        Tool.define("spawn_agent", spawner_description(types),
                     needs_approval: needs_approval, schema: schema) do |args, context|
-          run_child(label: child_label(args["name"]),
-                    provider: child_provider(provider, args["model"], models),
-                    system: args.fetch("instructions"),
-                    tools: pick(tools, args["tools"]),
+          crowded = over_capacity(context.session, max_children)
+          next crowded if crowded
+
+          worker = resolve_worker(args, types, tools, provider, models)
+          next worker if worker.is_a?(String)
+
+          run_child(label: child_label(args["name"]), provider: worker[:provider],
+                    system: worker[:system], tools: worker[:tools],
                     task: args.fetch("task"), context: context, **agent_options)
         end
+      end
+
+      # The whole kit in one call: the spawn tool plus the management
+      # console, so a host hands its agent everything workers need.
+      def pack(provider:, console: {}, **spawner_options)
+        [spawner(provider: provider, **spawner_options), *Console.tools(**console)]
       end
 
       def run_child(label:, provider:, system:, tools:, task:, context:, schema: nil,
@@ -197,6 +217,82 @@ module Mistri
         end
       end
 
+      # A worker's system prompt, tools, and provider, resolved from its
+      # type; a String answers the model in band instead of raising.
+      def resolve_worker(args, types, pool, parent_provider, models)
+        type = args["type"].to_s
+        return general_worker(args, pool, parent_provider, models) if type.empty? ||
+                                                                      type == "general-purpose"
+
+        definition = types[type]
+        unless definition
+          return "Unknown worker type #{type.inspect}; available: " \
+                 "#{["general-purpose", *types.keys].join(", ")}."
+        end
+
+        system = [definition.render, args["instructions"]]
+                 .reject { |part| part.to_s.strip.empty? }.join("\n\n")
+        chosen = args["tools"].nil? || args["tools"].empty? ? definition.tool_names : args["tools"]
+        { system: system, tools: pick(pool, chosen),
+          provider: typed_provider(parent_provider, args["model"], models, definition.model) }
+      end
+
+      def general_worker(args, pool, parent_provider, models)
+        system = args["instructions"].to_s
+        if system.strip.empty?
+          return "A general-purpose worker needs instructions: write its system prompt, " \
+                 "or pick a type."
+        end
+
+        { system: system, tools: pick(pool, args["tools"]),
+          provider: child_provider(parent_provider, args["model"], models) }
+      end
+
+      # An explicit model choice goes through the allowlist; otherwise a
+      # typed worker runs on its definition's model, and without one it
+      # inherits the parent's provider. Host-curated definitions are
+      # trusted the way the pool is.
+      def typed_provider(parent, requested, models, definition_model)
+        return child_provider(parent, requested, models) unless requested.to_s.empty?
+        return parent if definition_model.to_s.empty?
+
+        Mistri.provider(definition_model)
+      end
+
+      def over_capacity(session, max_children)
+        return nil unless session
+
+        busy = session.children.count { |child| %i[running queued].include?(child.status) }
+        return nil if busy < max_children
+
+        "You already have #{busy} workers running; wait for one to finish or stop one."
+      end
+
+      # Types fail at construction, never mid-spawn: every definition must
+      # render without vars (spawn types are self-contained prompts) and
+      # declare only tools the pool actually carries.
+      def validate_types!(types, pool)
+        return if types.empty?
+        if types.key?("general-purpose")
+          raise ConfigurationError, "\"general-purpose\" is the built-in type; pick another name"
+        end
+
+        pool_names = pool.map(&:name)
+        types.each do |name, definition|
+          begin
+            definition.render
+          rescue ConfigurationError => e
+            raise ConfigurationError,
+                  "type #{name.inspect} cannot be a spawn type: #{e.message}"
+          end
+          missing = definition.tool_names - pool_names
+          unless missing.empty?
+            raise ConfigurationError,
+                  "type #{name.inspect} declares tools the pool lacks: #{missing.join(", ")}"
+          end
+        end
+      end
+
       def pick(pool, names)
         return pool if names.nil? || names.empty?
 
@@ -209,19 +305,35 @@ module Mistri
         end
       end
 
-      def spawner_schema(pool, models, default)
+      def spawner_schema(pool, models, default, types = {})
         tool_names = pool.map(&:name)
+        type_names = ["general-purpose", *types.keys]
         fallback = default ? " (default: #{default})" : ""
         lambda do
           string :name, "A short name for this worker, shown wherever its events appear"
           string :task, "The child's complete task", required: true
-          string :instructions, "The child's system prompt", required: true
+          if types.any?
+            string :type, "The kind of worker (default: general-purpose)", enum: type_names
+            string :instructions, "The worker's system prompt (required for " \
+                                  "general-purpose; appended to a typed worker's own)"
+          else
+            string :instructions, "The child's system prompt", required: true
+          end
           if tool_names.any?
-            array :tools, "Subset of tools to grant (default: all)",
+            array :tools, "Subset of tools to grant (default: all, or the type's own list)",
                   items: { type: "string", enum: tool_names }
           end
           string :model, "Model for the child#{fallback}", enum: models if models.any?
         end
+      end
+
+      def spawner_description(types)
+        return SPAWNER_DESCRIPTION if types.empty?
+
+        "#{SPAWNER_DESCRIPTION} Typed workers come ready-made " \
+          "(#{types.keys.join(", ")}): their instructions, tools, and model " \
+          "are set; add instructions only to focus them. general-purpose " \
+          "workers are yours to compose."
       end
 
       def default_model(provider)

--- a/lib/mistri/sub_agent.rb
+++ b/lib/mistri/sub_agent.rb
@@ -103,6 +103,9 @@ module Mistri
           raise ConfigurationError, "the spawn tool never goes in its own pool"
         end
 
+        # Symbol keys are natural Ruby; the wire speaks strings. One
+        # normalization here and lookup, schema, and menu all agree.
+        types = types.transform_keys(&:to_s)
         validate_types!(types, tools)
 
         schema = spawner_schema(tools, models, default_model(provider), types)

--- a/test/test_spawn_types.rb
+++ b/test/test_spawn_types.rb
@@ -136,6 +136,19 @@ class TestSpawnTypes < Minitest::Test
     assert_equal :done, session.children.last.status
   end
 
+  def test_symbol_keyed_types_resolve_like_string_keyed_ones
+    child_fake = fake({ text: "Report ready." })
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [archive],
+                                     types: { researcher: researcher_type })
+    parent_fake = spawn_call({ "name" => "Corgi", "type" => "researcher", "task" => "go" })
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+
+    Mistri::Agent.new(provider: parent_fake, tools: [spawn], session:).run("go")
+
+    assert_equal :done, session.children.first.status,
+                 "the wire speaks strings; a symbol-keyed registry must still resolve"
+  end
+
   def test_pack_bundles_the_spawner_with_the_console
     names = Mistri::SubAgent.pack(provider: fake).map(&:name)
 

--- a/test/test_spawn_types.rb
+++ b/test/test_spawn_types.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Typed workers and the headcount: a spawn type is a host-curated
+# Definition (validated at construction, never mid-spawn), general-purpose
+# stays the composable default, and max_children answers in band.
+class TestSpawnTypes < Minitest::Test
+  def teardown
+    Mistri.locks = nil
+  end
+
+  def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
+
+  def archive = Mistri::Tool.define("archive", "Facts lookup.") { "founded 1912" }
+
+  def researcher_type(model: nil)
+    config = { "role" => "Researcher", "tools" => ["archive"] }
+    config["model"] = model if model
+    Mistri::Definition.new(name: "researcher", config: config,
+                           body: "You research companies and report tersely.")
+  end
+
+  def spawn_call(arguments)
+    fake({ tool_calls: [{ name: "spawn_agent", arguments: arguments }] },
+         { text: "Parent done." })
+  end
+
+  def test_a_typed_worker_takes_its_prompt_tools_and_appends_instructions
+    child_fake = fake({ text: "Report: founded 1912." })
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [archive],
+                                     types: { "researcher" => researcher_type })
+    parent_fake = spawn_call({ "name" => "Corgi", "type" => "researcher",
+                               "task" => "when was it founded?",
+                               "instructions" => "Focus on the founding year only." })
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+
+    Mistri::Agent.new(provider: parent_fake, tools: [spawn], session:).run("go")
+
+    system = child_fake.requests.first[:options][:system]
+
+    assert_match(/You research companies/, system)
+    assert_match(/Focus on the founding year only\./, system)
+    sent_tools = child_fake.requests.first[:options][:tools].map { |tool| tool[:name] }
+
+    assert_equal ["archive"], sent_tools
+    assert_equal :done, session.children.first.status
+  end
+
+  def test_a_general_purpose_worker_without_instructions_answers_in_band
+    spawn = Mistri::SubAgent.spawner(provider: fake)
+    parent_fake = spawn_call({ "name" => "Husky", "task" => "do something" })
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+
+    result = Mistri::Agent.new(provider: parent_fake, tools: [spawn], session:).run("go")
+
+    assert_equal "Parent done.", result.text, "the parent reads the refusal and continues"
+    tool_message = session.messages.select(&:tool?).last
+
+    assert_match(/needs instructions/, tool_message.text)
+    assert_empty session.children, "no child is born from a refused spawn"
+  end
+
+  def test_an_unknown_type_answers_with_the_menu
+    spawn = Mistri::SubAgent.spawner(provider: fake, tools: [archive],
+                                     types: { "researcher" => researcher_type })
+    parent_fake = spawn_call({ "name" => "Beagle", "type" => "designer", "task" => "draw" })
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+
+    Mistri::Agent.new(provider: parent_fake, tools: [spawn], session:).run("go")
+
+    tool_message = session.messages.select(&:tool?).last
+
+    assert_match(/Unknown worker type "designer"/, tool_message.text)
+    assert_match(/general-purpose, researcher/, tool_message.text)
+  end
+
+  def test_a_type_with_placeholders_fails_at_construction
+    holey = Mistri::Definition.new(name: "greeter", config: {},
+                                   body: "Greet {first_name} warmly.")
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.spawner(provider: fake, types: { "greeter" => holey })
+    end
+
+    assert_match(/cannot be a spawn type/, error.message)
+  end
+
+  def test_a_type_declaring_tools_outside_the_pool_fails_at_construction
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.spawner(provider: fake, tools: [],
+                               types: { "researcher" => researcher_type })
+    end
+
+    assert_match(/declares tools the pool lacks: archive/, error.message)
+  end
+
+  def test_the_built_in_type_name_is_reserved
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.spawner(provider: fake,
+                               types: { "general-purpose" => researcher_type })
+    end
+
+    assert_match(/built-in type/, error.message)
+  end
+
+  def test_max_children_refuses_in_band_and_freed_slots_reopen
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = Mistri::Stores::Memory.new
+    session = Mistri::Session.new(store:)
+    3.times do |i|
+      child = Mistri::Session.new(store:)
+      session.append("subagent", "name" => "W#{i}", "session_id" => child.id)
+      Mistri.locks.acquire(Mistri::Child.lease_key(child.id), ttl: 60)
+    end
+    spawn = Mistri::SubAgent.spawner(provider: fake({ text: "hi" }), max_children: 3)
+    parent_fake = spawn_call({ "name" => "Extra", "task" => "t", "instructions" => "You help." })
+
+    Mistri::Agent.new(provider: parent_fake, tools: [spawn], session:).run("go")
+
+    refusal = session.messages.select(&:tool?).last
+
+    assert_match(/already have 3 workers running/, refusal.text)
+    assert_equal 3, session.children.length, "the refused spawn creates nothing"
+
+    # One worker finishes; the slot reopens.
+    finished = session.children.first
+    Mistri.locks.release(Mistri::Child.lease_key(finished.session_id))
+    Mistri::Session.new(store:, id: finished.session_id)
+                   .append(Mistri::Child::TERMINAL, "status" => "done", "report" => "ok")
+    retry_fake = spawn_call({ "name" => "Extra", "task" => "t", "instructions" => "You help." })
+
+    Mistri::Agent.new(provider: retry_fake, tools: [spawn], session:).run("go")
+
+    assert_equal 4, session.children.length
+    assert_equal :done, session.children.last.status
+  end
+
+  def test_pack_bundles_the_spawner_with_the_console
+    names = Mistri::SubAgent.pack(provider: fake).map(&:name)
+
+    assert_equal %w[spawn_agent list_agents read_agent steer_agent stop_agent], names
+  end
+end


### PR DESCRIPTION
First half of background mode (5a of the design doc's step 5, split for reviewability): the spawn tool grows the vocabulary it needs before any new execution path exists. Everything here is inline-mode only.

## What changed

**Typed workers.** The spawner takes `types:`, a host registry of `Mistri::Definition`s by name:

```ruby
spawn = Mistri::SubAgent.spawner(
  provider:, tools: POOL,
  types: { "researcher" => Definitions.researcher },
)
```

A typed child takes its system prompt, tools (picked from the pool by the definition's own list), and model from the definition; `instructions` appends a per-run focus; explicit `tools`/`model` args still override, inside the pool and allowlist as always. `"general-purpose"` remains the built-in default: the model composes that worker itself (today's behavior, now named). The `type` schema enum only appears when host types exist, so schemas carry no dead weight.

**Types fail at boot, never mid-spawn.** A definition with unfilled `{placeholders}` (spawn types must be self-contained prompts) or declaring tools the pool lacks is a `ConfigurationError` at spawner construction. The reserved name `"general-purpose"` is refused.

**`max_children`** (default 4) counts live workers (`:running` or `:queued`) at spawn time and answers past the cap in band: "You already have 4 workers running; wait for one to finish or stop one." Freed slots reopen. Enforcement is best-effort at spawn (parallel spawn calls in one turn each check the registry); it is a guardrail, not a mutex.

**`SubAgent.pack`** returns `[spawn_agent, *Console.tools]` — the whole kit in one call. The spawner itself still returns one tool, so nothing breaks.

**In-band over raising, consistently**: unknown type answers with the menu ("available: general-purpose, researcher"), missing instructions for a general-purpose worker answers with what to do — the model reads and reacts, the parent's run never dies on a spawn argument.

## Testing

`test/test_spawn_types.rb`: typed prompt/tools/instructions-append verified against the child provider's actual received request, general-purpose refusal in band with no child born, unknown-type menu, both construction-time validations, the reserved name, max_children refusal plus slot-reopen, and the pack bundle contract. Full suite: 366 runs, 0 failures.

## Follow-up

5b lands background mode on this vocabulary: lifecycle entries (queued/started), the dispatcher seam with Inline and Thread dispatchers, `run_dispatched`, receipts, and the workspace invariant (parent-sharing requires inline).