### PR TITLE
Make the coalescer origin-aware and thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Sinks::Coalesced is origin-aware and thread-safe: a background worker's
+  deltas no longer merge into the parent's (or another worker's) event at
+  the same content index, and concurrent emitters serialize on an
+  internal mutex instead of racing the buffer. One uncontended mutex
+  acquire per event, at coalesced rate; nothing changes on the token
+  path.
 - OpenAI response.failed events classify by their error code instead of
   all reading as a retryable truncated stream: rate limits and server
   errors stay retryable, timeouts retry, and permanent rejections

--- a/lib/mistri/dispatchers.rb
+++ b/lib/mistri/dispatchers.rb
@@ -16,7 +16,9 @@ module Mistri
   # The runner closes over the spawn-time event sink, so in-process
   # children keep streaming to whoever watched the spawn; that sink must
   # outlive the parent's turn (a broadcast lambda does, a request-scoped
-  # object may not).
+  # object may not) and hears from the worker's thread, concurrently with
+  # the parent's own events. The gem's sinks tolerate that; a custom one
+  # must too.
   module Dispatchers
     # Runs the child synchronously inside the spawn call and still answers
     # in receipt form: background degrades gracefully where no concurrency

--- a/lib/mistri/sinks/coalesced.rb
+++ b/lib/mistri/sinks/coalesced.rb
@@ -4,8 +4,10 @@ module Mistri
   module Sinks
     # Wraps any sink and merges bursts of streaming deltas, so a transport
     # broadcasts at UI speed instead of token speed. Deltas buffer per
-    # content block and flush merged when the interval elapses or any other
-    # event arrives, so ordering is preserved and a turn always ends flushed.
+    # content block per origin and flush merged when the interval elapses or
+    # any other event arrives, so ordering is preserved and a turn always
+    # ends flushed. Safe to share across threads: a background worker's
+    # events serialize with the parent's instead of racing the buffer.
     #
     #   sink = Mistri::Sinks::Coalesced.new(
     #     Mistri::Sinks::ActionCable.new("agent_1"), interval: 0.1,
@@ -18,16 +20,19 @@ module Mistri
         @interval = interval
         @buffer = nil
         @flushed_at = now
+        @mutex = Mutex.new
       end
 
       def call(event)
-        unless DELTAS.include?(event.type)
-          flush
-          return @sink.call(event)
+        @mutex.synchronize do
+          if DELTAS.include?(event.type)
+            merge(event)
+            flush if now - @flushed_at >= @interval
+          else
+            flush
+            @sink.call(event)
+          end
         end
-
-        merge(event)
-        flush if now - @flushed_at >= @interval
       end
 
       def to_proc = method(:call).to_proc
@@ -35,10 +40,12 @@ module Mistri
       private
 
       # Merged deltas keep the newest partial, so a consumer that renders
-      # snapshots always renders the latest one.
+      # snapshots always renders the latest one. Origin is part of a block's
+      # identity: two agents' lanes never fold into one event.
       def merge(event)
         same = @buffer && @buffer.type == event.type &&
-               @buffer.content_index == event.content_index
+               @buffer.content_index == event.content_index &&
+               @buffer.origin == event.origin
         flush if @buffer && !same
         @buffer = if same
                     @buffer.with(delta: @buffer.delta.to_s + event.delta.to_s,

--- a/test/test_sinks.rb
+++ b/test/test_sinks.rb
@@ -6,8 +6,8 @@ require "stringio"
 # Sinks bridge the event stream to a transport: SSE frames, Action Cable
 # broadcasts, and a coalescer that merges delta bursts to UI speed.
 class TestSinks < Minitest::Test
-  def delta(text, index: 0)
-    Mistri::Event.new(type: :text_delta, content_index: index, delta: text)
+  def delta(text, index: 0, origin: nil)
+    Mistri::Event.new(type: :text_delta, content_index: index, delta: text, origin: origin)
   end
 
   def test_coalesced_merges_a_burst_into_one_delta
@@ -44,6 +44,47 @@ class TestSinks < Minitest::Test
 
     assert_equal %i[start text_delta tool_result], seen.map(&:type),
                  "the buffered delta flushes before the next non-delta event"
+  end
+
+  def test_coalesced_never_merges_across_origins
+    seen = []
+    sink = Mistri::Sinks::Coalesced.new(->(event) { seen << event }, interval: 60)
+
+    sink.call(delta("parent says "))
+    sink.call(delta("child says ", origin: "Corgi#ab12cd34"))
+    sink.call(delta("hello", origin: "Corgi#ab12cd34"))
+    sink.call(Mistri::Event.new(type: :done, reason: :stop))
+
+    deltas = seen.select { |event| event.type == :text_delta }
+
+    assert_equal ["parent says ", "child says hello"], deltas.map(&:delta),
+                 "a lane keeps its own bytes even at the same content index"
+    assert_equal [nil, "Corgi#ab12cd34"], deltas.map(&:origin)
+  end
+
+  # A background worker emits from its own thread while the parent streams;
+  # the coalescer must serialize them. Exact chunking is timing-dependent,
+  # so the assertions are the invariants: every lane's bytes arrive intact,
+  # in order, and never inside another lane's event.
+  def test_coalesced_is_safe_under_concurrent_emitters
+    seen = []
+    sink = Mistri::Sinks::Coalesced.new(->(event) { seen << event }, interval: 60)
+    lanes = { nil => "the parent narrates its own turn",
+              "Corgi#1" => "corgi reports pricing findings",
+              "Husky#2" => "husky reports founder findings" }
+
+    lanes.map do |origin, text|
+      Thread.new { text.chars.each { |char| sink.call(delta(char, origin: origin)) } }
+    end.each(&:join)
+    sink.call(Mistri::Event.new(type: :done, reason: :stop))
+
+    lanes.each do |origin, text|
+      arrived = seen.select { |e| e.type == :text_delta && e.origin == origin }
+                    .map(&:delta).join
+
+      assert_equal text, arrived, "lane #{origin.inspect} lost or mixed bytes"
+    end
+    assert_equal :done, seen.last.type, "the terminal still flushes and forwards last"
   end
 
   def test_coalesced_with_zero_interval_flushes_every_delta


### PR DESCRIPTION
## What and why

`Sinks::Coalesced` merged deltas by event type and content index but not origin, so a background worker streaming at content index 0 could fold its bytes into the parent's buffered delta at index 0 (or another worker's): one event carrying two agents' words, attributed to whichever lane got there first. The buffer was also plain mutable state with no synchronization, while `Dispatchers::Thread` workers emit from their own threads concurrently with the parent loop's events, so the merge itself raced.

Two moves fix both. Origin joins a block's identity in the merge check, so lanes never fold together; and a mutex serializes `call`, flush-and-forward included, so ordering holds across threads. The dispatcher's sink contract comment now states the cross-thread reality for custom sinks.

Latency: one uncontended mutex acquire per event (tens of nanoseconds on MRI), at the coalesced event rate, not token rate; no allocation added; the mutex only contends when multiple agents genuinely emit at once, which previously corrupted the buffer instead of waiting. Nothing changes on the streaming read path. The one observable behavior change is the bug itself: cross-origin deltas now arrive as separate, correctly attributed events.

## Testing

- `bundle exec rake test`: 422 runs, 0 failures. `bundle exec rubocop`: clean. `COVERAGE=1`: 95.66% line.
- New tests: a deterministic proof that same-index deltas from different origins never merge, and a concurrent-emitters test (three threads, three lanes) asserting the invariants that are stable under scheduling: every lane's bytes arrive intact, in order, never inside another lane's event, and the terminal still flushes last. Stable across five consecutive runs.
- Test-the-test: both new tests fail against main's coalescer and pass with this change.
- Live and integration suites are not run for this PR: no provider path is touched, and nothing in them exercises Coalesced; the concurrency tests here are the end-to-end evidence for this class.
