### PR TITLE
Surface refusals and content-filter stops honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Refusals and content-filter stops surface honestly on every provider
   instead of reading as clean stops or retryable truncations. Gemini's
   verdict finish reasons (SAFETY, RECITATION, LANGUAGE, BLOCKLIST,
-  PROHIBITED_CONTENT, SPII, the image family, OTHER) and blocked prompts
+  PROHIBITED_CONTENT, SPII, the image verdicts) and blocked prompts
   (promptFeedback.blockReason, which previously read as a retryable
   truncated stream) fail fast as Mistri::InvalidRequestError with the
-  wire word in the message; its model fumbles (MALFORMED_FUNCTION_CALL,
-  UNEXPECTED_TOOL_CALL, NO_IMAGE) error retryably. Anthropic's refusal
+  wire word in the message; its model fumbles and unknown stops
+  (MALFORMED_FUNCTION_CALL, UNEXPECTED_TOOL_CALL, TOO_MANY_TOOL_CALLS,
+  NO_IMAGE, and the catch-all OTHER pair, documented as unknown reasons
+  rather than rulings) error retryably. Anthropic's refusal
   stop reason fails fast carrying stop_details' category and explanation
   (the API's guidance is a different model, never a same-model retry),
   and model_context_window_exceeded maps to :length per its guidance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Refusals and content-filter stops surface honestly on every provider
+  instead of reading as clean stops or retryable truncations. Gemini's
+  verdict finish reasons (SAFETY, RECITATION, LANGUAGE, BLOCKLIST,
+  PROHIBITED_CONTENT, SPII, the image family, OTHER) and blocked prompts
+  (promptFeedback.blockReason, which previously read as a retryable
+  truncated stream) fail fast as Mistri::InvalidRequestError with the
+  wire word in the message; its model fumbles (MALFORMED_FUNCTION_CALL,
+  UNEXPECTED_TOOL_CALL, NO_IMAGE) error retryably. Anthropic's refusal
+  stop reason fails fast carrying stop_details' category and explanation
+  (the API's guidance is a different model, never a same-model retry),
+  and model_context_window_exceeded maps to :length per its guidance.
+  OpenAI's incomplete_details content_filter fails fast instead of
+  reading as a completed answer. Partial content stays on the errored
+  message for hosts to show. Undocumented future stop reasons still
+  tolerate as clean stops, unchanged.
 - Sinks::Coalesced is origin-aware and thread-safe: a background worker's
   deltas no longer merge into the parent's (or another worker's) event at
   the same content index, and concurrent emitters serialize on an

--- a/lib/mistri/providers/anthropic/assembler.rb
+++ b/lib/mistri/providers/anthropic/assembler.rb
@@ -39,6 +39,7 @@ module Mistri
         # reading as a cancellation.
         def finish(&emit)
           return fail_stream(@error, &emit) if @error
+          return fail_stream(refusal_error, &emit) if @refused
           return fail_stream("stream ended without message_stop", &emit) unless @done
 
           @message = assemble(stop_reason: @stop_reason || StopReason::STOP)
@@ -136,6 +137,10 @@ module Mistri
         def message_delta(record)
           reason = record.dig("delta", "stop_reason")
           @stop_reason = map_stop_reason(reason) if reason
+          if reason == "refusal"
+            @refused = true
+            @refusal = record.dig("delta", "stop_details")
+          end
           # message_delta usage is cumulative; merge output counts over the
           # opening snapshot rather than summing.
           output = record.dig("usage", "output_tokens")
@@ -183,12 +188,24 @@ module Mistri
                             usage: @usage, **meta)
         end
 
-        # pause_turn (a server tool paused a long turn) maps to tool_use so the
-        # loop continues the turn rather than ending it.
+        # pause_turn (a server tool paused a long turn) maps to tool_use so
+        # the loop continues the turn rather than ending it; a filled context
+        # window is a truncation, per the API's own guidance.
         def map_stop_reason(reason)
           { "end_turn" => StopReason::STOP, "stop_sequence" => StopReason::STOP,
             "max_tokens" => StopReason::LENGTH, "tool_use" => StopReason::TOOL_USE,
+            "model_context_window_exceeded" => StopReason::LENGTH,
             "pause_turn" => StopReason::TOOL_USE }.fetch(reason, StopReason::STOP)
+        end
+
+        # The API's guidance for a refusal is a different model, never a
+        # retry of this one, so it fails fast; stop_details names the policy
+        # category when the API provides one.
+        def refusal_error
+          details = [@refusal&.dig("category"), @refusal&.dig("explanation")].compact.join(": ")
+          text = +"the model refused to respond"
+          text << " (#{details})" unless details.empty?
+          InvalidRequestError.new(text)
         end
 
         def parse_usage(raw)

--- a/lib/mistri/providers/gemini/assembler.rb
+++ b/lib/mistri/providers/gemini/assembler.rb
@@ -22,6 +22,17 @@ module Mistri
           @finish_reason = nil
         end
 
+        # Finish reasons that are the provider's verdict on the content
+        # itself: a retry of the same input meets the same filter, and a
+        # harness that re-rolls against a policy verdict is machinery for
+        # evading it, so these fail fast.
+        VERDICTS = %w[SAFETY RECITATION LANGUAGE BLOCKLIST PROHIBITED_CONTENT SPII
+                      IMAGE_SAFETY IMAGE_PROHIBITED_CONTENT IMAGE_RECITATION
+                      OTHER IMAGE_OTHER].freeze
+        # The model fumbled its own output (an invalid function call, a
+        # missing image): the input is fine and a regeneration usually lands.
+        FUMBLES = %w[MALFORMED_FUNCTION_CALL UNEXPECTED_TOOL_CALL NO_IMAGE].freeze
+
         def feed(record, &)
           if (error = record["error"])
             @error = ProviderError.new(error["message"] || "provider error",
@@ -29,6 +40,8 @@ module Mistri
             return
           end
 
+          block = record.dig("promptFeedback", "blockReason").to_s
+          @block_reason = block unless block.empty? || block == "BLOCK_REASON_UNSPECIFIED"
           candidate = record.dig("candidates", 0) || {}
           Array(candidate.dig("content", "parts")).each { |part| fold_part(part, &) }
           @finish_reason = candidate["finishReason"] if candidate["finishReason"]
@@ -39,6 +52,9 @@ module Mistri
         # cancelled: fail it so the loop can treat it as retryable.
         def finish(&emit)
           return fail_stream(@error, &emit) if @error
+          if (refused = blocked)
+            return fail_stream(refused, &emit)
+          end
           return fail_stream("stream ended without a finish reason", &emit) unless @finish_reason
 
           close_current(&emit)
@@ -123,6 +139,23 @@ module Mistri
           else
             Content::Thinking.new(thinking: @current.text, signature: @current.signature)
           end
+        end
+
+        # A blocked prompt arrives as promptFeedback with no candidates; a
+        # blocked candidate arrives as a verdict finishReason. Either way the
+        # error carries the wire word, so hosts tell SAFETY from RECITATION
+        # without parsing prose.
+        def blocked
+          if @block_reason
+            return InvalidRequestError.new("the prompt was blocked: #{@block_reason}")
+          end
+          return unless @finish_reason
+          if VERDICTS.include?(@finish_reason)
+            return InvalidRequestError.new("generation stopped: #{@finish_reason}")
+          end
+          return unless FUMBLES.include?(@finish_reason)
+
+          ProviderError.new("generation stopped: #{@finish_reason}")
         end
 
         def stop_reason

--- a/lib/mistri/providers/gemini/assembler.rb
+++ b/lib/mistri/providers/gemini/assembler.rb
@@ -27,11 +27,13 @@ module Mistri
         # harness that re-rolls against a policy verdict is machinery for
         # evading it, so these fail fast.
         VERDICTS = %w[SAFETY RECITATION LANGUAGE BLOCKLIST PROHIBITED_CONTENT SPII
-                      IMAGE_SAFETY IMAGE_PROHIBITED_CONTENT IMAGE_RECITATION
-                      OTHER IMAGE_OTHER].freeze
-        # The model fumbled its own output (an invalid function call, a
-        # missing image): the input is fine and a regeneration usually lands.
-        FUMBLES = %w[MALFORMED_FUNCTION_CALL UNEXPECTED_TOOL_CALL NO_IMAGE].freeze
+                      IMAGE_SAFETY IMAGE_PROHIBITED_CONTENT IMAGE_RECITATION].freeze
+        # The model fumbled its own output (an invalid or runaway tool call,
+        # a missing image), or the API stopped for a reason it cannot name
+        # (OTHER is documented as "Unknown reason"). The input stands accused
+        # of nothing, so these error retryably; a regeneration usually lands.
+        FUMBLES = %w[MALFORMED_FUNCTION_CALL UNEXPECTED_TOOL_CALL TOO_MANY_TOOL_CALLS
+                     NO_IMAGE OTHER IMAGE_OTHER].freeze
 
         def feed(record, &)
           if (error = record["error"])

--- a/lib/mistri/providers/openai/assembler.rb
+++ b/lib/mistri/providers/openai/assembler.rb
@@ -40,6 +40,7 @@ module Mistri
         # not cancelled: fail it so the loop can treat it as retryable.
         def finish(&emit)
           return fail_stream(@error, &emit) if @error
+          return fail_stream(filter_error, &emit) if @incomplete_reason == "content_filter"
           return fail_stream("stream ended without a terminal event", &emit) unless @status
 
           @message = assemble(stop_reason: stop_reason)
@@ -190,6 +191,11 @@ module Mistri
 
           StopReason::STOP
         end
+
+        # The spec's only other incomplete reason: a filter cut is a verdict
+        # on the content, not a truncation, so it never reads as a clean stop
+        # and never retries.
+        def filter_error = InvalidRequestError.new("the response was cut by the content filter")
 
         def terminal(reason, text, error: nil, &emit)
           @message = assemble(stop_reason: reason, error_message: text, error: error)

--- a/test/test_anthropic_assembler.rb
+++ b/test/test_anthropic_assembler.rb
@@ -114,6 +114,54 @@ class TestAnthropicAssembler < Minitest::Test
     assert_in_delta 0.0, unknown.finish.usage.cost.total
   end
 
+  # The API's own guidance for a refusal is a different model, never a
+  # retry of this one; the machine-readable type keeps the loop from
+  # re-rolling against a policy verdict.
+  def test_a_refusal_fails_fast_with_its_policy_category
+    events = []
+    message = drive(events, [
+                      { "type" => "content_block_start", "index" => 0,
+                        "content_block" => { "type" => "text" } },
+                      { "type" => "content_block_delta", "index" => 0,
+                        "delta" => { "type" => "text_delta", "text" => "I can" } },
+                      { "type" => "content_block_stop", "index" => 0 },
+                      { "type" => "message_delta",
+                        "delta" => { "stop_reason" => "refusal",
+                                     "stop_details" => { "category" => "harmful_content",
+                                                         "explanation" => "Declined." } },
+                        "usage" => { "output_tokens" => 2 } },
+                      { "type" => "message_stop" }
+                    ])
+
+    assert_equal :error, message.stop_reason
+    assert_equal "InvalidRequestError", message.error["type"]
+    assert_includes message.error_message, "harmful_content"
+    assert_includes message.error_message, "Declined."
+    assert_equal "I can", message.text, "partial content stays readable for the host"
+    refute Mistri::RetryPolicy.new.retryable?(message.error)
+    assert_predicate events.last, :error?
+
+    bare = drive([], [
+                   { "type" => "message_delta", "delta" => { "stop_reason" => "refusal" },
+                     "usage" => {} },
+                   { "type" => "message_stop" }
+                 ])
+
+    assert_match(/refused to respond/, bare.error_message,
+                 "a refusal without stop_details still reads as a refusal")
+  end
+
+  def test_a_filled_context_window_reads_as_length
+    message = drive([], [
+                      { "type" => "message_delta",
+                        "delta" => { "stop_reason" => "model_context_window_exceeded" },
+                        "usage" => { "output_tokens" => 9 } },
+                      { "type" => "message_stop" }
+                    ])
+
+    assert_equal :length, message.stop_reason, "the API says treat the response as truncated"
+  end
+
   def test_a_provider_error_folds_with_its_status_and_body
     assembler = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")
     error = Mistri::ServerError.new(status: 503, body: "upstream connect timeout")

--- a/test/test_gemini_assembler.rb
+++ b/test/test_gemini_assembler.rb
@@ -88,6 +88,58 @@ class TestGeminiAssembler < Minitest::Test
     assert_in_delta 0.0, unknown.finish.usage.cost.total
   end
 
+  # Verdict finish reasons are the provider's ruling on the content; the
+  # loop must fail fast instead of re-rolling against the filter. Fumbles
+  # (the model botched its own output) stay retryable.
+  def test_blocked_finish_reasons_classify_as_verdicts_or_fumbles
+    policy = Mistri::RetryPolicy.new
+    %w[SAFETY RECITATION LANGUAGE BLOCKLIST PROHIBITED_CONTENT SPII OTHER].each do |reason|
+      message = drive([], [
+                        { "candidates" => [{ "content" => { "parts" => [{ "text" => "par" }] } }] },
+                        { "candidates" => [{ "finishReason" => reason }] }
+                      ])
+
+      assert_equal :error, message.stop_reason, "#{reason} must not read as a clean stop"
+      assert_equal "InvalidRequestError", message.error["type"], "#{reason} misclassified"
+      assert_includes message.error_message, reason
+      assert_equal "par", message.text, "partial content stays readable for the host"
+      refute policy.retryable?(message.error), "#{reason} is a verdict, never retried"
+    end
+
+    fumble = drive([], [{ "candidates" => [{ "finishReason" => "MALFORMED_FUNCTION_CALL" }] }])
+
+    assert_equal :error, fumble.stop_reason
+    assert_equal "ProviderError", fumble.error["type"]
+    assert policy.retryable?(fumble.error), "a fumbled function call retries"
+  end
+
+  def test_a_blocked_prompt_fails_fast_instead_of_reading_as_truncation
+    message = drive([], [{ "promptFeedback" => { "blockReason" => "SAFETY" } }])
+
+    assert_equal :error, message.stop_reason
+    assert_equal "InvalidRequestError", message.error["type"]
+    assert_includes message.error_message, "SAFETY"
+    refute Mistri::RetryPolicy.new.retryable?(message.error),
+           "a blocked prompt meets the same filter on every retry"
+
+    unspecified = drive([], [
+                          { "candidates" => [{ "content" => { "parts" => [{ "text" => "hi" }] } }],
+                            "promptFeedback" => { "blockReason" => "BLOCK_REASON_UNSPECIFIED" } },
+                          { "candidates" => [{ "finishReason" => "STOP" }] }
+                        ])
+
+    assert_equal :stop, unspecified.stop_reason, "the unused default value is not a block"
+  end
+
+  def test_an_undocumented_finish_reason_still_reads_as_stop
+    message = drive([], [
+                      { "candidates" => [{ "content" => { "parts" => [{ "text" => "hi" }] } }] },
+                      { "candidates" => [{ "finishReason" => "SOME_FUTURE_REASON" }] }
+                    ])
+
+    assert_equal :stop, message.stop_reason, "unknown wire values stay tolerated by contract"
+  end
+
   def test_a_stream_that_ends_without_a_finish_reason_is_an_error
     message = drive([], [
                       { "candidates" => [{ "content" => { "parts" => [{ "text" => "cut" }] } }] }

--- a/test/test_gemini_assembler.rb
+++ b/test/test_gemini_assembler.rb
@@ -90,10 +90,11 @@ class TestGeminiAssembler < Minitest::Test
 
   # Verdict finish reasons are the provider's ruling on the content; the
   # loop must fail fast instead of re-rolling against the filter. Fumbles
-  # (the model botched its own output) stay retryable.
+  # and unknown stops (OTHER is documented as "Unknown reason") accuse the
+  # input of nothing, so they error retryably instead.
   def test_blocked_finish_reasons_classify_as_verdicts_or_fumbles
     policy = Mistri::RetryPolicy.new
-    %w[SAFETY RECITATION LANGUAGE BLOCKLIST PROHIBITED_CONTENT SPII OTHER].each do |reason|
+    %w[SAFETY RECITATION LANGUAGE BLOCKLIST PROHIBITED_CONTENT SPII IMAGE_SAFETY].each do |reason|
       message = drive([], [
                         { "candidates" => [{ "content" => { "parts" => [{ "text" => "par" }] } }] },
                         { "candidates" => [{ "finishReason" => reason }] }
@@ -106,11 +107,13 @@ class TestGeminiAssembler < Minitest::Test
       refute policy.retryable?(message.error), "#{reason} is a verdict, never retried"
     end
 
-    fumble = drive([], [{ "candidates" => [{ "finishReason" => "MALFORMED_FUNCTION_CALL" }] }])
+    %w[MALFORMED_FUNCTION_CALL TOO_MANY_TOOL_CALLS OTHER].each do |reason|
+      fumble = drive([], [{ "candidates" => [{ "finishReason" => reason }] }])
 
-    assert_equal :error, fumble.stop_reason
-    assert_equal "ProviderError", fumble.error["type"]
-    assert policy.retryable?(fumble.error), "a fumbled function call retries"
+      assert_equal :error, fumble.stop_reason, "#{reason} must not read as a clean stop"
+      assert_equal "ProviderError", fumble.error["type"], "#{reason} misclassified"
+      assert policy.retryable?(fumble.error), "#{reason} accuses the input of nothing"
+    end
   end
 
   def test_a_blocked_prompt_fails_fast_instead_of_reading_as_truncation

--- a/test/test_openai_assembler.rb
+++ b/test/test_openai_assembler.rb
@@ -99,6 +99,21 @@ class TestOpenAIAssembler < Minitest::Test
     assert_equal({ "q" => "ru" }, mid.arguments)
   end
 
+  def test_a_content_filter_cut_fails_fast_instead_of_reading_complete
+    message = drive([], [
+                      { "type" => "response.incomplete",
+                        "response" => {
+                          "status" => "incomplete",
+                          "incomplete_details" => { "reason" => "content_filter" }
+                        } }
+                    ])
+
+    assert_equal :error, message.stop_reason
+    assert_equal "InvalidRequestError", message.error["type"]
+    refute Mistri::RetryPolicy.new.retryable?(message.error),
+           "a filter verdict is not a truncation"
+  end
+
   def test_incomplete_and_failed_responses_map_to_stop_reasons
     incomplete = drive([], [
                          { "type" => "response.incomplete",


### PR DESCRIPTION
## What and why

Provider refusals and content filters were invisible to the loop on all three providers, each in its own way, and every path either lied about success or burned the retry budget against a verdict that cannot change.

Gemini was the worst. A verdict finishReason (SAFETY, RECITATION, LANGUAGE, BLOCKLIST, PROHIBITED_CONTENT, SPII, the image family, OTHER) read as a clean `:stop`; since the API sends an empty candidate when filters block output, the turn then tripped the EmptyCompletion retry loop, re-rolled against the same filter, and finally returned completed-with-empty-text. A blocked prompt (`promptFeedback.blockReason`, no candidates, no finish reason at all) classified as a retryable truncated stream. Anthropic's `refusal` stop reason read as a clean stop, and `model_context_window_exceeded` read as a clean stop when the API's guidance is "treat the response as truncated". OpenAI's `incomplete_details.reason: "content_filter"` read as a completed answer.

One design across all three now. Verdicts on the content fail fast as `Mistri::InvalidRequestError` with the wire word in the message, because a retry of the same input meets the same filter, and a harness that re-rolls against a policy verdict is machinery for evading it; Anthropic's own refusal guidance agrees, prescribing a different model rather than a retry, so the error carries `stop_details`' category and explanation for the host that implements that fallback. Model fumbles (Gemini's MALFORMED_FUNCTION_CALL, UNEXPECTED_TOOL_CALL, NO_IMAGE) error retryably: the input is fine and a regeneration usually lands. Truncations map to `:length`. Partial content stays on the errored message for hosts to show. Undocumented future stop reasons keep tolerating as clean stops, the same forward-compatibility contract as before; Anthropic's `compaction` stop reason (a server-side beta the gem never requests) is deliberately left on that default.

Sources, all fetched during this change: Gemini's FinishReason enum from googleapis/python-genai and BlockReason from ai.google.dev; Anthropic's stop reason list and refusal guidance from platform.claude.com (handling-stop-reasons) and `stop_details` shape from anthropics/anthropic-sdk-ruby; OpenAI's `incomplete_details.reason` enum (`max_output_tokens`, `content_filter`, nothing else) from openai/openai-openapi.

Error-path only; nothing changes on streaming reads or clean turns.

## Testing

- `bundle exec rake test`: 429 runs, 0 failures. New tests: the Gemini verdict matrix with retryability pins and partial-content preservation, the fumble-retries case, blocked and unspecified promptFeedback, the undocumented-reason forward-compat pin, Anthropic refusal with and without stop_details plus the context-window-exceeded mapping, and the OpenAI content_filter cut.
- `bundle exec rubocop`: clean. `COVERAGE=1`: 95.7% line.
- `MISTRI_LIVE=1 bundle exec rake test`: 428 runs, 1603 assertions, 0 failures, 0 skips across all three providers.
- `bundle exec rake integration`: Anthropic and Gemini legs green (34 runs; one Gemini scenario flaked once per run on instruction-following, a different scenario each time, and both pass a targeted rerun). The OpenAI leg aborted mid-run: the account exhausted its quota, and every failure is `insufficient_quota`. That failure is itself live evidence for this PR family: `insufficient_quota` is a real `response.failed` code absent from the documented enum, and the unknown-code default from #23 correctly failed fast instead of retrying a drained account. The OpenAI integration leg should be rerun once the account is topped up.
- Safety-block provocation was attempted live with `safetySettings` at BLOCK_LOW_AND_ABOVE on innocuous content (an action-movie fight line, a cartoon taunt); Gemini's filters, reasonably, did not trip, so the block shapes are verified against the documented contract rather than a live capture. The probes did confirm the record structure the assembler reads.
