### PR TITLE
Deliver a worker's report to its parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Report delivery: a background child's terminal outcome reports back to
+  its parent, exactly once. The report queues in the parent's inbox as a
+  typed subagent_report entry and folds at the next turn boundary the way
+  a steer does — the model sees `[Magpie finished] <report>`, failures
+  carry the error, stops say so — and a report landing as a run finishes
+  cleanly extends it one turn so the parent reacts. A :subagent_report
+  event (agent, session_id, status, content) closes the child's lane in
+  whatever UI watched the spawn. Session#pending_inbox is the
+  steers-and-reports view (hosts that wake idle sessions on steers should
+  watch it instead); Session#deliver_report is the idempotent primitive
+  underneath.
+- Dispatched runs are fenced by the child's lease, taken before the
+  run-or-not decision: a queue that redelivers a live job leaves the
+  owner alone, a retry of a finished or cancelled child is a clean no-op,
+  and a retry of a child a crashed process left mid-run runs it again
+  (previously the guard refused it, wedging the child as interrupted
+  forever). Child#finished? and Child#error are new readers.
 - Background mode: spawn_agent takes mode: "background" when the spawner
   has a dispatcher, returning a truthful receipt immediately (what the
   child's status says after dispatch, not what the mode promised) while
-  the parent keeps working; reports collect through read_agent. The
+  the parent keeps working; the report arrives on its own (above). The
   dispatcher is a seam: Dispatchers::Inline (default degrade, synchronous
   but honest) and Dispatchers::Thread ship in the gem, and a queue host
   plugs one lambda whose job reconstructs tools from the serializable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Report delivery: a background child's terminal outcome reports back to
   its parent, exactly once. The report queues in the parent's inbox as a
   typed subagent_report entry and folds at the next turn boundary the way
-  a steer does — the model sees `[Magpie finished] <report>`, failures
-  carry the error, stops say so — and a report landing as a run finishes
+  a steer does (the model sees `[Magpie finished] <report>`; failures
+  carry the error, stops say so), and a report landing as a run finishes
   cleanly extends it one turn so the parent reacts. A :subagent_report
   event (agent, session_id, status, content) closes the child's lane in
   whatever UI watched the spawn. Session#pending_inbox is the

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -189,8 +189,8 @@ module Mistri
       @compaction&.window || Models.find(@provider.model)&.context_window
     end
 
-    # Materialize the inbox — queued steers and sub-agent reports — into the
-    # transcript in arrival order. The folded message entry carries the
+    # Materialize the inbox, queued steers and sub-agent reports alike, into
+    # the transcript in arrival order. The folded message entry carries the
     # source entry's id under its marker key, which is what marks the entry
     # consumed: one append is both the fold and the marker, so a crash
     # between folds never double-delivers.

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -14,7 +14,8 @@ module Mistri
   # returns at once (no thread ever waits on a human), the decision arrives
   # later as a session entry from any process, and resume settles it and
   # carries on. Session#steer queues a user message from any process while
-  # the loop runs; it folds into the transcript at the next turn boundary.
+  # the loop runs; it folds into the transcript at the next turn boundary,
+  # and a background child's report arrives through the same inbox.
   class Agent
     # compaction defaults on so long sessions survive their context window;
     # pass false to disable, or a tuned Compaction. It only ever triggers
@@ -68,7 +69,7 @@ module Mistri
               "run needs input text or images"
       end
 
-      fold_steers # steers queued while idle arrived first; keep that order
+      fold_inbox # anything queued while this session sat idle arrived first; keep that order
       @session.append_message(Message.user_with_images(input, images))
       loop_turns(signal, output_schema, &emit)
     end
@@ -144,7 +145,7 @@ module Mistri
         reason = @budget.exceeded(turns: turns, usage: usage, elapsed: monotonic_now - started)
         return stop_for_budget(reason, usage, &emit) if reason
 
-        fold_steers
+        fold_inbox
         compacted = auto_compact(&emit)
         usage += compacted[:usage] if compacted&.dig(:usage)
         last = run_turn(signal, output_schema, &emit)
@@ -159,14 +160,15 @@ module Mistri
       end
     end
 
-    # A steer that lands while the model finishes cleanly extends the run one
-    # more turn so it gets answered. Aborts, errors, and length stops always
-    # end the run; the steer stays pending for the next one.
+    # A steer or a child's report that lands while the model finishes
+    # cleanly extends the run one more turn, so it is answered rather than
+    # left dangling. Aborts, errors, and length stops always end the run;
+    # the inbox stays pending for the next one.
     def done?(last, signal)
       return false if last.stop_reason == StopReason::TOOL_USE && !signal&.aborted?
       return true if signal&.aborted? || last.stop_reason != StopReason::STOP
 
-      @session.pending_steers.empty?
+      @session.pending_inbox.empty?
     end
 
     # Compact when the context has grown into the reserve. A failed
@@ -187,13 +189,15 @@ module Mistri
       @compaction&.window || Models.find(@provider.model)&.context_window
     end
 
-    # Materialize queued steers into the transcript in arrival order. The
-    # folded message entry carries the steer id, which is what marks the steer
-    # consumed: one append is both the fold and the marker, so a crash between
-    # steers never double-delivers.
-    def fold_steers
-      @session.pending_steers.each do |steer|
-        @session.append("message", "message" => steer["message"], "steer_id" => steer["id"])
+    # Materialize the inbox — queued steers and sub-agent reports — into the
+    # transcript in arrival order. The folded message entry carries the
+    # source entry's id under its marker key, which is what marks the entry
+    # consumed: one append is both the fold and the marker, so a crash
+    # between folds never double-delivers.
+    def fold_inbox
+      @session.pending_inbox.each do |entry|
+        marker = Session::INBOX.fetch(entry["type"])
+        @session.append("message", "message" => entry["message"], marker => entry["id"])
       end
     end
 

--- a/lib/mistri/child.rb
+++ b/lib/mistri/child.rb
@@ -50,7 +50,7 @@ module Mistri
     end
 
     # A terminal entry exists: the child ended as done, stopped, or failed
-    # and will never run again. The question a queue retry asks — and its
+    # and will never run again. The question a queue retry asks; its
     # inverse (started but no terminal) is what makes a crashed child
     # re-runnable.
     def finished?

--- a/lib/mistri/child.rb
+++ b/lib/mistri/child.rb
@@ -49,8 +49,21 @@ module Mistri
       :running
     end
 
+    # A terminal entry exists: the child ended as done, stopped, or failed
+    # and will never run again. The question a queue retry asks — and its
+    # inverse (started but no terminal) is what makes a crashed child
+    # re-runnable.
+    def finished?
+      !terminal_entry.nil?
+    end
+
     def report
       terminal_entry&.fetch("report", nil)
+    end
+
+    # The terminal entry's error string, once failed.
+    def error
+      terminal_entry&.fetch("error", nil)
     end
 
     # Recent entries, oldest first, with inline image bytes replaced by a

--- a/lib/mistri/event.rb
+++ b/lib/mistri/event.rb
@@ -15,7 +15,8 @@ module Mistri
   # events; nil where nothing ran (denials, interruptions).
   class Event < Data.define(:type, :content_index, :delta, :content, :tool_call,
                             :reason, :message, :error_message, :partial, :origin,
-                            :duration, :attempt, :max_attempts, :delay)
+                            :duration, :attempt, :max_attempts, :delay,
+                            :agent, :session_id, :status)
     # The stream types come from a provider mid-turn; the loop adds
     # :tool_result after it runs each tool, :approval_needed when a gated
     # call parks for a human, :compacting/:compaction around a context
@@ -23,6 +24,9 @@ module Mistri
     # waits out a transient failure, so one subscription sees the whole
     # exchange. :done and :error are loop-owned and terminal: only the
     # accepted attempt's terminal event reaches the subscriber.
+    # :subagent_report announces a background child's terminal outcome
+    # (agent, session_id, status; content carries the report), so a UI that
+    # watched the spawn can settle the child's lane the moment it ends.
     TYPES = %i[
       start
       text_start text_delta text_end
@@ -32,11 +36,13 @@ module Mistri
       tool_result approval_needed
       compacting compaction
       retry
+      subagent_report
     ].freeze
 
     def initialize(type:, content_index: nil, delta: nil, content: nil, tool_call: nil,
                    reason: nil, message: nil, error_message: nil, partial: nil, origin: nil,
-                   duration: nil, attempt: nil, max_attempts: nil, delay: nil)
+                   duration: nil, attempt: nil, max_attempts: nil, delay: nil,
+                   agent: nil, session_id: nil, status: nil)
       raise ArgumentError, "unknown event type #{type.inspect}" unless TYPES.include?(type)
 
       super
@@ -52,7 +58,7 @@ module Mistri
     def to_h
       { type:, content_index:, delta:, content:, tool_call: tool_call&.to_h,
         reason:, message: message&.to_h, error_message:, origin:, duration:,
-        attempt:, max_attempts:, delay: }.compact
+        attempt:, max_attempts:, delay:, agent:, session_id:, status: }.compact
     end
   end
 end

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -100,8 +100,8 @@ module Mistri
       true
     end
 
-    # Everything queued for the loop's next turn boundary — steers and
-    # sub-agent reports — oldest first, in arrival order. The folding
+    # Everything queued for the loop's next turn boundary (steers and
+    # sub-agent reports), oldest first, in arrival order. The folding
     # message entry carries the source entry's id under its marker key, so
     # consumption is derived from the log alone and reads the same from
     # every process. A host that wakes an idle session when a steer arrives

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -66,6 +66,11 @@ module Mistri
       entries.reverse_each.find { |entry| entry["type"] == "compaction" }
     end
 
+    # The inbox: entry types queued for the loop's next turn boundary, each
+    # mapped to the marker key its fold leaves on the consuming message
+    # entry.
+    INBOX = { "steer" => "steer_id", "subagent_report" => "report_id" }.freeze
+
     # Queue a message for a running exchange from any process. The loop folds
     # pending steers into the transcript at the next turn boundary, so the
     # model sees them mid-run; one that arrives as the model finishes cleanly
@@ -74,13 +79,42 @@ module Mistri
       append("steer", "id" => SecureRandom.uuid, "message" => Message.user(text).to_h)
     end
 
-    # Steers not yet folded into the transcript, oldest first. The folding
-    # message entry carries the steer id, so consumption is derived from the
-    # log alone and reads the same from every process.
-    def pending_steers
+    # A sub-agent's report, queued for this session the way a steer is: it
+    # folds into the transcript at the next turn boundary as a labeled block
+    # the model can react to ("[Magpie finished] <report>"), while the typed
+    # entry keeps name, status, and the raw text for hosts to render as a
+    # report card rather than a fake user message. One report per child,
+    # ever: a duplicate delivery (a redelivered queue job, a lease race) is
+    # dropped, and the return says which happened. Reports normally arrive
+    # via SubAgent.run_dispatched; call this directly only from a custom
+    # dispatch path.
+    def deliver_report(name:, session_id:, status:, text: nil) # rubocop:disable Naming/PredicateMethod
+      already = entries.any? do |entry|
+        entry["type"] == "subagent_report" && entry["session_id"] == session_id
+      end
+      return false if already
+
+      append("subagent_report", "id" => SecureRandom.uuid, "name" => name,
+                                "session_id" => session_id, "status" => status, "report" => text,
+                                "message" => Message.user(report_label(name, status, text)).to_h)
+      true
+    end
+
+    # Everything queued for the loop's next turn boundary — steers and
+    # sub-agent reports — oldest first, in arrival order. The folding
+    # message entry carries the source entry's id under its marker key, so
+    # consumption is derived from the log alone and reads the same from
+    # every process. A host that wakes an idle session when a steer arrives
+    # should watch this instead: a report deserves the same pickup.
+    def pending_inbox
       log = entries
-      folded = log.filter_map { |entry| entry["steer_id"] }.to_set
-      log.select { |entry| entry["type"] == "steer" && !folded.include?(entry["id"]) }
+      folded = log.flat_map { |entry| entry.values_at(*INBOX.values) }.compact.to_set
+      log.select { |entry| INBOX.key?(entry["type"]) && !folded.include?(entry["id"]) }
+    end
+
+    # The steer-only slice of the inbox, oldest first.
+    def pending_steers
+      pending_inbox.select { |entry| entry["type"] == "steer" }
     end
 
     # Sub-agents this session has spawned, in spawn order: one Child window
@@ -147,6 +181,17 @@ module Mistri
 
     def summary_message(summary)
       Message.user("#{Compaction::SUMMARY_PREFACE}\n\n#{summary}")
+    end
+
+    # How a report reads to the model: labeled with the worker's name and
+    # fate, so the parent knows exactly who finished and how.
+    def report_label(name, status, text)
+      case status
+      when "done" then "[#{name} finished] #{text}"
+      when "failed" then "[#{name} failed] #{text}"
+      when "stopped" then "[#{name} was stopped]"
+      else "[#{name} ended: #{status}]"
+      end
     end
 
     def decide(call_id, approved:, note:)

--- a/lib/mistri/spawner.rb
+++ b/lib/mistri/spawner.rb
@@ -105,8 +105,9 @@ module Mistri
                 "already finished (#{status})"
               end
       ToolResult.new(
-        content: "#{label} #{state} (agent id #{child.id[0, 8]}). Keep working: " \
-                 "read_agent checks on it (wait: true blocks for its report), " \
+        content: "#{label} #{state} (agent id #{child.id[0, 8]}). Keep working: its " \
+                 "report will arrive in your context when it finishes. Meanwhile " \
+                 "read_agent checks on it (wait: true blocks for the report), " \
                  "steer_agent adjusts it, stop_agent stops it.",
         ui: { "agent" => label, "session_id" => child.id, "mode" => "background" }
       )
@@ -252,8 +253,8 @@ module Mistri
       end
       if @dispatcher
         text += " Use background mode when the work is long and you can keep helping " \
-                "meanwhile: you get a receipt now, manage the worker with the console " \
-                "tools, and collect its report with read_agent."
+                "meanwhile: you get a receipt now, its report arrives on its own when " \
+                "the worker finishes, and the console tools manage it in between."
       end
       text
     end

--- a/lib/mistri/stores/active_record.rb
+++ b/lib/mistri/stores/active_record.rb
@@ -20,21 +20,36 @@ module Mistri
     #   end
     #   add_index :mistri_entries, [:session_id, :position], unique: true
     #
-    # The unique index is load-bearing: one session has one writer at a time
-    # (the loop is serial), and if a host ever runs two agents on one session,
-    # a colliding append raises instead of silently corrupting entry order.
+    # The unique index is load-bearing: a session's loop is serial, but other
+    # writers append alongside it by design (a steer from a web process, a
+    # background child's report from a job), so appends are optimistic. Two
+    # writers that pick the same position collide on the index and the loser
+    # retries at the next one; entry order stays intact without a lock.
     #
     # Reads select only (position, payload) and sort in Ruby: ORDER BY over
     # rows carrying multi-megabyte payloads exhausts MySQL's sort buffer.
     class ActiveRecord
+      # Concurrent writers converge in one or two retries; a session would
+      # need this many simultaneous appenders to exhaust them.
+      APPEND_ATTEMPTS = 5
+
       def initialize(model)
         @model = model
       end
 
       def append(id, entry)
-        position = @model.where(session_id: id).maximum(:position).to_i + 1
-        @model.create!(session_id: id, position: position, payload: JSON.generate(entry))
-        nil
+        payload = JSON.generate(entry)
+        attempts = 0
+        begin
+          position = @model.where(session_id: id).maximum(:position).to_i + 1
+          @model.create!(session_id: id, position: position, payload: payload)
+          nil
+        rescue ::ActiveRecord::RecordNotUnique
+          attempts += 1
+          raise if attempts >= APPEND_ATTEMPTS
+
+          retry
+        end
       end
 
       def load(id)

--- a/lib/mistri/stores/jsonl.rb
+++ b/lib/mistri/stores/jsonl.rb
@@ -13,8 +13,10 @@ module Mistri
         FileUtils.mkdir_p(dir)
       end
 
+      # One write call per line: concurrent appenders (a steer, a child's
+      # report) interleave whole lines, never fragments.
       def append(id, entry)
-        File.open(path(id), "a") { |file| file.puts(JSON.generate(entry)) }
+        File.write(path(id), "#{JSON.generate(entry)}\n", mode: "a")
         nil
       end
 

--- a/lib/mistri/sub_agent.rb
+++ b/lib/mistri/sub_agent.rb
@@ -128,7 +128,7 @@ module Mistri
       #
       # The child's lease is the exactly-once fence, so it is taken before
       # anything else: refused means another process is running this child
-      # right now (a queue redelivered a live job) — leave its owner alone.
+      # right now (a queue redelivered a live job), so leave its owner alone.
       # Holding it, a terminal decides: present means the child was
       # cancelled while queued or the queue retried a finished job, so
       # there is nothing to run; absent means run, and that includes the
@@ -241,8 +241,8 @@ module Mistri
       end
 
       # Every terminal outcome reports back, exactly once. The report joins
-      # the parent's inbox — a typed entry that folds at its next turn
-      # boundary, exactly like a steer — and a :subagent_report event
+      # the parent's inbox (a typed entry that folds at its next turn
+      # boundary, exactly like a steer) and a :subagent_report event
       # closes the child's lane in whatever UI watched the spawn. A child
       # that never ran has nothing to say, and the parent session drops a
       # duplicate delivery, so a redelivered job cannot repeat one.

--- a/lib/mistri/sub_agent.rb
+++ b/lib/mistri/sub_agent.rb
@@ -120,27 +120,44 @@ module Mistri
       # The host job's way back in: reconstruct provider, system, and tools
       # from the spec through host registries, then hand them here. Reopens
       # the child session the spawn created, runs it exactly like an inline
-      # child (started entry, lease, stop watching, terminals), and streams
-      # origin-tagged events to the emit the job supplies. A background
-      # child runs on its own signal: the parent's turn is long over, so
-      # only stop_agent and the stop flag end it early.
+      # child (started entry, lease, stop watching, terminals), streams
+      # origin-tagged events to the emit the job supplies, and reports the
+      # outcome back to the parent (see report_back). A background child
+      # runs on its own signal: the parent's turn is long over, so only
+      # stop_agent and the stop flag end it early.
+      #
+      # The child's lease is the exactly-once fence, so it is taken before
+      # anything else: refused means another process is running this child
+      # right now (a queue redelivered a live job) — leave its owner alone.
+      # Holding it, a terminal decides: present means the child was
+      # cancelled while queued or the queue retried a finished job, so
+      # there is nothing to run; absent means run, and that includes the
+      # child a crashed process left mid-run, which is exactly what queue
+      # retries are for. Either kind of no-op returns nil.
       def run_dispatched(spec, provider:, system:, tools:, store:, emit: nil, schema: nil,
                          **agent_options)
         child = Session.new(store: store, id: spec.fetch("session_id"))
-        # A terminal already written means there is nothing to run: the
-        # child was cancelled while queued, or a queue retried a job that
-        # already finished. Honoring it keeps stop_agent instant and
-        # double-dispatch harmless.
-        already = Child.new(name: spec.fetch("name"), session_id: child.id, store: store)
-        return nil unless Child::LIVE.include?(already.status)
-
         signal = AbortSignal.new
-        result = execute_child(child: child, label: spec.fetch("name"), provider: provider,
-                               system: system, tools: tools, task: spec.fetch("task"),
-                               schema: schema, signal: signal, emit: emit, **agent_options)
-        deny_pending(result, child)
-        child.append(Child::TERMINAL, terminal(result))
-        result
+        lease = Locks.hold(Child.lease_key(child.id),
+                           stop_key: Child.stop_key(child.id), signal: signal)
+        return nil if Mistri.locks && lease.nil?
+
+        begin
+          if Child.new(name: spec.fetch("name"), session_id: child.id, store: store).finished?
+            lease&.release
+            return nil
+          end
+
+          result = execute_child(child: child, label: spec.fetch("name"), provider: provider,
+                                 system: system, tools: tools, task: spec.fetch("task"),
+                                 schema: schema, signal: signal, emit: emit, lease: lease,
+                                 **agent_options)
+          deny_pending(result, child)
+          child.append(Child::TERMINAL, terminal(result))
+          result
+        ensure
+          report_back(spec, store, emit)
+        end
       end
 
       # A child cannot wait for a human, whichever door it entered by: any
@@ -188,12 +205,15 @@ module Mistri
       # door it entered by. From the started entry on, every exit writes a
       # terminal, setup failures included, or the child would read as
       # running forever. The lease says "alive right now" to other
-      # processes and its thread watches the child's stop flag.
+      # processes and its thread watches the child's stop flag; a
+      # dispatched run hands in the lease it already holds (its run-or-not
+      # decision happened under the fence), an inline child acquires its
+      # own here. Either way, this path releases it.
       def execute_child(child:, label:, provider:, system:, tools:, task:, schema:,
-                        signal:, emit:, **agent_options)
+                        signal:, emit:, lease: nil, **agent_options)
         child.append(Child::STARTED, {})
-        lease = Locks.hold(Child.lease_key(child.id),
-                           stop_key: Child.stop_key(child.id), signal: signal)
+        lease ||= Locks.hold(Child.lease_key(child.id),
+                             stop_key: Child.stop_key(child.id), signal: signal)
         begin
           agent = Agent.new(provider: provider, session: child, system: system,
                             tools: tools, **agent_options)
@@ -218,6 +238,32 @@ module Mistri
 
         tagged = event.origin ? "#{origin}>#{event.origin}" : origin
         emit.call(event.with(origin: tagged))
+      end
+
+      # Every terminal outcome reports back, exactly once. The report joins
+      # the parent's inbox — a typed entry that folds at its next turn
+      # boundary, exactly like a steer — and a :subagent_report event
+      # closes the child's lane in whatever UI watched the spawn. A child
+      # that never ran has nothing to say, and the parent session drops a
+      # duplicate delivery, so a redelivered job cannot repeat one.
+      def report_back(spec, store, emit)
+        facade = Child.new(name: spec.fetch("name"), session_id: spec.fetch("session_id"),
+                           store: store)
+        return unless facade.finished?
+
+        status = facade.status
+        text = status == :failed ? facade.error : facade.report
+        delivered = if (parent_id = spec["parent_session_id"])
+                      Session.new(store: store, id: parent_id)
+                             .deliver_report(name: facade.name, session_id: facade.session_id,
+                                             status: status.to_s, text: text)
+                    else
+                      true
+                    end
+        return unless delivered
+
+        emit&.call(Event.new(type: :subagent_report, agent: facade.name,
+                             session_id: facade.session_id, status: status, content: text))
       end
 
       # The parent always gets an in-band answer it can react to. A child

--- a/test/integration/test_background.rb
+++ b/test/integration/test_background.rb
@@ -53,4 +53,49 @@ class TestBackgroundIntegration < Minitest::Test
     assert_equal :done, child.status
     assert_equal :done, child.status, "terminal entry persists"
   end
+
+  # The report arrives on its own: no read_agent, no waiting — the worker
+  # finishes, its report folds into the parent's context, and the model
+  # answers from it.
+  Integration.scenario(self, :a_workers_report_arrives_without_being_asked_for) do |model|
+    Mistri.locks = Mistri::Locks::Memory.new
+    number = rand(100..900)
+    store = Mistri::Stores::Memory.new
+    oracle = Mistri::Tool.define("oracle", "Answers the secret number, slowly.") do
+      sleep 1
+      number.to_s
+    end
+    tools = Mistri::SubAgent.pack(provider: Mistri.provider(model), tools: [oracle],
+                                  dispatcher: Mistri::Dispatchers::Thread.new)
+    parent = Mistri::Agent.new(
+      provider: Mistri.provider(model), tools: tools,
+      session: Mistri::Session.new(store:),
+      system: "Delegate lookups to workers; their reports arrive on their own " \
+              "when they finish."
+    )
+
+    first = parent.run(
+      "Spawn a background worker named Terrier (instructions: call the oracle " \
+      "tool and report its answer) to fetch the secret number. Then, without " \
+      "waiting for Terrier, reply with exactly: receipt acknowledged."
+    )
+
+    assert_predicate first, :completed?
+
+    # The typed entry lands in the parent session whether the report folded
+    # mid-run or still waits in the inbox, so this await is race-free.
+    ends = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 60
+    until parent.session.entries.any? { |entry| entry["type"] == "subagent_report" } ||
+          Process.clock_gettime(Process::CLOCK_MONOTONIC) > ends
+      sleep 0.2
+    end
+
+    assert_predicate parent.session.children.first, :finished?
+
+    second = parent.run("What number did your worker report? Answer with just the number.")
+
+    assert_predicate second, :completed?
+    assert Integration.saw?(second.text, number.to_s),
+           "the folded report never reached the model: #{second.text}"
+  end
 end

--- a/test/integration/test_background.rb
+++ b/test/integration/test_background.rb
@@ -54,7 +54,7 @@ class TestBackgroundIntegration < Minitest::Test
     assert_equal :done, child.status, "terminal entry persists"
   end
 
-  # The report arrives on its own: no read_agent, no waiting — the worker
+  # The report arrives on its own: no read_agent, no waiting. The worker
   # finishes, its report folds into the parent's context, and the model
   # answers from it.
   Integration.scenario(self, :a_workers_report_arrives_without_being_asked_for) do |model|

--- a/test/test_background_mode.rb
+++ b/test/test_background_mode.rb
@@ -69,6 +69,11 @@ class TestBackgroundMode < Minitest::Test
 
     assert_equal :done, child.status
     assert_equal "The answer is 7.", child.report
+
+    # The child finished during the spawn itself, so its report folded at
+    # the very next turn boundary: the parent's final word already saw it.
+    assert_includes parent.requests.last[:messages].map(&:text).join("\n"),
+                    "[Corgi finished] The answer is 7."
   end
 
   def test_thread_dispatcher_runs_the_child_while_the_parent_moves_on
@@ -99,6 +104,13 @@ class TestBackgroundMode < Minitest::Test
     assert_equal :done, await_status(child, :done)
     assert_equal "Finished the slow work.", child.report
     refute Mistri.locks.held?(Mistri::Child.lease_key(child.session_id))
+
+    # The parent's run was long over, so the report waits in its inbox.
+    ends = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 3
+    sleep 0.05 while session.pending_inbox.empty? &&
+                     Process.clock_gettime(Process::CLOCK_MONOTONIC) < ends
+
+    assert_equal "Finished the slow work.", session.pending_inbox.first["report"]
   end
 
   def test_a_dropped_spec_reads_queued_and_run_dispatched_picks_it_up

--- a/test/test_report_delivery.rb
+++ b/test/test_report_delivery.rb
@@ -1,0 +1,279 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Report delivery: a background child's terminal outcome reaches its parent
+# exactly once — a typed inbox entry that folds like a steer, and an event
+# that closes the child's lane — and the lease fences dispatched runs so
+# queue retries heal crashes without ever double-running a child.
+class TestReportDelivery < Minitest::Test
+  def teardown
+    Mistri.locks = nil
+  end
+
+  def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
+
+  def spawn_call(arguments)
+    fake({ tool_calls: [{ name: "spawn_agent", arguments: arguments }] },
+         { text: "Parent moved on." })
+  end
+
+  def drop_dispatcher
+    Class.new do
+      attr_reader :spec
+
+      def call(spec, _runner)
+        @spec = spec
+        nil
+      end
+    end.new
+  end
+
+  def await(deadline: 3)
+    ends = Process.clock_gettime(Process::CLOCK_MONOTONIC) + deadline
+    sleep 0.05 until yield || Process.clock_gettime(Process::CLOCK_MONOTONIC) > ends
+  end
+
+  # Dispatch through a dropper, then run the job by hand: everything is
+  # deterministic and the spec is exactly what a queue would carry.
+  def dispatch(child_fake, name: "Basset", tools: [])
+    dropper = drop_dispatcher
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: tools, dispatcher: dropper)
+    parent = spawn_call({ "name" => name, "task" => "t", "instructions" => "You help.",
+                          "mode" => "background" })
+    store = Mistri::Stores::Memory.new
+    session = Mistri::Session.new(store:)
+    Mistri::Agent.new(provider: parent, tools: [spawn], session:).run("go")
+    [dropper.spec, store, session]
+  end
+
+  def test_a_finished_worker_reports_into_the_parents_inbox
+    child_fake = fake({ text: "The answer is 7." })
+    spec, store, session = dispatch(child_fake)
+    events = []
+
+    Mistri::SubAgent.run_dispatched(spec, provider: child_fake, system: "You help.",
+                                          tools: [], store: store,
+                                          emit: ->(event) { events << event })
+
+    report = session.pending_inbox.first
+
+    assert_equal "subagent_report", report["type"]
+    assert_equal "Basset", report["name"]
+    assert_equal spec.fetch("session_id"), report["session_id"]
+    assert_equal "done", report["status"]
+    assert_equal "The answer is 7.", report["report"]
+    assert_equal "[Basset finished] The answer is 7.",
+                 report.dig("message", "content", 0, "text")
+
+    event = events.find { |e| e.type == :subagent_report }
+
+    assert_equal "Basset", event.agent
+    assert_equal :done, event.status
+    assert_equal "The answer is 7.", event.content
+  end
+
+  def test_the_report_folds_at_the_parents_next_turn
+    child_fake = fake({ text: "Their pricing starts at $49." })
+    spec, store, session = dispatch(child_fake, name: "Beagle")
+    Mistri::SubAgent.run_dispatched(spec, provider: child_fake, system: "You help.",
+                                          tools: [], store: store)
+    entry_id = session.pending_inbox.first["id"]
+    parent = fake({ text: "Noted, folding that in." })
+
+    Mistri::Agent.new(provider: parent, session:).run("continue")
+
+    folded = session.entries.find { |entry| entry["report_id"] == entry_id }
+
+    refute_nil folded, "the folding message entry marks the report consumed"
+    assert_includes parent.requests.first[:messages].map(&:text).join("\n"),
+                    "[Beagle finished] Their pricing starts at $49."
+    assert_empty session.pending_inbox
+  end
+
+  def test_a_report_landing_mid_final_turn_extends_the_run_so_the_parent_reacts
+    parent = fake({ text: "All done here." }, { text: "Thanks, Corgi: it is 42." })
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    delivered = false
+
+    # The worker finishes while the model is mid-way through its clean
+    # final turn — too late for that turn's fold, so the run extends.
+    result = Mistri::Agent.new(provider: parent, session:).run("go") do |event|
+      next if delivered || event.type != :text_end
+
+      delivered = true
+      session.deliver_report(name: "Corgi", session_id: "abc", status: "done", text: "42")
+    end
+
+    assert_equal "Thanks, Corgi: it is 42.", result.text,
+                 "a clean finish with a pending report runs one more turn"
+    assert_includes parent.requests.last[:messages].map(&:text).join("\n"),
+                    "[Corgi finished] 42"
+    assert_empty session.pending_inbox
+  end
+
+  def test_a_failed_worker_reports_the_error
+    child_fake = fake({ error: "exploded" })
+    spec, store, session = dispatch(child_fake, name: "Husky")
+
+    Mistri::SubAgent.run_dispatched(spec, provider: child_fake, system: "You help.",
+                                          tools: [], store: store)
+
+    report = session.pending_inbox.first
+
+    assert_equal "failed", report["status"]
+    assert_match(/\[Husky failed\] .*exploded/, report.dig("message", "content", 0, "text"))
+    assert_match(/exploded/, Mistri::Child.new(name: "Husky",
+                                               session_id: spec.fetch("session_id"),
+                                               store: store).error)
+  end
+
+  def test_a_stopped_worker_reports_it_was_stopped
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = Mistri::Stores::Memory.new
+    slow = Mistri::Tool.define("slow", "Takes a while.") do
+      sleep 1.4
+      "worked"
+    end
+    child_fake = fake({ tool_calls: [{ name: "slow", arguments: {} }] }, { text: "never" })
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [slow],
+                                     dispatcher: Mistri::Dispatchers::Thread.new)
+    parent = spawn_call({ "name" => "Pointer", "task" => "work",
+                          "instructions" => "Use slow.", "mode" => "background" })
+    session = Mistri::Session.new(store:)
+    Mistri::Agent.new(provider: parent, tools: [spawn], session:).run("go")
+    child = session.children.first
+
+    child.stop
+    await { session.pending_inbox.any? }
+
+    report = session.pending_inbox.first
+
+    assert_equal "stopped", report["status"]
+    assert_equal "[Pointer was stopped]", report.dig("message", "content", 0, "text")
+    assert_nil report["report"]
+  end
+
+  def test_delivery_is_idempotent_and_labels_unknown_statuses_honestly
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+
+    first = session.deliver_report(name: "Corgi", session_id: "abc", status: "done", text: "42")
+    second = session.deliver_report(name: "Corgi", session_id: "abc", status: "done", text: "42")
+
+    assert first
+    refute second, "the second delivery for the same child is dropped"
+    assert_equal 1, session.pending_inbox.length
+
+    session.deliver_report(name: "Akita", session_id: "def", status: "interrupted")
+
+    assert_equal "[Akita ended: interrupted]",
+                 session.pending_inbox.last.dig("message", "content", 0, "text")
+  end
+
+  def test_steers_and_reports_fold_in_arrival_order
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    session.steer("check their pricing")
+    session.deliver_report(name: "Corgi", session_id: "abc", status: "done", text: "42")
+    session.steer("and be quick")
+    parent = fake({ text: "On it." })
+
+    Mistri::Agent.new(provider: parent, session:).run("go")
+
+    texts = parent.requests.first[:messages].map(&:text)
+    positions = ["check their pricing", "[Corgi finished] 42", "and be quick"]
+                .map { |needle| texts.index { |text| text.include?(needle) } }
+
+    assert_equal positions.sort, positions, "the inbox folds in arrival order"
+    refute_includes positions, nil
+    assert_empty session.pending_inbox
+  end
+
+  def test_a_crashed_workers_retry_runs_it_again
+    Mistri.locks = Mistri::Locks::Memory.new
+    child_fake = fake({ text: "Recovered on retry." })
+    spec, store, session = dispatch(child_fake, name: "Saluki")
+    child_session = Mistri::Session.new(store:, id: spec.fetch("session_id"))
+    # The first delivery started the child, then its process died: a
+    # started entry, no terminal, no live lease.
+    child_session.append(Mistri::Child::STARTED, {})
+    child = session.children.first
+
+    assert_equal :interrupted, child.status
+
+    result = Mistri::SubAgent.run_dispatched(spec, provider: child_fake, system: "You help.",
+                                                   tools: [], store: store)
+
+    assert_predicate result, :completed?
+    assert_equal :done, child.status
+    assert_equal "Recovered on retry.", session.pending_inbox.first["report"]
+  end
+
+  def test_a_redelivered_live_job_leaves_the_owner_alone
+    Mistri.locks = Mistri::Locks::Memory.new
+    child_fake = fake({ text: "should never run" })
+    spec, store, session = dispatch(child_fake, name: "Whippet")
+    child_session = Mistri::Session.new(store:, id: spec.fetch("session_id"))
+    child_session.append(Mistri::Child::STARTED, {})
+    Mistri.locks.acquire(Mistri::Child.lease_key(spec.fetch("session_id")), ttl: 30)
+
+    result = Mistri::SubAgent.run_dispatched(spec, provider: child_fake, system: "You help.",
+                                                   tools: [], store: store)
+
+    assert_nil result
+    assert_empty child_fake.requests, "the redelivered job never ran the child"
+    assert_equal :running, session.children.first.status
+    assert_empty session.pending_inbox
+  end
+
+  def test_a_retry_of_a_finished_job_neither_runs_nor_repeats_the_report
+    child_fake = fake({ text: "done once" })
+    spec, store, session = dispatch(child_fake)
+    Mistri::SubAgent.run_dispatched(spec, provider: child_fake, system: "You help.",
+                                          tools: [], store: store)
+    events = []
+
+    retried = Mistri::SubAgent.run_dispatched(spec, provider: child_fake, system: "You help.",
+                                                    tools: [], store: store,
+                                                    emit: ->(event) { events << event })
+
+    assert_nil retried
+    assert_equal 1, session.pending_inbox.length
+    assert_empty events, "a dropped duplicate delivers no event either"
+  end
+
+  def test_a_cancelled_queued_worker_still_reports_when_the_job_arrives_late
+    Mistri.locks = Mistri::Locks::Memory.new
+    child_fake = fake({ text: "never" })
+    spec, store, session = dispatch(child_fake, name: "Collie")
+    session.children.first.stop
+
+    Mistri::SubAgent.run_dispatched(spec, provider: child_fake, system: "You help.",
+                                          tools: [], store: store)
+
+    report = session.pending_inbox.first
+
+    assert_equal "stopped", report["status"]
+    assert_equal "[Collie was stopped]", report.dig("message", "content", 0, "text")
+    assert_empty child_fake.requests
+  end
+
+  def test_a_parentless_spec_still_emits_the_event
+    child_fake = fake({ text: "orphan work" })
+    store = Mistri::Stores::Memory.new
+    child = Mistri::Session.new(store:)
+    child.append(Mistri::Child::DISPATCHED, {})
+    # The wire shape, hand-authored: a spec is only JSON.
+    spec = { "name" => "Vizsla", "session_id" => child.id, "parent_session_id" => nil,
+             "task" => "t", "type" => "general-purpose", "instructions" => "You help.",
+             "tool_names" => [], "model" => nil, "workspace" => "own" }
+    events = []
+
+    result = Mistri::SubAgent.run_dispatched(spec, provider: child_fake, system: "You help.",
+                                                   tools: [], store: store,
+                                                   emit: ->(event) { events << event })
+
+    assert_predicate result, :completed?
+    assert_equal :subagent_report, events.last.type
+    assert_equal "orphan work", events.last.content
+  end
+end

--- a/test/test_report_delivery.rb
+++ b/test/test_report_delivery.rb
@@ -3,8 +3,8 @@
 require_relative "test_helper"
 
 # Report delivery: a background child's terminal outcome reaches its parent
-# exactly once — a typed inbox entry that folds like a steer, and an event
-# that closes the child's lane — and the lease fences dispatched runs so
+# exactly once (a typed inbox entry that folds like a steer, plus an event
+# that closes the child's lane), and the lease fences dispatched runs so
 # queue retries heal crashes without ever double-running a child.
 class TestReportDelivery < Minitest::Test
   def teardown
@@ -97,7 +97,7 @@ class TestReportDelivery < Minitest::Test
     delivered = false
 
     # The worker finishes while the model is mid-way through its clean
-    # final turn — too late for that turn's fold, so the run extends.
+    # final turn, too late for that turn's fold, so the run extends.
     result = Mistri::Agent.new(provider: parent, session:).run("go") do |event|
       next if delivered || event.type != :text_end
 

--- a/test/test_stores.rb
+++ b/test/test_stores.rb
@@ -3,6 +3,14 @@
 require "tmpdir"
 require_relative "test_helper"
 
+begin
+  require "active_record"
+  require_relative "../lib/mistri/stores/active_record"
+rescue LoadError
+  # The gem has zero runtime dependencies; ActiveRecord store coverage runs
+  # only where activerecord is installed (the rails_test bundle group).
+end
+
 class TestStores < Minitest::Test
   def test_session_round_trips_messages_through_each_store
     each_store do |store|
@@ -48,5 +56,116 @@ class TestStores < Minitest::Test
   def each_store
     yield Mistri::Stores::Memory.new
     Dir.mktmpdir { |dir| yield Mistri::Stores::JSONL.new(dir) }
+  end
+end
+
+if defined?(Mistri::Stores::ActiveRecord)
+  # A model standing in for the host's table, faithful to the one contract
+  # the store leans on: the unique (session_id, position) index. Uniqueness
+  # is checked under a lock, exactly as the database would.
+  class FakeEntryModel
+    Row = Struct.new(:session_id, :position, :payload)
+
+    def initialize
+      @rows = []
+      @mutex = Mutex.new
+      @before_insert = nil
+    end
+
+    # Runs inside the insert lock, before uniqueness is checked: a hook a
+    # test uses to slip a competing row in, deterministically.
+    def race_once(&block)
+      @before_insert = block
+    end
+
+    def where(session_id:)
+      rows = @mutex.synchronize { @rows.select { |row| row.session_id == session_id }.dup }
+      Scope.new(rows)
+    end
+
+    def create!(session_id:, position:, payload:)
+      @mutex.synchronize do
+        if (hook = @before_insert)
+          @before_insert = nil
+          hook.call
+        end
+        if @rows.any? { |row| row.session_id == session_id && row.position == position }
+          raise ::ActiveRecord::RecordNotUnique, "duplicate (#{session_id}, #{position})"
+        end
+
+        @rows << Row.new(session_id, position, payload)
+      end
+    end
+
+    def insert_bare(session_id, position)
+      @rows << Row.new(session_id, position, "{}")
+    end
+
+    class Scope
+      def initialize(rows) = @rows = rows
+
+      def maximum(_column) = @rows.map(&:position).max
+
+      def pluck(*) = @rows.map { |row| [row.position, row.payload] }
+    end
+  end
+
+  # The optimistic append: writers that collide on the unique index retry
+  # at the next position, because sessions have concurrent appenders by
+  # design (the loop, a steer from another process, a child's report).
+  class TestActiveRecordStore < Minitest::Test
+    def setup
+      @model = FakeEntryModel.new
+      @store = Mistri::Stores::ActiveRecord.new(@model)
+    end
+
+    def test_appends_and_loads_in_position_order
+      @store.append("s", { "type" => "message", "n" => 1 })
+      @store.append("s", { "type" => "message", "n" => 2 })
+
+      numbers = @store.load("s").map { |entry| entry["n"] }
+
+      assert_equal [1, 2], numbers
+    end
+
+    def test_a_losing_writer_retries_at_the_next_position
+      @store.append("s", { "n" => 1 })
+      # Another process appends between this writer's max(position) read
+      # and its insert; the index rejects the stale position and the
+      # retry lands cleanly after the winner.
+      @model.race_once { @model.insert_bare("s", 2) }
+
+      @store.append("s", { "n" => 3 })
+
+      assert_equal 3, @store.load("s").length
+      assert_equal({ "n" => 3 }, @store.load("s").last)
+    end
+
+    def test_concurrent_appenders_all_land_with_unique_positions
+      threads = Array.new(4) do |writer|
+        Thread.new do
+          5.times { |n| @store.append("s", { "writer" => writer, "n" => n }) }
+        end
+      end
+      threads.each(&:join)
+
+      entries = @store.load("s")
+
+      assert_equal 20, entries.length
+      positions = @model.where(session_id: "s").pluck.map(&:first)
+
+      assert_equal positions.uniq, positions
+    end
+
+    def test_gives_up_loudly_when_the_slot_never_frees
+      # A pathological model that reports the same max forever: every
+      # attempt collides, so the append must surface the conflict rather
+      # than spin.
+      @model.define_singleton_method(:create!) do |**|
+        raise ::ActiveRecord::RecordNotUnique, "always"
+      end
+
+      assert_raises(::ActiveRecord::RecordNotUnique) { @store.append("s", { "n" => 1 }) }
+    end
   end
 end


### PR DESCRIPTION
Background mode (#14) let a parent move on while a worker runs. This PR closes the loop: when the worker finishes, its report comes to the parent — the parent never has to go ask.

## What

A background child's terminal outcome now reports back, exactly once, through two channels:

- **The parent's inbox.** The report is appended to the parent session as a typed `subagent_report` entry and folds into the transcript at the next turn boundary, using the same fold-and-marker machinery steers have always used. The model sees a labeled block — `[Magpie finished] <report>`, `[Magpie failed] <error>`, `[Magpie was stopped]` — while the typed entry keeps `name`, `status`, and the raw text so a host renders a report card, never a fake user message. A report that lands while the model is mid-way through a clean final turn extends the run one turn, so the parent reacts instead of leaving it dangling.
- **The event stream.** A `:subagent_report` event (`agent`, `session_id`, `status`, `content`) fires on the emit the job supplies, so a UI that watched the spawn can settle the child's lane the moment it ends.

New public surface: `Session#pending_inbox` (steers and reports, arrival order — hosts that wake idle sessions on pending steers should watch this instead), `Session#deliver_report` (the idempotent primitive: one report per child, ever; duplicates are dropped and the return says which happened), `Child#finished?`, `Child#error`.

## The exactly-once fence

Writing delivery forced a hard look at `run_dispatched`'s retry semantics, and the guard from #14 had two gaps:

- A child a crashed process left mid-run (started entry, no terminal, lapsed lease) read `:interrupted`, which is not in `Child::LIVE` — so the queue retry that exists precisely to heal it was refused, wedging the child forever.
- A refused lease was not treated as "another process owns this child", so a queue that redelivers a still-running job (SQS visibility timeouts, Sidekiq super_fetch) could double-run it.

The rewrite takes the lease **before** the run-or-not decision: refused means leave the owner alone; holding it, a terminal means nothing to run (cancelled while queued, or a retry of a finished job — the no-op still delivers the report if it never went out, so a cancelled-while-queued worker's parent learns it was stopped); no terminal means run, crashed-and-retried children included. Inline children keep acquiring their own lease inside `execute_child` — their session ids are fresh per spawn, so they cannot collide.

## Tests

Twelve new unit tests cover the matrix: done/failed/stopped delivery with exact labels, fold order interleaved with steers, mid-final-turn extension, idempotent delivery, crash-retry healing, redelivered-live-job refusal (the child's provider records zero requests), retry-of-finished no-op (no duplicate entry, no duplicate event), late cancellation reporting, and a hand-authored parentless spec. The live matrix (`test/integration/test_background.rb`) adds the end-to-end proof on Anthropic, OpenAI, and Gemini: spawn a background worker, never touch the console, and the model answers from the folded report — 6/6 passed against real APIs.
