### PR TITLE
Reject workspace symlink traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Directory workspaces reject existing symlinks in model-controlled paths and
+  omit symlinked files from listings. In a stable, host-controlled tree, reads,
+  writes, and deletes no longer follow a link outside the configured root.
 - Streamable HTTP no longer replays an MCP `tools/call` when its response cannot
   be confirmed. The server may already have committed the tool's side effect,
   so the call now raises `AmbiguousDeliveryError` with an explicit do-not-retry

--- a/lib/mistri/workspace/directory.rb
+++ b/lib/mistri/workspace/directory.rb
@@ -4,12 +4,16 @@ require "fileutils"
 
 module Mistri
   module Workspace
-    # Documents as files under one root. Every path resolves inside the root
-    # or raises, so a model-supplied "../../etc/passwd" cannot escape.
+    # Documents as ordinary files under a host-controlled root. Model-supplied
+    # paths cannot escape lexically or traverse an existing symlink. The host
+    # must keep the root and tree stable for the instance's lifetime; this is
+    # not an OS sandbox against concurrent filesystem mutation.
     class Directory
       def initialize(root)
-        @root = File.expand_path(root)
-        FileUtils.mkdir_p(@root)
+        expanded = File.expand_path(root)
+        FileUtils.mkdir_p(expanded)
+        @root = File.realpath(expanded)
+        @root_prefix = @root.end_with?(File::SEPARATOR) ? @root : "#{@root}#{File::SEPARATOR}"
       end
 
       def read(path)
@@ -20,6 +24,7 @@ module Mistri
       def write(path, content)
         full = resolve(path)
         FileUtils.mkdir_p(File.dirname(full))
+        full = resolve(path)
         File.write(full, content.to_s)
         nil
       end
@@ -31,9 +36,13 @@ module Mistri
       end
 
       def list(prefix = nil)
-        base = @root.length + 1
-        paths = Dir.glob(File.join(@root, "**", "*")).select { |f| File.file?(f) }
-                                                     .map { |f| f[base..] }.sort
+        paths = Dir.glob("**/*", base: @root).filter_map do |path|
+          full = File.join(@root, path)
+          next if traverses_symlink?(full)
+          next unless File.file?(full)
+
+          path
+        end.sort
         prefix ? paths.select { |p| p.start_with?(prefix.to_s) } : paths
       end
 
@@ -41,11 +50,21 @@ module Mistri
 
       def resolve(path)
         full = File.expand_path(path.to_s, @root)
-        unless full == @root || full.start_with?("#{@root}#{File::SEPARATOR}")
+        unless full == @root || full.start_with?(@root_prefix)
           raise SchemaError, "path escapes the workspace: #{path}"
         end
+        raise SchemaError, "path traverses a symlink: #{path}" if traverses_symlink?(full)
 
         full
+      end
+
+      def traverses_symlink?(full)
+        current = @root
+        relative = full.delete_prefix(@root).delete_prefix(File::SEPARATOR)
+        relative.split(File::SEPARATOR).any? do |part|
+          current = File.join(current, part)
+          File.symlink?(current)
+        end
       end
     end
   end

--- a/test/test_workspace.rb
+++ b/test/test_workspace.rb
@@ -47,6 +47,77 @@ class TestWorkspace < Minitest::Test
     end
   end
 
+  def test_the_directory_backend_refuses_symlinks_to_outside_directories
+    Dir.mktmpdir do |root|
+      Dir.mktmpdir do |outside|
+        secret = File.join(outside, "secret.txt")
+        File.write(secret, "private")
+        File.symlink(outside, File.join(root, "linked"))
+        workspace = Mistri::Workspace::Directory.new(root)
+
+        assert_raises(Mistri::SchemaError) { workspace.read("linked/secret.txt") }
+        assert_raises(Mistri::SchemaError) { workspace.write("linked/new.txt", "hostile") }
+        assert_raises(Mistri::SchemaError) { workspace.delete("linked/secret.txt") }
+        assert_empty workspace.list
+        assert_equal "private", File.read(secret)
+        refute_path_exists File.join(outside, "new.txt")
+      end
+    end
+  end
+
+  def test_the_directory_backend_refuses_file_and_broken_symlinks
+    Dir.mktmpdir do |root|
+      Dir.mktmpdir do |outside|
+        secret = File.join(outside, "secret.txt")
+        missing = File.join(outside, "missing.txt")
+        File.write(secret, "private")
+        File.symlink(secret, File.join(root, "secret.txt"))
+        File.symlink(missing, File.join(root, "missing.txt"))
+        workspace = Mistri::Workspace::Directory.new(root)
+
+        assert_empty workspace.list
+        assert_raises(Mistri::SchemaError) { workspace.read("secret.txt") }
+        assert_raises(Mistri::SchemaError) { workspace.write("secret.txt", "hostile") }
+        assert_raises(Mistri::SchemaError) { workspace.write("missing.txt", "hostile") }
+        assert_raises(Mistri::SchemaError) { workspace.delete("secret.txt") }
+        assert_equal "private", File.read(secret)
+        refute_path_exists missing
+      end
+    end
+  end
+
+  def test_the_directory_backend_omits_safe_directory_symlinks
+    Dir.mktmpdir do |root|
+      workspace = Mistri::Workspace::Directory.new(root)
+      workspace.write("real/inside.txt", "inside")
+      File.symlink(File.join(root, "real"), File.join(root, "linked"))
+
+      assert_raises(Mistri::SchemaError) { workspace.read("linked/inside.txt") }
+      assert_equal ["real/inside.txt"], workspace.list
+    end
+  end
+
+  def test_the_directory_backend_accepts_children_of_the_filesystem_root
+    workspace = Mistri::Workspace::Directory.new(File::SEPARATOR)
+    missing = "mistri-workspace-missing-#{Process.pid}-#{object_id}"
+
+    assert_nil workspace.read(missing)
+  end
+
+  def test_the_directory_backend_treats_a_canonical_root_as_a_literal_path
+    Dir.mktmpdir do |parent|
+      root = File.join(parent, "workspace[1]")
+      FileUtils.mkdir_p(root)
+      link = File.join(parent, "workspace")
+      File.symlink(root, link)
+      workspace = Mistri::Workspace::Directory.new(link)
+
+      workspace.write("notes/one.txt", "one")
+
+      assert_equal ["notes/one.txt"], workspace.list
+    end
+  end
+
   private
 
   def each_workspace


### PR DESCRIPTION
## Summary

- reject existing file, directory, nested, and broken symlinks in model-supplied workspace paths
- revalidate writes after creating parent directories
- omit symlinked files and directories from listings
- treat canonical roots literally, including glob metacharacters and filesystem roots

## Why

`Workspace::Directory` previously proved only lexical containment. A symlink already inside the workspace could redirect read, write, or delete operations outside the configured root.

The adapter now rejects every existing symlink component. Its security boundary is explicit: the host must keep the root and tree stable for the instance's lifetime. This is not an OS sandbox against a process concurrently replacing filesystem entries.

## Impact

Each direct file operation performs one symlink check per existing path component; writes repeat validation after parent creation. This work is confined to workspace file I/O and does not affect request building, provider streaming, or token delivery.

Normal files, nested directory creation, list prefixes, and host-configured root symlinks retain their behavior.

## Validation

- `bundle exec rake test` - 441 runs, 1,533 assertions, 0 failures
- `bundle exec rubocop` - 163 files, 0 offenses
- coverage - 95.90% line, 81.66% branch
- `Workspace::Directory` - no missing executable lines or uncovered branches
- independent security and portability review - no remaining findings