### PR TITLE
Classify failed OpenAI responses by their error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- OpenAI response.failed events classify by their error code instead of
+  all reading as a retryable truncated stream: rate limits and server
+  errors stay retryable, timeouts retry, and permanent rejections
+  (invalid_prompt, the image family) carry the new
+  Mistri::InvalidRequestError shape and fail fast, so the loop no longer
+  burns its retry budget on input the provider already ruled out. A
+  failed response without an error object now errors instead of reading
+  as a clean stop.
 - The model catalog carries each model's published API prices, and the
   assemblers price every turn's usage from them: message.usage.cost and
   Result#usage now report real dollars for catalogued models, and the

--- a/lib/mistri/errors.rb
+++ b/lib/mistri/errors.rb
@@ -57,6 +57,12 @@ module Mistri
     def self.default_message = "provider server error"
   end
 
+  # The provider rejected the request itself: an invalid prompt, a bad
+  # image, a policy violation. Never retried; the same input cannot succeed.
+  class InvalidRequestError < ProviderError
+    def self.default_message = "provider rejected the request"
+  end
+
   # Tool arguments or structured output that violate their declared schema.
   class SchemaError < Error; end
 

--- a/lib/mistri/providers/openai/assembler.rb
+++ b/lib/mistri/providers/openai/assembler.rb
@@ -161,9 +161,27 @@ module Mistri
         def finish_response(response)
           @status = response["status"] || "completed"
           @incomplete_reason = response.dig("incomplete_details", "reason")
-          @error = response.dig("error", "message") if @status == "failed"
+          @error = failure_error(response["error"]) if @status == "failed"
           usage = response["usage"]
           @usage = priced(parse_usage(usage)) if usage
+        end
+
+        # A failed response is the provider's verdict on this input, not a
+        # transport accident: only its documented transient codes retry
+        # (rate limits, server errors, timeouts). Everything else, like
+        # invalid_prompt and the image family, cannot succeed on a retry.
+        def failure_error(error)
+          return ProviderError.new("the response failed without an error") unless error
+
+          code = error["code"].to_s
+          message = [code, error["message"] || "the response failed"]
+                    .reject(&:empty?).join(": ")
+          klass = if code.include?("rate_limit") then RateLimitError
+                  elsif code.include?("server") then ServerError
+                  elsif code.include?("timeout") then ProviderError
+                  else InvalidRequestError
+                  end
+          klass.new(message)
         end
 
         def stop_reason

--- a/test/test_errors.rb
+++ b/test/test_errors.rb
@@ -6,7 +6,8 @@ class TestErrors < Minitest::Test
   def test_every_error_rescues_as_mistri_error
     [Mistri::ConfigurationError, Mistri::ProviderError, Mistri::AuthenticationError,
      Mistri::RateLimitError, Mistri::OverloadedError, Mistri::ServerError,
-     Mistri::SchemaError, Mistri::AbortError, Mistri::BudgetError].each do |klass|
+     Mistri::InvalidRequestError, Mistri::SchemaError, Mistri::AbortError,
+     Mistri::BudgetError].each do |klass|
       assert_operator klass, :<, Mistri::Error
     end
   end

--- a/test/test_openai_assembler.rb
+++ b/test/test_openai_assembler.rb
@@ -117,7 +117,39 @@ class TestOpenAIAssembler < Minitest::Test
                    ])
 
     assert_equal :error, failed.stop_reason
-    assert_equal "server exploded", failed.error_message
+    assert_match(/server exploded/, failed.error_message)
+  end
+
+  # A failed response is the provider's verdict, not a dropped stream: its
+  # code decides retryability, and it must never read as TruncatedStream.
+  def test_failed_responses_classify_by_their_error_code
+    { "rate_limit_exceeded" => "RateLimitError",
+      "server_error" => "ServerError",
+      "vector_store_timeout" => "ProviderError",
+      "invalid_prompt" => "InvalidRequestError",
+      "image_content_policy_violation" => "InvalidRequestError" }.each do |code, type|
+      failed = drive([], [
+                       { "type" => "response.failed",
+                         "response" => { "status" => "failed",
+                                         "error" => { "code" => code, "message" => "no" } } }
+                     ])
+
+      assert_equal :error, failed.stop_reason
+      assert_equal type, failed.error["type"], "#{code} misclassified"
+      assert_includes failed.error_message, code
+    end
+
+    bare = drive([], [{ "type" => "response.failed",
+                        "response" => { "status" => "failed" } }])
+
+    assert_equal :error, bare.stop_reason, "failure without an error object is not a clean stop"
+    assert_equal "ProviderError", bare.error["type"]
+
+    terse = drive([], [{ "type" => "response.failed",
+                         "response" => { "status" => "failed",
+                                         "error" => { "code" => "invalid_prompt" } } }])
+
+    assert_includes terse.error_message, "the response failed"
   end
 
   def test_usage_prices_from_the_catalog_and_unknown_models_stay_zero

--- a/test/test_retry_policy.rb
+++ b/test/test_retry_policy.rb
@@ -18,7 +18,7 @@ class TestRetryPolicy < Minitest::Test
     %w[ProviderError RateLimitError OverloadedError ServerError TruncatedStream].each do |type|
       assert policy.retryable?({ "type" => type })
     end
-    %w[SchemaError RuntimeError Error NoMethodError].each do |type|
+    %w[SchemaError RuntimeError Error NoMethodError InvalidRequestError].each do |type|
       refute policy.retryable?({ "type" => type })
     end
     refute policy.retryable?(nil)


### PR DESCRIPTION
## What and why

A streamed `response.failed` from OpenAI stored its failure as a bare String, and `ErrorData.for` maps any string to `{"type" => "TruncatedStream"}`, which is retryable. So a response the provider had already ruled out (an invalid prompt, a bad image) retried through the whole backoff schedule before surfacing, and the persisted error type lied to hosts about what happened. A failed status with no error object was worse: `@error` stayed nil and the turn read as a clean stop.

Now the failure classifies by its documented error code (the enum from OpenAI's own SDK: `server_error`, `rate_limit_exceeded`, `invalid_prompt`, `vector_store_timeout`, and the image family). Rate limits and server errors keep their retryable classes, timeouts retry as `ProviderError` (matching the policy's stance that timeouts are transient), and everything else carries the new `Mistri::InvalidRequestError`, a `ProviderError` subclass that is not in `RETRYABLE_TYPES`, so the same input is never resent. The distinction matters because a bare statusless `ProviderError` is deliberately retryable (that is how transport drops retry); a failed response is the provider's verdict on this input, not a transport accident, so it needs its own non-retryable shape. A failed response without an error object now errors as `ProviderError` ("the response failed without an error") instead of masquerading as success.

The in-stream `error` event path (`wire_error`) keeps its retry-friendly default: an ambient stream error of unknown code is transport-grade ambiguity, while `response.failed` is a completed verdict. Error-path only; no change to streaming reads or the hot path.

## Testing

- `bundle exec rake test`: 420 runs, 0 failures. New tests map each documented code family to its class through the assembler, pin `InvalidRequestError` as non-retryable in the policy, cover failure-without-an-error and code-without-a-message, and register the new class in the error-hierarchy test.
- `bundle exec rubocop`: clean. `COVERAGE=1`: 95.66% line.
- `MISTRI_LIVE=1 bundle exec rake test`: 420 runs, 1530 assertions, 0 failures, 0 skips.
- `bundle exec rake integration`: 51 runs, 279 assertions, 0 failures (a first pass had one unrelated live-model flake in a scenario assertion; rerun clean).
- Live probe: a deliberately broken base64 image is rejected synchronously with HTTP 400 and already fails fast via its status, which confirms the streamed `response.failed` path (mid-generation verdicts) is the one that needed this fix; it cannot be provoked innocuously on demand, so it is verified hermetically against the documented wire shape.
