### PR TITLE
Prevent ambiguous MCP tool call replays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Streamable HTTP no longer replays an MCP `tools/call` when its response cannot
+  be confirmed. The server may already have committed the tool's side effect,
+  so the call now raises `AmbiguousDeliveryError` with an explicit do-not-retry
+  warning instead of transparently executing twice.
 - Refusals and content-filter stops surface honestly on every provider
   instead of reading as clean stops or retryable truncations. Gemini's
   verdict finish reasons (SAFETY, RECITATION, LANGUAGE, BLOCKLIST,

--- a/lib/mistri/errors.rb
+++ b/lib/mistri/errors.rb
@@ -57,6 +57,14 @@ module Mistri
     def self.default_message = "provider server error"
   end
 
+  # A non-replayable request has no confirmed response, so execution is unknown.
+  class AmbiguousDeliveryError < ProviderError
+    def self.default_message
+      "connection failed before the response was confirmed; the operation may have completed; " \
+        "do not retry automatically; verify external state first"
+    end
+  end
+
   # The provider rejected the request itself: an invalid prompt, a bad
   # image, a policy violation. Never retried; the same input cannot succeed.
   class InvalidRequestError < ProviderError

--- a/lib/mistri/mcp/client.rb
+++ b/lib/mistri/mcp/client.rb
@@ -119,7 +119,9 @@ module Mistri
         payload = { jsonrpc: "2.0", id: id, method: method, params: params }
         result = nil
         responded = false
-        @wire.call(payload) do |record|
+        replayable = method != "tools/call"
+        # A tool may commit its external side effect before the connection dies.
+        @wire.call(payload, replayable: replayable) do |record|
           next unless record.is_a?(Hash) && record["id"] == id
 
           responded = true
@@ -127,7 +129,12 @@ module Mistri
 
           result = record["result"]
         end
-        raise Error, "the server sent no response to #{method}" unless responded
+        unless responded
+          detail = "the server sent no matching response to #{method}"
+          raise Error, detail if replayable
+
+          raise AmbiguousDeliveryError, "#{AmbiguousDeliveryError.default_message}: #{detail}"
+        end
 
         result
       rescue ProviderError => e

--- a/lib/mistri/mcp/wires.rb
+++ b/lib/mistri/mcp/wires.rb
@@ -27,8 +27,9 @@ module Mistri
 
         attr_writer :protocol_version
 
-        def call(payload, &)
-          meta = @transport.post_either(@path, body: payload, headers: request_headers, &)
+        def call(payload, replayable:, &)
+          meta = @transport.post_either(@path, body: payload, headers: request_headers,
+                                               replayable: replayable, &)
           capture_session(meta)
           nil
         end
@@ -79,7 +80,7 @@ module Mistri
           @pid = nil
         end
 
-        def call(payload)
+        def call(payload, **)
           spawn_server unless @pid
           write(payload)
           loop do

--- a/lib/mistri/transport.rb
+++ b/lib/mistri/transport.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "net/http"
+require "openssl"
 require "json"
 require "uri"
 
@@ -47,10 +48,9 @@ module Mistri
 
     # POST for Streamable-HTTP endpoints (the MCP shape) that answer either
     # a JSON body or an SSE stream: yields each JSON record either way and
-    # returns the response headers, downcased. Retries only a dead idle
-    # socket that failed before any response started, so a side-effecting
-    # call can never run twice.
-    def post_either(path, body:, headers: {}, &block)
+    # returns the response headers, downcased. A replayable request retries
+    # once when a dead idle socket fails before any response starts.
+    def post_either(path, body:, headers: {}, replayable: true, &block)
       @mutex.synchronize do
         retried = false
         begin
@@ -63,8 +63,12 @@ module Mistri
             read_either(response, &block)
           end
           response_headers
-        rescue IOError, SocketError, SystemCallError, Timeout::Error => e
+        rescue IOError, SocketError, SystemCallError, Timeout::Error, JSON::ParserError,
+               Net::HTTPBadResponse, OpenSSL::SSL::SSLError => e
           teardown
+          unless replayable
+            raise AmbiguousDeliveryError, "#{AmbiguousDeliveryError.default_message}: #{e.message}"
+          end
           if started || retried || e.is_a?(Timeout::Error)
             raise ProviderError, "connection failed: #{e.message}"
           end

--- a/test/support/mcp_stub_server.rb
+++ b/test/support/mcp_stub_server.rb
@@ -14,7 +14,8 @@ module Mistri
       attr_reader :calls, :initializes
 
       def initialize(tools: {}, sse: true, session: nil, page_size: nil,
-                     require_token: nil, expire_after: nil, protocol: "2025-11-25")
+                     require_token: nil, expire_after: nil, protocol: "2025-11-25",
+                     drop_after: nil, malformed_after: nil, empty_after: nil)
         @tools = tools
         @sse = sse
         @session = session
@@ -22,6 +23,12 @@ module Mistri
         @require_token = require_token
         @expire_after = expire_after
         @protocol = protocol
+        @drop_after = drop_after
+        @malformed_after = malformed_after
+        @empty_after = empty_after
+        @dropped = false
+        @malformed = false
+        @emptied = false
         @calls = []
         @initializes = 0
         @served = 0
@@ -47,7 +54,22 @@ module Mistri
         @served += 1
         return @stub.respond_json(socket, "", status: 202) unless message["id"]
 
-        respond(socket, message["id"], result_for(message), headers: session_headers(message))
+        result = result_for(message)
+        if message["method"] == @drop_after && !@dropped
+          @dropped = true
+          return :close
+        end
+        if message["method"] == @malformed_after && !@malformed
+          @malformed = true
+          @stub.respond_json(socket, "{")
+          return :close
+        end
+        if message["method"] == @empty_after && !@emptied
+          @emptied = true
+          return @stub.respond_json(socket, "", status: 202)
+        end
+
+        respond(socket, message["id"], result, headers: session_headers(message))
         nil
       end
 

--- a/test/test_errors.rb
+++ b/test/test_errors.rb
@@ -6,8 +6,8 @@ class TestErrors < Minitest::Test
   def test_every_error_rescues_as_mistri_error
     [Mistri::ConfigurationError, Mistri::ProviderError, Mistri::AuthenticationError,
      Mistri::RateLimitError, Mistri::OverloadedError, Mistri::ServerError,
-     Mistri::InvalidRequestError, Mistri::SchemaError, Mistri::AbortError,
-     Mistri::BudgetError].each do |klass|
+     Mistri::AmbiguousDeliveryError, Mistri::InvalidRequestError, Mistri::SchemaError,
+     Mistri::AbortError, Mistri::BudgetError].each do |klass|
       assert_operator klass, :<, Mistri::Error
     end
   end
@@ -25,5 +25,12 @@ class TestErrors < Minitest::Test
 
     assert_in_delta 12.5, error.retry_after
     assert_equal 429, error.status
+  end
+
+  def test_ambiguous_delivery_error_warns_against_an_automatic_retry
+    error = Mistri::AmbiguousDeliveryError.new
+
+    assert_match(/operation may have completed/, error.message)
+    assert_match(/do not retry automatically/, error.message)
   end
 end

--- a/test/test_mcp_bridge.rb
+++ b/test/test_mcp_bridge.rb
@@ -66,6 +66,27 @@ class TestMcpBridge < Minitest::Test
     server.stop
   end
 
+  def test_an_ambiguous_delivery_warns_the_model_not_to_retry
+    tools = { "send" => { description: "Sends once.", handler: ->(_) { "sent" } } }
+    server = Mistri::Test::McpStubServer.new(tools: tools, drop_after: "tools/call")
+    client = Mistri::MCP::Client.new(url: server.url)
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "send", arguments: {} }] },
+                                             { text: "I will verify before retrying." }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: Mistri::MCP.tools(client))
+
+    agent.run("send it")
+
+    result = agent.session.messages.find(&:tool?)
+
+    assert_match(/AmbiguousDeliveryError/, result.text)
+    assert_match(/do not retry automatically/, result.text)
+    assert_equal 1, server.calls.length
+  ensure
+    server&.stop
+  end
+
   def test_an_approval_gate_parks_a_bridged_tool_before_the_server_sees_it
     tools = { "send" => { description: "Sends.", handler: ->(_) { "sent" } } }
     server = Mistri::Test::McpStubServer.new(tools: tools)

--- a/test/test_mcp_client.rb
+++ b/test/test_mcp_client.rb
@@ -105,6 +105,80 @@ class TestMcpClient < Minitest::Test
     end
   end
 
+  def test_a_dropped_tool_response_does_not_replay_the_call
+    with_server(drop_after: "tools/call") do |server|
+      client = Mistri::MCP::Client.new(url: server.url)
+
+      error = assert_raises(Mistri::AmbiguousDeliveryError) do
+        client.call_tool("echo", { "text" => "once" })
+      end
+
+      assert_match(/may have completed/, error.message)
+      assert_match(/do not retry automatically/, error.message)
+      assert_equal 1, server.calls.length
+    end
+  end
+
+  def test_a_dropped_replayable_request_reconnects_once
+    with_server(drop_after: "tools/list") do |server|
+      client = Mistri::MCP::Client.new(url: server.url)
+      names = client.tools.map { |tool| tool["name"] }
+      list_calls = server.bodies.count { |body| body["method"] == "tools/list" }
+
+      assert_equal ["echo"], names
+      assert_equal 2, list_calls
+    end
+  end
+
+  def test_a_malformed_tool_response_is_ambiguous
+    with_server(malformed_after: "tools/call") do |server|
+      client = Mistri::MCP::Client.new(url: server.url)
+
+      error = assert_raises(Mistri::AmbiguousDeliveryError) do
+        client.call_tool("echo", { "text" => "once" })
+      end
+
+      assert_match(/may have completed/, error.message)
+      assert_equal 1, server.calls.length
+    end
+  end
+
+  def test_a_malformed_replayable_response_is_not_replayed
+    with_server(malformed_after: "tools/list") do |server|
+      client = Mistri::MCP::Client.new(url: server.url)
+
+      assert_raises(Mistri::ProviderError) { client.tools }
+      list_calls = server.bodies.count { |body| body["method"] == "tools/list" }
+
+      assert_equal 1, list_calls
+      assert_empty server.calls
+    end
+  end
+
+  def test_a_missing_tool_response_is_ambiguous
+    with_server(empty_after: "tools/call") do |server|
+      client = Mistri::MCP::Client.new(url: server.url)
+
+      error = assert_raises(Mistri::AmbiguousDeliveryError) do
+        client.call_tool("echo", { "text" => "once" })
+      end
+
+      assert_match(/no matching response/, error.message)
+      assert_equal 1, server.calls.length
+    end
+  end
+
+  def test_a_missing_replayable_response_remains_a_protocol_error
+    with_server(empty_after: "tools/list") do |server|
+      client = Mistri::MCP::Client.new(url: server.url)
+
+      error = assert_raises(Mistri::MCP::Error) { client.tools }
+
+      assert_match(/no matching response/, error.message)
+      assert_empty server.calls
+    end
+  end
+
   def test_an_unsupported_protocol_version_fails_loudly
     with_server(protocol: "1999-01-01") do |server|
       client = Mistri::MCP::Client.new(url: server.url)


### PR DESCRIPTION
## Summary

- classify MCP `tools/call` as non-replayable in the protocol-aware client
- raise `AmbiguousDeliveryError` when a non-replayable response is dropped, malformed, or missing its matching JSON-RPC result
- carry an explicit no-auto-retry warning into the model-visible tool result
- preserve one reconnect retry for replay-safe requests such as `tools/list`

## Why

A connection failure before a confirmed response does not prove that the MCP server skipped the request. The server may have committed the tool's external side effect and lost only the response. Retrying transparently can therefore execute a write twice.

The delivery error is deliberately conservative: Net::HTTP cannot prove whether a pre-response failure happened before or after the server received the request. Callers must verify external state before retrying.

## Impact

Successful MCP requests add one method comparison before transport. Streaming and token paths are unchanged. Aggressive proxies that close idle sockets may now surface an ambiguity error for `tools/call` instead of being retried; that is the intended correctness tradeoff.

Explicit HTTP and JSON-RPC error responses keep their existing authentication, session recovery, and protocol behavior.

## Validation

- `bundle exec rake test` - 436 runs, 1,514 assertions, 0 failures
- `bundle exec rubocop` - 163 files, 0 offenses
- coverage - 95.88% line, 81.55% branch
- live Gemini MCP scenario on `gemini-3.1-flash-lite` - 1 run, 8 assertions, 0 failures
- independent adversarial review - no remaining findings

A separate `gemini-3.5-flash` attempt reached the MCP tool path, then Google returned a transient 503 high-demand response on the final model turn; no quota error was observed.