### PR TITLE
Stream in-progress tool calls and name each specialist run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- The Fake provider streams tool-call arguments in chunks, and each
+  delta's partial carries the in-progress call with arguments parsed so
+  far, the same shape a real assembler builds. A consumer that renders
+  tool input as it arrives (a page preview, a code block) is now testable
+  headless.
+- Each run of a named specialist can carry its own name: the delegate
+  tool takes an optional name argument, so two parallel researchers read
+  as Corgi and Beagle in lanes, lists, and links instead of "researcher"
+  twice. SubAgent.sanitize_label is the one shared sanitizer behind
+  specialist runs and spawner labels.
 - Tool.define takes ends_turn: true for a tool that is the last word of
   its turn: once it executes, the loop ends the run instead of prompting
   the model again, so an ask_user tool hands the floor to a human

--- a/lib/mistri/providers/fake.rb
+++ b/lib/mistri/providers/fake.rb
@@ -67,16 +67,30 @@ module Mistri
         kind == :text ? Content::Text.new(text:) : Content::Thinking.new(thinking: text)
       end
 
+      # Arguments stream in chunks, and every delta's partial carries the
+      # in-progress call with the arguments parsed so far, the same shape a
+      # real assembler builds, so a consumer that renders tool input as it
+      # arrives (a page preview, a code block) is testable headless.
       def stream_tool_call(spec, position, blocks, emit)
         spec = spec.transform_keys(&:to_sym)
         call = ToolCall.new(id: spec[:id] || "call_#{position + 1}", name: spec[:name],
                             arguments: (spec[:arguments] || {}).transform_keys(&:to_s))
         index = blocks.size
         emit_event(emit, :toolcall_start, blocks, content_index: index)
-        emit_event(emit, :toolcall_delta, blocks, content_index: index,
-                                                  delta: JSON.generate(call.arguments))
+        built = +""
+        JSON.generate(call.arguments).scan(/.{1,#{@chunk_size}}/m) do |chunk|
+          built << chunk
+          emit_event(emit, :toolcall_delta, blocks + [in_progress(call, built)],
+                     content_index: index, delta: chunk)
+        end
         blocks << call
         emit_event(emit, :toolcall_end, blocks, content_index: index, tool_call: call)
+      end
+
+      def in_progress(call, json)
+        parsed = PartialJson.parse(json)
+        ToolCall.new(id: call.id, name: call.name,
+                     arguments: parsed.is_a?(Hash) ? parsed : {})
       end
 
       def finish(turn, blocks, emit)

--- a/lib/mistri/spawner.rb
+++ b/lib/mistri/spawner.rb
@@ -259,12 +259,8 @@ module Mistri
       text
     end
 
-    # The label rides origins as "label#id" and joins nesting with ">",
-    # so those separators squeeze to hyphens along with whitespace.
     def label_for(args)
-      label = args["name"].to_s.gsub(/[#>\s]+/, "-").squeeze("-")[0, 32]
-      label = label.delete_prefix("-").delete_suffix("-")
-      label.empty? ? "spawn" : label
+      SubAgent.sanitize_label(args["name"], fallback: "spawn")
     end
   end
 end

--- a/lib/mistri/sub_agent.rb
+++ b/lib/mistri/sub_agent.rb
@@ -62,7 +62,9 @@ module Mistri
 
     # The delegate tool: each call runs a fresh child and answers with its
     # final text, plus {agent, session_id} on the ui channel so a host can
-    # link the child's transcript.
+    # link the child's transcript. The model may name each run, so two
+    # parallel researchers read as "Corgi" and "Beagle" in lanes and lists
+    # instead of "researcher" twice.
     def tool
       sub = self
       blurb = "#{@description} Runs as a focused sub-agent with a clean " \
@@ -71,13 +73,16 @@ module Mistri
                                 schema: lambda {
                                   string :task, "Complete instructions for the sub-agent",
                                          required: true
+                                  string :name, "A short name for this run, shown wherever " \
+                                                "its events appear (default: the tool's name)"
                                 }) do |args, context|
-        sub.run_child(args.fetch("task"), context)
+        sub.run_child(args.fetch("task"), context, name: args["name"])
       end
     end
 
-    def run_child(task, context)
-      SubAgent.run_child(label: @name, provider: @provider, system: @system,
+    def run_child(task, context, name: nil)
+      SubAgent.run_child(label: SubAgent.sanitize_label(name, fallback: @name),
+                         provider: @provider, system: @system,
                          tools: @tools, task: task, context: context, schema: @schema,
                          **@agent_options)
     end
@@ -94,6 +99,15 @@ module Mistri
       # console, so a host hands its agent everything workers need.
       def pack(provider:, console: {}, **spawner_options)
         [spawner(provider: provider, **spawner_options), *Console.tools(**console)]
+      end
+
+      # A worker's display name, made safe for origins: the label rides
+      # them as "label#id" and nesting joins with ">", so those separators
+      # squeeze to hyphens along with whitespace. Blank falls back.
+      def sanitize_label(text, fallback:)
+        label = text.to_s.gsub(/[#>\s]+/, "-").squeeze("-")[0, 32]
+        label = label.delete_prefix("-").delete_suffix("-")
+        label.empty? ? fallback : label
       end
 
       def run_child(label:, provider:, system:, tools:, task:, context:, schema: nil,

--- a/test/test_fake_provider.rb
+++ b/test/test_fake_provider.rb
@@ -64,6 +64,31 @@ class TestFakeProvider < Minitest::Test
     assert_equal 1, provider.requests.first[:messages].length
   end
 
+  def test_tool_call_arguments_stream_in_chunks_with_readable_partials
+    html = "<main>Hello, page</main>"
+    turn = { tool_calls: [{ name: "write_page", arguments: { "html" => html } }] }
+    provider = Mistri::Providers::Fake.new(turns: [turn], chunk_size: 8)
+    events = []
+
+    provider.stream { |event| events << event }
+
+    assert_well_formed events
+    chunks = deltas(events, :toolcall_delta)
+
+    assert_operator chunks.length, :>, 1, "arguments arrive over many deltas"
+    assert_equal JSON.generate({ "html" => html }), chunks.join
+
+    calls = events.select { |e| e.type == :toolcall_delta }
+                  .map { |e| e.partial.content.last }
+
+    calls.each { |call| assert_equal "write_page", call.name }
+    htmls = calls.map { |call| call.arguments["html"].to_s }
+
+    assert_equal htmls.sort_by(&:length), htmls,
+                 "the in-progress html only ever grows: #{htmls.inspect}"
+    assert_equal html, htmls.last, "the final delta's partial already reads complete"
+  end
+
   private
 
   def deltas(events, type)

--- a/test/test_specialist_naming.rb
+++ b/test/test_specialist_naming.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# A named specialist is a role; each run of it can carry its own name, so
+# two parallel researchers read as Corgi and Beagle in lanes, lists, and
+# links instead of "researcher" twice.
+class TestSpecialistNaming < Minitest::Test
+  def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
+
+  def researcher(provider)
+    Mistri::SubAgent.new(name: "researcher", description: "Looks things up.",
+                         provider: provider)
+  end
+
+  def run_with(arguments)
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    parent = fake({ tool_calls: [{ name: "researcher", arguments: arguments }] },
+                  { text: "Done." })
+    origins = []
+    Mistri::Agent.new(provider: parent, tools: [researcher(fake({ text: "Found." })).tool],
+                      session:).run("go") do |event|
+      origins << event.origin if event.origin
+    end
+    [session, origins]
+  end
+
+  def test_a_run_can_carry_its_own_name
+    session, origins = run_with({ "task" => "find the HQ", "name" => "Corgi" })
+    child = session.children.first
+
+    assert_equal "Corgi", child.name
+    assert origins.all? { |origin| origin.start_with?("Corgi#") },
+           "the lane is the run's name, not the role's: #{origins.uniq}"
+  end
+
+  def test_an_unnamed_run_reads_as_the_specialist
+    session, origins = run_with({ "task" => "find the HQ" })
+
+    assert_equal "researcher", session.children.first.name
+    assert origins.all? { |origin| origin.start_with?("researcher#") },
+           "unexpected lane: #{origins.uniq}"
+  end
+
+  def test_hostile_names_are_made_safe_for_origins
+    session, = run_with({ "task" => "t", "name" => "Cor gi>#hash" })
+
+    assert_equal "Cor-gi-hash", session.children.first.name
+  end
+
+  def test_a_blank_name_falls_back
+    assert_equal "researcher", Mistri::SubAgent.sanitize_label("  ", fallback: "researcher")
+    assert_equal "spawn", Mistri::SubAgent.sanitize_label(nil, fallback: "spawn")
+  end
+end


### PR DESCRIPTION
Two ergonomics gaps left in the worker experience, both small, both felt daily.

## Fake tool-call partials

A consumer that renders tool input as it arrives (a page preview filling in as the model writes html, a code block growing line by line) could only be tested against a live provider, because the Fake delivered tool-call arguments as one delta with no in-progress call in its partials. Now arguments stream in `chunk_size` pieces and every delta's `partial` carries the in-progress call with arguments parsed so far via `PartialJson` — the same shape the real assemblers build (`providers/anthropic/assembler.rb` is the reference). The test drives a `write_page` call and asserts the html grows monotonically across partials and reads complete on the final delta.

## Per-run specialist names

A named specialist is a role; each run of it can now carry its own name. The delegate tool takes an optional `name` argument, so two parallel researchers read as Corgi and Beagle in lanes, lists, and links instead of "researcher" twice. `SubAgent.sanitize_label` is the one sanitizer behind both specialist runs and spawner labels (origins ride `label#id` and nest with `>`, so those separators squeeze to hyphens), and a blank or hostile name falls back to the role. This upstreams a seam one host already hand-rolled: a required name argument bolted onto its researcher tool.

## Tests

Streaming: chunked deltas reassemble to the exact argument JSON, partials stay well-formed, in-progress arguments only grow. Naming: a named run owns its lane origin end to end, an unnamed run reads as the role, hostile names sanitize, blanks fall back. Full suite green, rubocop clean.
