### PR TITLE
Cut the GitHub release from the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,5 +22,34 @@ jobs:
         with:
           ruby-version: "3.4"
           bundler-cache: true
+      # The tag does not set the published version; lib/mistri/version.rb
+      # does. A mismatched tag fails here, plainly, instead of surfacing as
+      # rubygems rejecting a republish of the old version.
+      - if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          ruby -r ./lib/mistri/version -e 'tag = ENV.fetch("GITHUB_REF_NAME");
+            abort "tag #{tag} but VERSION is #{Mistri::VERSION}" unless tag == "v#{Mistri::VERSION}"'
       - run: bundle exec rake test
       - uses: rubygems/release-gem@v1
+
+  # The release page exists only for versions that actually published, and
+  # this job alone gets write access; the publish job stays read-only.
+  github-release:
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      # Notes are this version's changelog section; an unwritten section
+      # fails the job rather than shipping an empty page. Reruns are safe:
+      # an existing release is left alone.
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="$version" '$0 ~ "^## \\[" ver "\\]" {flag=1; next} /^## \[/ {flag=0} flag' CHANGELOG.md > notes.md
+          test -s notes.md
+          gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1 && exit 0
+          gh release create "$GITHUB_REF_NAME" --title "mistri $version" --notes-file notes.md

--- a/test/test_background_mode.rb
+++ b/test/test_background_mode.rb
@@ -99,7 +99,8 @@ class TestBackgroundMode < Minitest::Test
     receipt = session.messages.select(&:tool?).last
 
     assert_match(/working in the background/, receipt.text)
-    assert_equal :running, child.status, "the child is still at work as the parent finishes"
+    assert_includes Mistri::Child::LIVE, child.status,
+                    "the child has not finished as the parent moves on"
 
     assert_equal :done, await_status(child, :done)
     assert_equal "Finished the slow work.", child.report


### PR DESCRIPTION
Tagging publishes the gem, but the GitHub release page was still a manual step after every release (0.3.0 through 0.5.0), and the workflow silently tolerated the one mistake that can actually break a release: tagging before the version bump landed.

## What

- **A github-release job**, downstream of publish and tag-only: extracts the tag's own section from the changelog, fails if that section was never written, and creates the release page. Reruns are safe; an existing release is left alone. It is a separate job so it alone carries `contents: write` while the publish job keeps its read-only, OIDC-only posture.
- **A version guard in publish**: the tag does not set the published version, `lib/mistri/version.rb` does, so a `v0.6.0` tag on a `0.5.0` tree now fails with "tag v0.6.0 but VERSION is 0.5.0" before anything ships, instead of surfacing as rubygems rejecting a republish.

## Verification

Workflows only fire on tags, so the moving pieces were exercised directly against the real repo files: the guard passes on `v0.5.0` and aborts with the plain message on `v0.6.0`; the awk extraction returns exactly the 21-bullet 0.5.0 section; `gh release view` short-circuits for the already-cut v0.5.0. YAML parses. The first live end-to-end run is the 0.5.1 tag, by design.