### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,36 +3,48 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.5.0] - 2026-07-08
 
-- The Fake provider streams tool-call arguments in chunks, and each
-  delta's partial carries the in-progress call with arguments parsed so
-  far, the same shape a real assembler builds. A consumer that renders
-  tool input as it arrives (a page preview, a code block) is now testable
-  headless.
-- Each run of a named specialist can carry its own name: the delegate
-  tool takes an optional name argument, so two parallel researchers read
-  as Corgi and Beagle in lanes, lists, and links instead of "researcher"
-  twice. SubAgent.sanitize_label is the one shared sanitizer behind
-  specialist runs and spawner labels.
-- Tool.define takes ends_turn: true for a tool that is the last word of
-  its turn: once it executes, the loop ends the run instead of prompting
-  the model again, so an ask_user tool hands the floor to a human
-  structurally instead of through prompt discipline. The whole batch it
-  arrived in still executes and is answered; a blocked or denied call
-  never executed, so the model keeps the floor; a parked approval outranks
-  it (the run suspends, and an approved ends_turn call ends the resumed
-  run). A pending steer stays queued for the next run. The Result says it
-  happened (Result#handed_off?), so hosts route on the handoff instead of
-  sniffing messages, and task mode returns the handoff as-is rather than
-  re-prompting for JSON while a human holds the floor.
-- Session#transcript reads the whole conversation back from the store:
-  entries with image bytes stripped, and with include_children every
-  sub-agent's log spliced in after its link entry, tagged with an
-  "origin" key shaped exactly like the live stream's event origins
-  (nesting joined with ">"). A UI that rebuilds from the transcript shows
-  the lanes it showed live, running children's progress-so-far included;
-  hosts stop hand-walking link entries.
+- The children registry: Session#children lists every sub-agent a session
+  has spawned as a Mistri::Child, a window onto the child's own session
+  with name, status, report, transcript(tail:) with image bytes stripped,
+  and say(text) to steer it. All of it derives from the store, so it reads
+  the same from any process, while the child runs and forever after.
+- Completion is a contract: every child ends by writing a terminal entry
+  (done with its report, stopped, or failed with the error), including
+  when the child's run raises, so a crashed child never reads as running.
+
+- Spawn policy is an object: Mistri::Spawner carries the pool, types,
+  models, headcount, and dispatcher; SubAgent.spawner and SubAgent.pack
+  stay the front doors.
+- Typed workers: the spawner takes types:, a host registry of Definitions
+  by name. A typed child takes its system prompt, tools, and model from
+  the definition; instructions appends; explicit tool and model args
+  override within the pool and allowlist. "general-purpose" stays the
+  built-in composable default. Types fail at construction, never
+  mid-spawn: a definition with unfilled placeholders or tools the pool
+  lacks is a boot-time ConfigurationError.
+- max_children (default 4) caps live workers per session; a spawn past
+  the cap answers in band and freed slots reopen.
+- SubAgent.pack returns the spawn tool plus the management console in one
+  call, the whole kit for a worker-running agent.
+
+- Background mode: spawn_agent takes mode: "background" when the spawner
+  has a dispatcher, returning a truthful receipt immediately (what the
+  child's status says after dispatch, not what the mode promised) while
+  the parent keeps working; the report arrives on its own (above). The
+  dispatcher is a seam: Dispatchers::Inline (default degrade, synchronous
+  but honest) and Dispatchers::Thread ship in the gem, and a queue host
+  plugs one lambda whose job reconstructs tools from the serializable
+  spec and calls SubAgent.run_dispatched.
+- Lifecycle is entries: subagent_dispatched and subagent_started join the
+  terminal, so status walks the store alone: queued, running, interrupted,
+  done, stopped, failed. A job that dies before starting reads :queued,
+  honestly.
+- A background child runs on its own signal: the parent's turn is over, so
+  only stop_agent and the stop flag end it early. workspace: "parent"
+  requires inline mode, enforced in band.
+
 - Report delivery: a background child's terminal outcome reports back to
   its parent, exactly once. The report queues in the parent's inbox as a
   typed subagent_report entry and folds at the next turn boundary the way
@@ -50,36 +62,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and a retry of a child a crashed process left mid-run runs it again
   (previously the guard refused it, wedging the child as interrupted
   forever). Child#finished? and Child#error are new readers.
-- Background mode: spawn_agent takes mode: "background" when the spawner
-  has a dispatcher, returning a truthful receipt immediately (what the
-  child's status says after dispatch, not what the mode promised) while
-  the parent keeps working; the report arrives on its own (above). The
-  dispatcher is a seam: Dispatchers::Inline (default degrade, synchronous
-  but honest) and Dispatchers::Thread ship in the gem, and a queue host
-  plugs one lambda whose job reconstructs tools from the serializable
-  spec and calls SubAgent.run_dispatched.
-- Lifecycle is entries: subagent_dispatched and subagent_started join the
-  terminal, so status walks the store alone: queued, running, interrupted,
-  done, stopped, failed. A job that dies before starting reads :queued,
-  honestly.
-- A background child runs on its own signal: the parent's turn is over, so
-  only stop_agent and the stop flag end it early. workspace: "parent"
-  requires inline mode, enforced in band.
-- Spawn policy is an object: Mistri::Spawner carries the pool, types,
-  models, headcount, and dispatcher; SubAgent.spawner and SubAgent.pack
-  stay the front doors.
-
-- Typed workers: the spawner takes types:, a host registry of Definitions
-  by name. A typed child takes its system prompt, tools, and model from
-  the definition; instructions appends; explicit tool and model args
-  override within the pool and allowlist. "general-purpose" stays the
-  built-in composable default. Types fail at construction, never
-  mid-spawn: a definition with unfilled placeholders or tools the pool
-  lacks is a boot-time ConfigurationError.
-- max_children (default 4) caps live workers per session; a spawn past
-  the cap answers in band and freed slots reopen.
-- SubAgent.pack returns the spawn tool plus the management console in one
-  call, the whole kit for a worker-running agent.
 
 - The management console: Mistri::Console.tools returns list_agents,
   read_agent (tail: to choose how much transcript, wait: to block for the
@@ -112,14 +94,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   reads :interrupted instead of :running forever. Without an adapter
   nothing changes.
 
-- The children registry: Session#children lists every sub-agent a session
-  has spawned as a Mistri::Child, a window onto the child's own session
-  with name, status, report, transcript(tail:) with image bytes stripped,
-  and say(text) to steer it. All of it derives from the store, so it reads
-  the same from any process, while the child runs and forever after.
-- Completion is a contract: every child ends by writing a terminal entry
-  (done with its report, stopped, or failed with the error), including
-  when the child's run raises, so a crashed child never reads as running.
+- Session#transcript reads the whole conversation back from the store:
+  entries with image bytes stripped, and with include_children every
+  sub-agent's log spliced in after its link entry, tagged with an
+  "origin" key shaped exactly like the live stream's event origins
+  (nesting joined with ">"). A UI that rebuilds from the transcript shows
+  the lanes it showed live, running children's progress-so-far included;
+  hosts stop hand-walking link entries.
+
+- Tool.define takes ends_turn: true for a tool that is the last word of
+  its turn: once it executes, the loop ends the run instead of prompting
+  the model again, so an ask_user tool hands the floor to a human
+  structurally instead of through prompt discipline. The whole batch it
+  arrived in still executes and is answered; a blocked or denied call
+  never executed, so the model keeps the floor; a parked approval outranks
+  it (the run suspends, and an approved ends_turn call ends the resumed
+  run). A pending steer stays queued for the next run. The Result says it
+  happened (Result#handed_off?), so hosts route on the handoff instead of
+  sniffing messages, and task mode returns the handoff as-is rather than
+  re-prompting for JSON while a human holds the floor.
+
+- Store appends tolerate concurrent writers. Sessions have more than one
+  appender by design (the loop, a steer from a web process, a worker's
+  report from a job), so the ActiveRecord store's unique index is now
+  concurrency control rather than a tripwire: a writer that loses the
+  position race retries at the next slot, bounded, then raises loudly.
+  The JSONL store writes each line in a single call, so concurrent
+  appenders interleave whole lines, never fragments.
+
+- The Fake provider streams tool-call arguments in chunks, and each
+  delta's partial carries the in-progress call with arguments parsed so
+  far, the same shape a real assembler builds. A consumer that renders
+  tool input as it arrives (a page preview, a code block) is now testable
+  headless.
+- Each run of a named specialist can carry its own name: the delegate
+  tool takes an optional name argument, so two parallel researchers read
+  as Corgi and Beagle in lanes, lists, and links instead of "researcher"
+  twice. SubAgent.sanitize_label is the one shared sanitizer behind
+  specialist runs and spawner labels.
 
 ## [0.4.1] - 2026-07-06
 

--- a/lib/mistri/dispatchers.rb
+++ b/lib/mistri/dispatchers.rb
@@ -30,13 +30,15 @@ module Mistri
     # spawn call returns immediately. Enough for development and for hosts
     # whose children are short; queue-backed hosts plug their own lambda.
     class Thread
-      def call(_spec, runner)
+      def call(spec, runner)
         ::Thread.new do
           runner.call
-        rescue StandardError
-          # The runner writes terminals for its own failures; a thread must
-          # never die loudly into the process.
-          nil
+        rescue StandardError => e
+          # The runner writes the child's failed terminal before re-raising;
+          # a thread must not die loudly into the process, but it must not
+          # die silently either, or there is no trace to debug from.
+          warn "mistri: background runner for #{spec["name"].inspect} crashed: " \
+               "#{e.class}: #{e.message}"
         end
         nil
       end

--- a/lib/mistri/sub_agent.rb
+++ b/lib/mistri/sub_agent.rb
@@ -156,22 +156,32 @@ module Mistri
                            stop_key: Child.stop_key(child.id), signal: signal)
         return nil if Mistri.locks && lease.nil?
 
-        begin
-          if Child.new(name: spec.fetch("name"), session_id: child.id, store: store).finished?
-            lease&.release
-            return nil
-          end
-
-          result = execute_child(child: child, label: spec.fetch("name"), provider: provider,
-                                 system: system, tools: tools, task: spec.fetch("task"),
-                                 schema: schema, signal: signal, emit: emit, lease: lease,
-                                 **agent_options)
-          deny_pending(result, child)
-          child.append(Child::TERMINAL, terminal(result))
-          result
-        ensure
-          report_back(spec, store, emit)
+        if Child.new(name: spec.fetch("name"), session_id: child.id, store: store).finished?
+          lease&.release
+          return nil
         end
+
+        result = execute_child(child: child, label: spec.fetch("name"), provider: provider,
+                               system: system, tools: tools, task: spec.fetch("task"),
+                               schema: schema, signal: signal, emit: emit, lease: lease,
+                               **agent_options)
+        deny_pending(result, child)
+        child.append(Child::TERMINAL, terminal(result))
+        result
+      rescue StandardError => e
+        # Completion is a contract even when the runner dies in the
+        # preamble: without this, a raise before the started entry (a lock
+        # backend down, say) would leave the child reading :queued forever,
+        # with nothing to report and nothing for a retry to heal.
+        if child && !Child.new(name: spec.fetch("name"), session_id: child.id,
+                               store: store).finished?
+          child.append(Child::TERMINAL,
+                       "status" => "failed", "error" => "#{e.class}: #{e.message}")
+        end
+        lease&.release
+        raise
+      ensure
+        report_back(spec, store, emit) if child
       end
 
       # A child cannot wait for a human, whichever door it entered by: any

--- a/lib/mistri/version.rb
+++ b/lib/mistri/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mistri
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end

--- a/test/integration/test_background.rb
+++ b/test/integration/test_background.rb
@@ -14,8 +14,11 @@ class TestBackgroundIntegration < Minitest::Test
     Mistri.locks = Mistri::Locks::Memory.new
     number = rand(100..900)
     store = Mistri::Stores::Memory.new
+    # Slow enough that the parent's receipt turn reliably finishes first;
+    # a faster oracle folds its report mid-run and the parent, correctly,
+    # answers with the number instead of the scripted acknowledgement.
     oracle = Mistri::Tool.define("oracle", "Answers the secret number, slowly.") do
-      sleep 2
+      sleep 8
       number.to_s
     end
     tools = Mistri::SubAgent.pack(provider: Mistri.provider(model), tools: [oracle],

--- a/test/integration/test_delegation.rb
+++ b/test/integration/test_delegation.rb
@@ -32,7 +32,11 @@ class TestDelegationIntegration < Minitest::Test
 
     assert_predicate result, :completed?
     assert Integration.saw?(result.text, year.to_s), "the year never flowed up: #{result.text}"
-    assert(origins.all? { |o| o.start_with?("researcher#") }, "child events untagged")
+    lanes = origins.uniq
+
+    assert_equal 1, lanes.length, "one worker, one lane: #{lanes.inspect}"
+    assert_match(/\A[\w-]+#\h{8}\z/, lanes.first,
+                 "child events carry a worker tag: #{lanes.first.inspect}")
 
     link = parent.session.messages.select(&:tool?).last.ui
     child = Mistri::Session.new(store:, id: link.fetch("session_id"))

--- a/test/test_report_delivery.rb
+++ b/test/test_report_delivery.rb
@@ -257,6 +257,29 @@ class TestReportDelivery < Minitest::Test
     assert_empty child_fake.requests
   end
 
+  def test_a_runner_that_dies_before_the_start_still_fails_the_child
+    broken = Class.new do
+      def held?(_key) = false
+      def acquire(*) = raise("lock backend down")
+      def clear_flag(_key) = nil
+    end
+    Mistri.locks = broken.new
+    child_fake = fake({ text: "never runs" })
+    spec, store, session = dispatch(child_fake, name: "Vizsla")
+
+    assert_raises(RuntimeError) do
+      Mistri::SubAgent.run_dispatched(spec, provider: child_fake, system: "You help.",
+                                            tools: [], store: store)
+    end
+
+    child = session.children.first
+
+    assert_equal :failed, child.status, "queued forever is a contract violation"
+    assert_match(/lock backend down/, child.error)
+    assert_equal "failed", session.pending_inbox.first["status"],
+                 "the failure still reports back to the parent"
+  end
+
   def test_a_parentless_spec_still_emits_the_event
     child_fake = fake({ text: "orphan work" })
     store = Mistri::Stores::Memory.new


### PR DESCRIPTION
The 0.5 slate is merged; this is the release commit, carrying what the full live matrix (51 scenarios, three providers) surfaced on its first complete run since 0.4.1.

## The version and the notes

0.4.1 to 0.5.0, and the unreleased changelog groomed into release notes: bullets reordered foundation-first (registry, spawning, background, reports, console, stop, locks, transcript, ends_turn, stores, polish) plus one bullet that had never been written for the concurrent-append hardening that shipped inside #15.

## What the matrix caught

Three failures, three different stories:

- **A feature outran its test.** Per-run worker names (#18) mean gpt-5.2 labels its researcher lane with a name of its own choosing, so `origins.all? { start_with?("researcher#") }` asserted the pre-#18 world. The scenario now asserts the real invariant, exactly one consistently-shaped lane tag, while the unit suite keeps pinning the default-name fallback.
- **A fixture's timing premise expired.** Report self-delivery (#15) means a 2-second oracle finishes mid-turn on a fast model and the parent, correctly, answers with the folded report instead of the scripted acknowledgement. The oracle now sleeps 8 seconds so the receipt turn reliably lands first; assertions untouched.
- **A transient exposed a real hole.** One run wedged a child as `:queued` forever: a runner that dies before the started entry (session open, lock acquire, terminal check) wrote no terminal, and `Dispatchers::Thread` swallowed the exception with `rescue nil`. "Completion is a contract" now covers the preamble: `run_dispatched` writes the failed terminal on any raise, releases the lease, re-raises, and the failure reports to the parent like every other terminal; the thread warns with class and message instead of dying mute. A new test breaks the lock backend and asserts the child reads `:failed` and the report arrives.

## Verification

414 hermetic runs green, rubocop clean, `gem build` valid, and the full live matrix green across Anthropic, OpenAI, and Gemini, modulo two one-off task-adherence flakes on gemini-flash that pass in isolation and are deliberately not tuned around.