### PR TITLE
Price usage from the model catalog so cost budgets enforce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+- The model catalog carries each model's published API prices, and the
+  assemblers price every turn's usage from them: message.usage.cost and
+  Result#usage now report real dollars for catalogued models, and the
+  Budget cost_usd ceiling actually stops a run. It never could before:
+  nothing computed cost, so the comparison always saw zero. Uncatalogued
+  models still report zero cost and only the other ceilings stop them.
+  Long-context premium tiers (Gemini Pro and GPT past 200k input) are not
+  modeled; those turns under-count.
+
 ## [0.5.0] - 2026-07-08
 
 - The children registry: Session#children lists every sub-agent a session

--- a/README.md
+++ b/README.md
@@ -445,7 +445,9 @@ the generator and stores duck-type into any app.
 signal = Mistri::AbortSignal.new
 agent.run("Draft a long essay.", signal: signal)
 
-# Ceilings are opt-in and off by default.
+# Ceilings are opt-in and off by default. Dollar cost is priced from the
+# model catalog's published rates; a model the catalog does not know
+# reports zero cost, so only the other ceilings can stop it.
 budget = Mistri::Budget.new(turns: 20, cost_usd: 2.00)
 
 # Transient failures (429, 5xx, timeouts) retry with backoff, invisibly to

--- a/lib/mistri/models.rb
+++ b/lib/mistri/models.rb
@@ -18,7 +18,7 @@ module Mistri
     # 200k input) are not modeled; those turns under-count.
     Model = Data.define(:id, :provider, :max_output, :context_window, :thinking, :rates) do
       def initialize(id:, provider:, max_output:, context_window:, thinking:, rates: nil)
-        super(id:, provider:, max_output:, context_window:, thinking:, rates: rates&.freeze)
+        super(id:, provider:, max_output:, context_window:, thinking:, rates: rates.freeze)
       end
     end
 

--- a/lib/mistri/models.rb
+++ b/lib/mistri/models.rb
@@ -9,26 +9,50 @@ module Mistri
     # thinking is how the model accepts a reasoning request: :adaptive (the
     # model decides), :budget (a token budget), or :effort. It is what keeps
     # a provider from sending an unsupported thinking shape that 400s.
-    Model = Data.define(:id, :provider, :max_output, :context_window, :thinking)
+    #
+    # rates is the published API price in USD per million tokens; assemblers
+    # price each turn's usage from it. cache_write is the 5-minute write
+    # rate; the 1-hour slice bills at 2x input, which Usage#with_cost applies
+    # on its own. An uncatalogued model reports zero cost, so a cost budget
+    # never stops it. Long-context premium tiers (Gemini Pro and GPT past
+    # 200k input) are not modeled; those turns under-count.
+    Model = Data.define(:id, :provider, :max_output, :context_window, :thinking, :rates) do
+      def initialize(id:, provider:, max_output:, context_window:, thinking:, rates: nil)
+        super(id:, provider:, max_output:, context_window:, thinking:, rates: rates&.freeze)
+      end
+    end
 
     CATALOG = [
-      ["claude-fable-5", :anthropic, 128_000, 200_000, :adaptive],
-      ["claude-opus-4-8", :anthropic, 128_000, 200_000, :adaptive],
-      ["claude-opus-4-7", :anthropic, 128_000, 200_000, :adaptive],
-      ["claude-opus-4-6", :anthropic, 128_000, 200_000, :adaptive],
-      ["claude-sonnet-5", :anthropic, 128_000, 200_000, :adaptive],
-      ["claude-sonnet-4-6", :anthropic, 128_000, 200_000, :adaptive],
-      ["claude-haiku-4-5", :anthropic, 64_000, 200_000, :budget],
-      ["gpt-5.5", :openai, 128_000, 400_000, :effort],
-      ["gpt-5.4", :openai, 128_000, 400_000, :effort],
-      ["gpt-5-nano", :openai, 128_000, 400_000, :effort],
-      ["gemini-3.5-flash", :gemini, 65_536, 1_048_576, :level],
-      ["gemini-3.1-pro-preview", :gemini, 65_536, 1_048_576, :level],
-      ["gemini-2.5-pro", :gemini, 65_536, 1_048_576, :budget],
-      ["gemini-2.5-flash", :gemini, 65_536, 1_048_576, :budget]
-    ].to_h do |id, provider, max_output, context_window, thinking|
-      [id, Model.new(id:, provider:, max_output:, context_window:, thinking:)]
-    end.freeze
+      ["claude-fable-5", :anthropic, 128_000, 200_000, :adaptive,
+       { input: 10.0, output: 50.0, cache_read: 1.0, cache_write: 12.5 }],
+      ["claude-opus-4-8", :anthropic, 128_000, 200_000, :adaptive,
+       { input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25 }],
+      ["claude-opus-4-7", :anthropic, 128_000, 200_000, :adaptive,
+       { input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25 }],
+      ["claude-opus-4-6", :anthropic, 128_000, 200_000, :adaptive,
+       { input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25 }],
+      # Introductory pricing through 2026-08-31; 3.0/15.0 (0.3/3.75) after.
+      ["claude-sonnet-5", :anthropic, 128_000, 200_000, :adaptive,
+       { input: 2.0, output: 10.0, cache_read: 0.2, cache_write: 2.5 }],
+      ["claude-sonnet-4-6", :anthropic, 128_000, 200_000, :adaptive,
+       { input: 3.0, output: 15.0, cache_read: 0.3, cache_write: 3.75 }],
+      ["claude-haiku-4-5", :anthropic, 64_000, 200_000, :budget,
+       { input: 1.0, output: 5.0, cache_read: 0.1, cache_write: 1.25 }],
+      ["gpt-5.5", :openai, 128_000, 400_000, :effort,
+       { input: 5.0, output: 30.0, cache_read: 0.5 }],
+      ["gpt-5.4", :openai, 128_000, 400_000, :effort,
+       { input: 2.5, output: 15.0, cache_read: 0.25 }],
+      ["gpt-5-nano", :openai, 128_000, 400_000, :effort,
+       { input: 0.05, output: 0.4, cache_read: 0.005 }],
+      ["gemini-3.5-flash", :gemini, 65_536, 1_048_576, :level,
+       { input: 1.5, output: 9.0, cache_read: 0.15 }],
+      ["gemini-3.1-pro-preview", :gemini, 65_536, 1_048_576, :level,
+       { input: 2.0, output: 12.0, cache_read: 0.2 }],
+      ["gemini-2.5-pro", :gemini, 65_536, 1_048_576, :budget,
+       { input: 1.25, output: 10.0, cache_read: 0.125 }],
+      ["gemini-2.5-flash", :gemini, 65_536, 1_048_576, :budget,
+       { input: 0.3, output: 2.5, cache_read: 0.03 }]
+    ].to_h { |row| [row.first, Model.new(*row)] }.freeze
 
     # Dated aliases resolve to their base entry: claude-opus-4-8-20260115 and
     # gpt-5.4-2025-04-14 both match their base ids.
@@ -39,5 +63,7 @@ module Mistri
     def self.max_output(id) = find(id)&.max_output
 
     def self.thinking(id) = find(id)&.thinking
+
+    def self.rates(id) = find(id)&.rates
   end
 end

--- a/lib/mistri/providers/anthropic/assembler.rb
+++ b/lib/mistri/providers/anthropic/assembler.rb
@@ -13,6 +13,7 @@ module Mistri
       class Assembler
         def initialize(model:)
           @model = model
+          @rates = Models.rates(model)
           @blocks = []
           @current = nil
           @usage = Usage.zero
@@ -22,7 +23,7 @@ module Mistri
 
         def feed(record, &)
           case record["type"]
-          when "message_start" then @usage = parse_usage(record.dig("message", "usage"))
+          when "message_start" then @usage = priced(parse_usage(record.dig("message", "usage")))
           when "content_block_start" then start_block(record, &)
           when "content_block_delta" then delta_block(record, &)
           when "content_block_stop" then stop_block(record, &)
@@ -138,7 +139,7 @@ module Mistri
           # message_delta usage is cumulative; merge output counts over the
           # opening snapshot rather than summing.
           output = record.dig("usage", "output_tokens")
-          @usage = @usage.with(output: output.to_i) if output
+          @usage = priced(@usage.with(output: output.to_i)) if output
         end
 
         def finalize_current
@@ -199,6 +200,8 @@ module Mistri
                     cache_write: raw["cache_creation_input_tokens"].to_i,
                     cache_write_1h: cache_creation["ephemeral_1h_input_tokens"].to_i)
         end
+
+        def priced(usage) = @rates ? usage.with_cost(@rates) : usage
       end
     end
   end

--- a/lib/mistri/providers/gemini/assembler.rb
+++ b/lib/mistri/providers/gemini/assembler.rb
@@ -15,6 +15,7 @@ module Mistri
       class Assembler
         def initialize(model:)
           @model = model
+          @rates = Models.rates(model)
           @blocks = []
           @current = nil
           @usage = Usage.zero
@@ -31,7 +32,7 @@ module Mistri
           candidate = record.dig("candidates", 0) || {}
           Array(candidate.dig("content", "parts")).each { |part| fold_part(part, &) }
           @finish_reason = candidate["finishReason"] if candidate["finishReason"]
-          @usage = parse_usage(record["usageMetadata"]) if record["usageMetadata"]
+          @usage = priced(parse_usage(record["usageMetadata"])) if record["usageMetadata"]
         end
 
         # A stream that ended without a finishReason was truncated, not
@@ -157,6 +158,8 @@ module Mistri
                     output: raw["candidatesTokenCount"].to_i + reasoning,
                     cache_read: cache_read, reasoning: reasoning)
         end
+
+        def priced(usage) = @rates ? usage.with_cost(@rates) : usage
       end
     end
   end

--- a/lib/mistri/providers/openai/assembler.rb
+++ b/lib/mistri/providers/openai/assembler.rb
@@ -14,6 +14,7 @@ module Mistri
       class Assembler
         def initialize(model:)
           @model = model
+          @rates = Models.rates(model)
           @blocks = []
           @current = nil
           @usage = Usage.zero
@@ -162,7 +163,7 @@ module Mistri
           @incomplete_reason = response.dig("incomplete_details", "reason")
           @error = response.dig("error", "message") if @status == "failed"
           usage = response["usage"]
-          @usage = parse_usage(usage) if usage
+          @usage = priced(parse_usage(usage)) if usage
         end
 
         def stop_reason
@@ -209,6 +210,8 @@ module Mistri
                     output: raw["output_tokens"].to_i, cache_read: cache_read,
                     reasoning: output_details["reasoning_tokens"].to_i)
         end
+
+        def priced(usage) = @rates ? usage.with_cost(@rates) : usage
       end
     end
   end

--- a/test/test_agent.rb
+++ b/test/test_agent.rb
@@ -78,6 +78,22 @@ class TestAgent < Minitest::Test
     assert_equal "budget_turns", message.error_message
   end
 
+  def test_a_cost_budget_stops_the_run_between_turns
+    priced = Mistri::Usage.new(input: 200_000, output: 10_000)
+                          .with_cost(input: 5.0, output: 25.0)
+    provider = Mistri::Providers::Fake.new(turns: Array.new(3) do
+      { tool_calls: [{ name: "loop", arguments: {} }], usage: priced }
+    end)
+    tool = Mistri::Tool.define("loop", "Loops.") { "again" }
+    agent = Mistri::Agent.new(provider:, tools: [tool],
+                              budget: Mistri::Budget.new(cost_usd: 1.00))
+
+    message = agent.run("go")
+
+    assert_equal :budget, message.stop_reason
+    assert_equal "budget_cost", message.error_message
+  end
+
   def test_empty_input_and_duplicate_tools_fail_loudly
     provider = Mistri::Providers::Fake.new
     ping = Mistri::Tool.define("ping", "Ping.") { "pong" }

--- a/test/test_anthropic_assembler.rb
+++ b/test/test_anthropic_assembler.rb
@@ -89,6 +89,31 @@ class TestAnthropicAssembler < Minitest::Test
     assert_equal "opaque", message.content.first.signature
   end
 
+  def test_usage_prices_from_the_catalog_and_unknown_models_stay_zero
+    message = drive([], [
+                      { "type" => "message_start",
+                        "message" => { "usage" => { "input_tokens" => 1000,
+                                                    "cache_read_input_tokens" => 2000 } } },
+                      { "type" => "message_delta", "delta" => { "stop_reason" => "end_turn" },
+                        "usage" => { "output_tokens" => 500 } },
+                      { "type" => "message_stop" }
+                    ])
+    rates = Mistri::Models.rates("claude-opus-4-8")
+    expected = ((rates[:input] * 1000) + (rates[:cache_read] * 2000) +
+                (rates[:output] * 500)) / 1_000_000.0
+
+    assert_operator message.usage.cost.total, :>, 0
+    assert_in_delta expected, message.usage.cost.total,
+                    1e-9, "the delta's output count must be repriced, not left stale"
+
+    unknown = Mistri::Providers::Anthropic::Assembler.new(model: "claude-next-9000")
+    unknown.feed({ "type" => "message_start",
+                   "message" => { "usage" => { "input_tokens" => 1000 } } })
+    unknown.feed({ "type" => "message_stop" })
+
+    assert_in_delta 0.0, unknown.finish.usage.cost.total
+  end
+
   def test_a_provider_error_folds_with_its_status_and_body
     assembler = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")
     error = Mistri::ServerError.new(status: 503, body: "upstream connect timeout")

--- a/test/test_anthropic_live.rb
+++ b/test/test_anthropic_live.rb
@@ -22,6 +22,7 @@ class TestAnthropicLive < Minitest::Test
     assert_match(/mistri lives/i, message.text)
     assert events.any? { |e| e.type == :text_delta }, "expected streamed text deltas"
     assert_operator message.usage.output, :>, 0
+    assert_operator message.usage.cost.total, :>, 0, "catalog pricing must ride live usage"
   ensure
     provider&.close
   end

--- a/test/test_budget.rb
+++ b/test/test_budget.rb
@@ -15,8 +15,9 @@ class TestBudget < Minitest::Test
 
     assert_equal :turns, Mistri::Budget.new(turns: 3).exceeded(turns: 3, usage: usage)
     assert_equal :tokens, Mistri::Budget.new(tokens: 1000).exceeded(turns: 0, usage: usage)
+    assert_equal :cost, Mistri::Budget.new(cost_usd: 0.005).exceeded(turns: 0, usage: usage)
     assert_equal :wall_clock,
                  Mistri::Budget.new(wall_clock: 60).exceeded(turns: 0, usage: usage, elapsed: 61)
-    assert_nil Mistri::Budget.new(turns: 4).exceeded(turns: 3, usage: usage)
+    assert_nil Mistri::Budget.new(turns: 4, cost_usd: 0.006).exceeded(turns: 3, usage: usage)
   end
 end

--- a/test/test_gemini_assembler.rb
+++ b/test/test_gemini_assembler.rb
@@ -64,7 +64,7 @@ class TestGeminiAssembler < Minitest::Test
     assert_equal 500, failed.error["status"], "the wire code rides as a status"
   end
 
-  def test_usage_prices_from_the_catalog
+  def test_usage_prices_from_the_catalog_and_unknown_models_stay_zero
     message = drive([], [
                       { "candidates" => [{ "content" => { "parts" => [{ "text" => "hi" }] } }],
                         "usageMetadata" => { "promptTokenCount" => 1000,
@@ -79,6 +79,13 @@ class TestGeminiAssembler < Minitest::Test
 
     assert_operator message.usage.cost.total, :>, 0
     assert_in_delta expected, message.usage.cost.total, 1e-9
+
+    unknown = Mistri::Providers::Gemini::Assembler.new(model: "gemini-hypothetical")
+    unknown.feed({ "candidates" => [{ "finishReason" => "STOP" }],
+                   "usageMetadata" => { "promptTokenCount" => 1000,
+                                        "candidatesTokenCount" => 200 } })
+
+    assert_in_delta 0.0, unknown.finish.usage.cost.total
   end
 
   def test_a_stream_that_ends_without_a_finish_reason_is_an_error

--- a/test/test_gemini_assembler.rb
+++ b/test/test_gemini_assembler.rb
@@ -64,6 +64,23 @@ class TestGeminiAssembler < Minitest::Test
     assert_equal 500, failed.error["status"], "the wire code rides as a status"
   end
 
+  def test_usage_prices_from_the_catalog
+    message = drive([], [
+                      { "candidates" => [{ "content" => { "parts" => [{ "text" => "hi" }] } }],
+                        "usageMetadata" => { "promptTokenCount" => 1000,
+                                             "cachedContentTokenCount" => 400,
+                                             "candidatesTokenCount" => 100,
+                                             "thoughtsTokenCount" => 50 } },
+                      { "candidates" => [{ "finishReason" => "STOP" }] }
+                    ])
+    rates = Mistri::Models.rates("gemini-2.5-flash")
+    expected = ((rates[:input] * 600) + (rates[:cache_read] * 400) +
+                (rates[:output] * 150)) / 1_000_000.0
+
+    assert_operator message.usage.cost.total, :>, 0
+    assert_in_delta expected, message.usage.cost.total, 1e-9
+  end
+
   def test_a_stream_that_ends_without_a_finish_reason_is_an_error
     message = drive([], [
                       { "candidates" => [{ "content" => { "parts" => [{ "text" => "cut" }] } }] }

--- a/test/test_gemini_live.rb
+++ b/test/test_gemini_live.rb
@@ -22,6 +22,7 @@ class TestGeminiLive < Minitest::Test
     assert_match(/mistri lives/i, message.text)
     assert(events.any? { |e| e.type == :text_delta })
     assert_operator message.usage.output, :>, 0
+    assert_operator message.usage.cost.total, :>, 0, "catalog pricing must ride live usage"
   ensure
     provider&.close
   end

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -15,6 +15,19 @@ class TestModels < Minitest::Test
     assert_nil Mistri::Models.find("claude-next-9000")
   end
 
+  def test_catalogued_models_carry_their_published_rates
+    rates = Mistri::Models.rates("claude-opus-4-8")
+
+    assert_in_delta 5.0, rates[:input]
+    assert_in_delta 25.0, rates[:output]
+    assert_in_delta 0.5, rates[:cache_read]
+    assert_predicate rates, :frozen?
+
+    assert_nil Mistri::Models.rates("claude-next-9000"), "unknown models carry no rates"
+    assert(Mistri::Models::CATALOG.each_value.all?(&:rates),
+           "every catalogued model carries verified rates")
+  end
+
   def test_the_provider_sends_the_model_ceiling_as_max_tokens
     server = Mistri::Test::StubServer.new do |socket, _request|
       server.start_sse(socket)

--- a/test/test_openai_assembler.rb
+++ b/test/test_openai_assembler.rb
@@ -120,6 +120,24 @@ class TestOpenAIAssembler < Minitest::Test
     assert_equal "server exploded", failed.error_message
   end
 
+  def test_usage_prices_from_the_catalog
+    message = drive([], [
+                      { "type" => "response.completed",
+                        "response" => {
+                          "status" => "completed",
+                          "usage" => { "input_tokens" => 1000,
+                                       "input_tokens_details" => { "cached_tokens" => 400 },
+                                       "output_tokens" => 200 }
+                        } }
+                    ])
+    rates = Mistri::Models.rates("gpt-5.5")
+    expected = ((rates[:input] * 600) + (rates[:cache_read] * 400) +
+                (rates[:output] * 200)) / 1_000_000.0
+
+    assert_operator message.usage.cost.total, :>, 0
+    assert_in_delta expected, message.usage.cost.total, 1e-9
+  end
+
   def test_a_stream_that_ends_without_a_terminal_event_is_an_error
     message = drive([], [{ "type" => "response.output_text.delta", "delta" => "cut off" }])
 

--- a/test/test_openai_assembler.rb
+++ b/test/test_openai_assembler.rb
@@ -120,7 +120,7 @@ class TestOpenAIAssembler < Minitest::Test
     assert_equal "server exploded", failed.error_message
   end
 
-  def test_usage_prices_from_the_catalog
+  def test_usage_prices_from_the_catalog_and_unknown_models_stay_zero
     message = drive([], [
                       { "type" => "response.completed",
                         "response" => {
@@ -136,6 +136,14 @@ class TestOpenAIAssembler < Minitest::Test
 
     assert_operator message.usage.cost.total, :>, 0
     assert_in_delta expected, message.usage.cost.total, 1e-9
+
+    unknown = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-hypothetical")
+    unknown.feed({ "type" => "response.completed",
+                   "response" => { "status" => "completed",
+                                   "usage" => { "input_tokens" => 1000,
+                                                "output_tokens" => 200 } } })
+
+    assert_in_delta 0.0, unknown.finish.usage.cost.total
   end
 
   def test_a_stream_that_ends_without_a_terminal_event_is_an_error

--- a/test/test_openai_live.rb
+++ b/test/test_openai_live.rb
@@ -22,6 +22,7 @@ class TestOpenAILive < Minitest::Test
     assert_match(/mistri lives/i, message.text)
     assert(events.any? { |e| e.type == :text_delta })
     assert_operator message.usage.output, :>, 0
+    assert_operator message.usage.cost.total, :>, 0, "catalog pricing must ride live usage"
   ensure
     provider&.close
   end


### PR DESCRIPTION
## What and why

`Budget.new(cost_usd:)` has been a silent no-op since it shipped: the loop compares `usage.cost.total` against the ceiling, but nothing ever computed a cost. `Usage#with_cost` existed with no callers, the catalog carried no prices, and the assemblers left every turn at `Cost.zero`, so the ceiling compared against zero forever. None of the three provider APIs return a dollar cost on inference responses (verified on live calls: the usage objects carry token counts only), so client-side rates are the only way a mid-run budget can know what a run has spent.

This change feeds the design that was already there. The model catalog gains each model's published API price in USD per million tokens, sourced from the official pricing pages on 2026-07-08:

- Anthropic: https://platform.claude.com/docs/en/docs/about-claude/pricing
- OpenAI: https://developers.openai.com/api/docs/pricing (gpt-5-nano from its model page, absent from the main table)
- Gemini: https://ai.google.dev/gemini-api/docs/pricing

Each assembler resolves its model's rates once at construction and prices usage wherever it is assigned, so `message.usage.cost` and `Result#usage` report real dollars for catalogued models and the cost ceiling actually stops a run. Decisions worth knowing:

- An uncatalogued model reports zero cost and never trips `cost_usd`; the other ceilings still apply. Honest degradation over invented numbers, same philosophy as the catalog's other fields.
- `cache_write` in the rates is the 5-minute rate; the 1-hour slice bills at 2x input, which `Usage#with_cost` already applies on its own (verified against the published multipliers: 1.25x / 2x / 0.1x).
- Claude Sonnet 5 carries its introductory price with a dated comment naming the 2026-09-01 standard price.
- Long-context premium tiers (Gemini Pro and GPT past 200k input) are not modeled; those turns under-count. Flat rates match `with_cost`'s contract; tiering is a follow-up if it ever matters in practice.

Latency: rates resolve once per assembler construction (one hash lookup); pricing runs on usage records, which arrive at most a few times per turn, never on the delta path. No change to streaming reads.

## Testing

- `bundle exec rake test`: 419 runs, 0 failures (hermetic).
- `bundle exec rubocop`: clean.
- `COVERAGE=1 bundle exec rake test`: 95.6% line, above the 90% floor.
- `MISTRI_LIVE=1 bundle exec rake test`: 419 runs, 1500 assertions, 0 failures, 0 skips, including the full 14-model live matrix and new assertions that live usage carries a positive cost on all three providers.
- `bundle exec rake integration`: 51 runs, 279 assertions, 0 failures.
- Wire check: a raw probe of all three streaming APIs confirmed the usage objects carry token counts only (no cost field exists to pass through), which is why the rates live client-side.

New tests: the `:cost` budget reason, a loop-level `cost_usd` stop, per-assembler pricing against catalog rates (including Anthropic's message_delta repricing and the unknown-model zero path), catalog rate presence and frozenness, and live positive-cost assertions per provider.
