### PR TITLE
Read the whole conversation back, lanes included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Session#transcript reads the whole conversation back from the store:
+  entries with image bytes stripped, and with include_children every
+  sub-agent's log spliced in after its link entry, tagged with an
+  "origin" key shaped exactly like the live stream's event origins
+  (nesting joined with ">"). A UI that rebuilds from the transcript shows
+  the lanes it showed live, running children's progress-so-far included;
+  hosts stop hand-walking link entries.
 - Report delivery: a background child's terminal outcome reports back to
   its parent, exactly once. The report queues in the parent's inbox as a
   typed subagent_report entry and folds at the next turn boundary the way

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -128,6 +128,17 @@ module Mistri
       end
     end
 
+    # The session as a reader renders it: entries in order with inline image
+    # bytes stripped, and, with include_children, every sub-agent's own
+    # transcript spliced in after its link entry. Spliced entries carry an
+    # "origin" key shaped exactly like the live stream's event origins
+    # ("Magpie#ab12cd34", nesting joined with ">"), so a UI that rebuilds
+    # from this sees what it saw live, lanes included, running children's
+    # progress-so-far included. The raw log stays available as #entries.
+    def transcript(include_children: false)
+      splice(entries, include_children: include_children, prefix: nil, seen: Set[@id])
+    end
+
     # Record a human's decision on a parked tool call. Decisions are session
     # entries, so they can be written from any process, days later, with no
     # agent constructed; the next resume settles them.
@@ -181,6 +192,28 @@ module Mistri
 
     def summary_message(summary)
       Message.user("#{Compaction::SUMMARY_PREFACE}\n\n#{summary}")
+    end
+
+    # Each link entry opens its child's log in place, depth first, the way
+    # nested lanes opened live. The seen set makes expansion idempotent per
+    # child (a repeated or self-referencing link renders but never expands
+    # twice), so a hostile log cannot loop this.
+    def splice(log, include_children:, prefix:, seen:)
+      log.flat_map do |entry|
+        rendered = Child.strip_images(entry)
+        rendered = rendered.merge("origin" => prefix) if prefix
+        next [rendered] unless include_children && expandable?(entry, seen)
+
+        seen << entry["session_id"]
+        origin = "#{entry["name"]}##{entry["session_id"][0, 8]}"
+        origin = "#{prefix}>#{origin}" if prefix
+        child_log = self.class.new(store: @store, id: entry["session_id"]).entries
+        [rendered, *splice(child_log, include_children: true, prefix: origin, seen: seen)]
+      end
+    end
+
+    def expandable?(entry, seen)
+      entry["type"] == "subagent" && !seen.include?(entry["session_id"])
     end
 
     # How a report reads to the model: labeled with the worker's name and

--- a/test/test_session_transcript.rb
+++ b/test/test_session_transcript.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Session#transcript: the readable view of a run. Images strip, and with
+# include_children every sub-agent's log splices in after its link entry,
+# origin-tagged exactly like the live stream, so a UI rebuilding from the
+# store sees the lanes it saw live.
+class TestSessionTranscript < Minitest::Test
+  def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
+
+  def test_the_transcript_strips_images_but_the_raw_log_keeps_them
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    image = Mistri::Content::Image.from_bytes("png!", mime_type: "image/png")
+    session.append_message(Mistri::Message.user(["look", image]))
+
+    rendered = session.transcript.first.dig("message", "content").last
+
+    assert rendered["omitted"]
+    refute rendered.key?("data")
+    raw = session.entries.first.dig("message", "content").last
+
+    assert raw.key?("data"), "the raw log is untouched"
+  end
+
+  def test_child_entries_splice_in_after_their_link_origin_tagged
+    store = Mistri::Stores::Memory.new
+    session = Mistri::Session.new(store:)
+    researcher = Mistri::SubAgent.new(name: "researcher", description: "Looks things up.",
+                                      provider: fake({ text: "Their HQ is in Boise." }))
+    parent = fake({ tool_calls: [{ name: "researcher",
+                                   arguments: { "task" => "find the HQ" } }] },
+                  { text: "It is Boise." })
+
+    Mistri::Agent.new(provider: parent, tools: [researcher.tool], session:).run("go")
+
+    transcript = session.transcript(include_children: true)
+    link_at = transcript.index { |entry| entry["type"] == "subagent" }
+    child_id = transcript[link_at]["session_id"]
+    spliced = transcript.select { |entry| entry["origin"] }
+
+    refute_empty spliced, "the child's entries are in the parent's transcript"
+    spliced.each { |entry| assert_equal "researcher##{child_id[0, 8]}", entry["origin"] }
+    assert_operator link_at, :<, transcript.index { |entry| entry["origin"] },
+                    "the lane opens where the link sits"
+    texts = spliced.filter_map { |entry| entry.dig("message", "content", 0, "text") }
+
+    assert_includes texts.join("\n"), "Their HQ is in Boise."
+    assert(session.transcript.none? { |entry| entry["origin"] },
+           "without include_children the view stays flat")
+  end
+
+  def test_nested_lanes_join_origins_like_the_live_stream
+    store = Mistri::Stores::Memory.new
+    session = Mistri::Session.new(store:)
+    grandchild = Mistri::Session.new(store:)
+    grandchild.append_message(Mistri::Message.user("deep work"))
+    child = Mistri::Session.new(store:)
+    child.append("subagent", "name" => "writer", "session_id" => grandchild.id)
+    session.append("subagent", "name" => "researcher", "session_id" => child.id)
+
+    transcript = session.transcript(include_children: true)
+    deep = transcript.find { |entry| entry.dig("message", "content", 0, "text") == "deep work" }
+
+    assert_equal "researcher##{child.id[0, 8]}>writer##{grandchild.id[0, 8]}",
+                 deep["origin"]
+    nested_link = transcript.find { |entry| entry["name"] == "writer" }
+
+    assert_equal "researcher##{child.id[0, 8]}", nested_link["origin"],
+                 "the nested link entry itself sits in its parent's lane"
+  end
+
+  def test_a_running_childs_progress_so_far_is_included
+    store = Mistri::Stores::Memory.new
+    session = Mistri::Session.new(store:)
+    child = Mistri::Session.new(store:)
+    session.append("subagent", "name" => "scout", "session_id" => child.id)
+    child.append(Mistri::Child::STARTED, {})
+    child.append_message(Mistri::Message.user("half way"))
+
+    spliced = session.transcript(include_children: true).select { |entry| entry["origin"] }
+
+    assert_equal 2, spliced.length, "a live lane renders its progress so far"
+  end
+
+  def test_repeated_and_self_links_render_but_never_expand_twice
+    store = Mistri::Stores::Memory.new
+    session = Mistri::Session.new(store:)
+    child = Mistri::Session.new(store:)
+    child.append_message(Mistri::Message.user("once"))
+    session.append("subagent", "name" => "echo", "session_id" => child.id)
+    session.append("subagent", "name" => "echo", "session_id" => child.id)
+    session.append("subagent", "name" => "loop", "session_id" => session.id)
+
+    transcript = session.transcript(include_children: true)
+    links = transcript.count { |entry| entry["type"] == "subagent" }
+    lanes = transcript.count { |entry| entry["origin"] }
+
+    assert_equal 3, links
+    assert_equal 1, lanes, "the child expanded exactly once and the self-link not at all"
+  end
+
+  def test_a_link_to_a_session_with_no_entries_renders_just_the_link
+    store = Mistri::Stores::Memory.new
+    session = Mistri::Session.new(store:)
+    session.append("subagent", "name" => "ghost", "session_id" => "never-ran")
+
+    transcript = session.transcript(include_children: true)
+
+    assert_equal 1, transcript.length
+    assert_equal "ghost", transcript.first["name"]
+  end
+
+  def test_transcript_origins_match_what_the_stream_emitted
+    store = Mistri::Stores::Memory.new
+    session = Mistri::Session.new(store:)
+    researcher = Mistri::SubAgent.new(name: "researcher", description: "Looks things up.",
+                                      provider: fake({ text: "Found it." }))
+    parent = fake({ tool_calls: [{ name: "researcher", arguments: { "task" => "look" } }] },
+                  { text: "Done." })
+    streamed = []
+
+    Mistri::Agent.new(provider: parent, tools: [researcher.tool], session:).run("go") do |event|
+      streamed << event.origin if event.origin
+    end
+
+    replayed = session.transcript(include_children: true)
+                      .filter_map { |entry| entry["origin"] }
+
+    assert_equal streamed.uniq.sort, replayed.uniq.sort,
+                 "a reload rebuilds exactly the lanes the stream showed"
+  end
+end


### PR DESCRIPTION
A live run shows sub-agent lanes: the stream tags every child event with an origin, the UI renders each origin as a lane. Then the user reloads the page and the lanes vanish, because rebuilding from the store only ever read the parent's entries. Every host that hits this ends up hand-walking `subagent` link entries and merging child logs itself. That merge belongs in the gem.

## What

`Session#transcript(include_children: false)` is the readable view of a run:

- Inline image bytes are stripped and marked (`"omitted" => true`), the same sanitization `Child#transcript` already applies. Transcripts are for reading and re-rendering, not for hauling screenshots. The raw log stays available as `#entries`.
- With `include_children: true`, every sub-agent's own log splices in right after its link entry, depth first, each spliced entry carrying an `"origin"` key shaped exactly like the live stream's event origins: `researcher#ab12cd34`, nesting joined with `>`. A UI that keys lanes by origin rebuilds precisely what it showed live, including a still-running child's progress so far.

## Design notes

- **Stream parity is the contract, and it is tested**: one test runs a spawn while collecting event origins from the stream, then asserts the replayed transcript yields exactly the same origin set. If the stream and the store ever disagree about lane identity, that test fails.
- **Expansion is idempotent per child.** A `seen` set (seeded with the session's own id) means a repeated link renders but expands once, and a self-referencing link never recurses. A hostile or corrupted log cannot loop the reader.
- **Absent children degrade to nothing.** A link whose session never wrote an entry renders just the link, so a child that was dispatched but never started still shows where its lane would open.

## Tests

Seven new tests: image stripping (raw log untouched), splice position and tagging through a real spawned child, nested lanes with joined origins, running-child progress, repeated/self links, ghost children, and the stream-parity assertion. Full suite green, rubocop clean.
