### PR TITLE
Make cost budgets pricing-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,14 +43,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   burns its retry budget on input the provider already ruled out. A
   failed response without an error object now errors instead of reading
   as a clean stop.
-- The model catalog carries each model's published API prices, and the
-  assemblers price every turn's usage from them: message.usage.cost and
-  Result#usage now report real dollars for catalogued models, and the
+- The model catalog carries each model's published standard paid direct-API
+  prices. Assemblers price every turn's usage from them: message.usage.cost and
+  Result#usage now report list-price dollar estimates for catalogued models, and the
   Budget cost_usd ceiling actually stops a run. It never could before:
-  nothing computed cost, so the comparison always saw zero. Uncatalogued
-  models still report zero cost and only the other ceilings stop them.
-  Long-context premium tiers (Gemini Pro and GPT past 200k input) are not
-  modeled; those turns under-count.
+  nothing computed cost, so the comparison always saw zero. Pricing is
+  selected per request, including GPT-5.4/5.5 and Gemini Pro long-context
+  tiers and Sonnet 5's September 2026 rate change. Unpriced usage is marked
+  unknown instead of free. A cost ceiling rejects an unknown model or origin
+  at construction and fails closed when a request's pricing is unknown at
+  runtime. Catalog pricing requires an explicit `catalog_pricing:` opt-in on
+  custom origins and observes service-tier policy without changing it;
+  nonstandard or unreported tiers stay unknown. A deterministic standard tier
+  is required up front for cost-budgeted Anthropic and OpenAI agents; Gemini's
+  reported standard, Flex, or Priority tier is honored rather than assuming
+  standard. Cost ceilings remain soft and are checked between model-visible
+  turns. An unmetered attempt raises Mistri::BudgetError instead of retrying
+  under false certainty; the error and an unpriced_attempt session entry retain
+  its partial accounting. Run usage includes every retry and compaction attempt,
+  and retry session entries now carry their own usage. Truncated streams preserve
+  partial token counts but mark their dollar total unknown.
 
 ## [0.5.0] - 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -445,15 +445,45 @@ the generator and stores duck-type into any app.
 signal = Mistri::AbortSignal.new
 agent.run("Draft a long essay.", signal: signal)
 
-# Ceilings are opt-in and off by default. Dollar cost is priced from the
-# model catalog's published rates; a model the catalog does not know
-# reports zero cost, so only the other ceilings can stop it.
+# Ceilings are opt-in and off by default. Dollar cost uses each request's
+# published paid-list rate, including long-context tiers and dated changes.
 budget = Mistri::Budget.new(turns: 20, cost_usd: 2.00)
+
+# Anthropic and OpenAI need an explicit standard tier for a cost budget.
+agent = Mistri.agent("gpt-5.5", budget: budget,
+                     provider_options: { service_tier: "default" })
 
 # Transient failures (429, 5xx, timeouts) retry with backoff, invisibly to
 # the model. On by default; retries: false disables.
 policy = Mistri::RetryPolicy.new(attempts: 3)
 ```
+
+Cost is explicit: `result.usage.cost.known?` is false when Mistri cannot
+price every turn. Constructing an agent with `cost_usd` therefore requires a
+catalogued model, a list-priced origin, and deterministic standard-tier policy
+instead of treating unknown cost as free. Anthropic uses `standard_only`;
+OpenAI uses `default`; Gemini's omitted tier is standard by contract. All
+ceilings are checked between model-visible turns, so the final turn, including
+its provider retry attempts, can exceed one. If an attempted request has no
+trustworthy usage, the run raises `BudgetError` and does not retry it. The
+error exposes `usage` and `provider_message`, and the session records an
+`unpriced_attempt` entry for reconciliation. Reported dollars are standard paid
+direct-API list-price estimates; contracted or regional uplifts and separately
+billed provider tools are outside this total.
+Gemini free-tier usage is conservatively valued at the paid rate.
+
+Built-in providers disable catalog pricing for a custom `origin:`. Pass
+`catalog_pricing: true` only when that route bills the same published rates.
+Pricing never changes service-tier policy. Anthropic and OpenAI usage is known
+only when the response reports their standard tier; Priority, Flex, or a
+missing tier stays unknown. A host that needs deterministic list-price
+budgeting can select it explicitly with `provider_options: { service_tier:
+"standard_only" }` for Anthropic or `"default"` for OpenAI. Gemini observes
+`usageMetadata.serviceTier`; Flex and Priority are unpriced by this catalog.
+A custom provider can support cost ceilings by returning true from
+`prices_usage?` and attaching a known cost to every response, commonly with
+`Mistri::Usage#with_cost`; missing or partial pricing then fails closed at
+runtime.
 
 Retries are invisible to the model but not to your UI: each backoff emits a
 `:retry` event carrying `attempt`, `max_attempts`, and `delay`, so a sink can

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -19,7 +19,7 @@ module Mistri
   # queues a user message from any process while the loop runs; it folds
   # into the transcript at the next turn boundary, and a background child's
   # report arrives through the same inbox.
-  class Agent
+  class Agent # rubocop:disable Metrics/ClassLength -- lifecycle order is the class contract
     # compaction defaults on so long sessions survive their context window;
     # pass false to disable, or a tuned Compaction. It only ever triggers
     # when the model's window is known (catalog or Compaction#window).
@@ -45,6 +45,7 @@ module Mistri
       raise ConfigurationError, "duplicate tool names" if @tools_by_name.length != @tools.length
 
       @budget = budget || Budget.new
+      @budget.validate_provider!(@provider)
       @max_concurrency = max_concurrency
       @transform_context = Array(transform_context)
       @compaction = compaction || nil
@@ -159,10 +160,16 @@ module Mistri
 
         fold_inbox
         compacted = auto_compact(&emit)
-        usage += compacted[:usage] if compacted&.dig(:usage)
-        last = run_turn(signal, output_schema, &emit)
+        if compacted
+          compaction_usage = compacted[:usage] || Usage.new
+          validate_usage!(compaction_usage, kind: "compaction", &emit)
+          usage += compaction_usage
+          reason = @budget.exceeded(turns:, usage:, elapsed: monotonic_now - started)
+          return stop_for_budget(reason, usage, &emit) if reason
+        end
+        last, turn_usage = run_turn(signal, output_schema, &emit)
         turns += 1
-        usage += last.usage if last.usage
+        usage += turn_usage
 
         # Any tool call the turn made must be answered or parked, or the
         # transcript is unpairable and replay fails.
@@ -193,8 +200,8 @@ module Mistri
       return nil unless @compaction.needed?(tokens, context_window)
 
       Compactor.call(session: @session, provider: @provider, settings: @compaction, &)
-    rescue CompactionError
-      nil
+    rescue CompactionError => e
+      { usage: e.usage || Usage.new }
     end
 
     def context_window
@@ -229,12 +236,16 @@ module Mistri
         transform.call(messages)
       end
       attempt = 0
+      usage = Usage.zero
       loop do
         held = nil
         gate = emit && ->(event) { event.terminal? ? held = event : emit.call(event) }
         message = @provider.stream(messages: history, system: @system,
                                    tools: @tools.map(&:spec), signal: signal,
                                    output_schema: output_schema, &gate)
+        attempt_usage = message.usage || Usage.new
+        validate_usage!(attempt_usage, message:, kind: "turn", &emit)
+        usage += attempt_usage
         attempt += 1
         error = @retries&.error_for(message)
         if retry_turn?(error, attempt, signal)
@@ -245,7 +256,7 @@ module Mistri
         end
         emit&.call(held) if held
         @session.append_message(message)
-        return message
+        return [message, usage]
       end
     end
 
@@ -257,13 +268,30 @@ module Mistri
     end
 
     def record_retry(message, error, attempt, pause, &emit)
-      @session.append("retry", "attempt" => attempt, "error" => error,
-                               "delay" => pause.round(2))
+      entry = { "attempt" => attempt, "error" => error, "delay" => pause.round(2) }
+      entry["usage"] = (message.usage || Usage.new).to_h
+      @session.append("retry", entry)
       note = format("attempt %<attempt>d failed; retrying in %<pause>.1fs",
                     attempt: attempt, pause: pause)
       emit&.call(Event.new(type: :retry, content: note, attempt: attempt,
                            max_attempts: @retries.attempts, delay: pause.round(2),
                            message: message))
+    end
+
+    def validate_usage!(usage, kind:, message: nil, &emit)
+      @budget.validate_usage!(usage)
+    rescue BudgetError => e
+      entry = { "kind" => kind, "usage" => usage.to_h }
+      entry["message"] = message.to_h if message
+      @session.append("unpriced_attempt", entry)
+      error = BudgetError.new(e.message, usage: e.usage || usage, provider_message: message)
+      stopped = Message.assistant(content: "Run stopped: cost could not be determined.",
+                                  stop_reason: StopReason::BUDGET,
+                                  error_message: "budget_cost_unknown")
+      @session.append_message(stopped)
+      emit&.call(Event.new(type: :error, reason: StopReason::BUDGET, message: stopped,
+                           error_message: error.message))
+      raise error
     end
 
     # Backoff that an abort can cut short.
@@ -404,5 +432,5 @@ module Mistri
     end
 
     def monotonic_now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-  end
+  end # rubocop:enable Metrics/ClassLength
 end

--- a/lib/mistri/budget.rb
+++ b/lib/mistri/budget.rb
@@ -16,11 +16,36 @@ module Mistri
 
     def none? = [@turns, @tokens, @cost_usd, @wall_clock].all?(&:nil?)
 
+    def cost? = !@cost_usd.nil?
+
+    def validate_provider!(provider)
+      return unless cost?
+      return if provider.respond_to?(:prices_usage?) && provider.prices_usage?
+
+      raise ConfigurationError,
+            "cost budget requires a catalogued model, list-priced origin, and deterministic " \
+            "standard service tier for #{provider.model.inspect}"
+    end
+
+    def validate_usage!(usage)
+      return unless cost?
+      return if usage.cost.known?
+
+      raise BudgetError.new(
+        "cost budget cannot continue after a request returned unpriced usage; not retrying",
+        usage:
+      )
+    end
+
     # The reason the run should stop, or nil to continue.
     def exceeded(turns:, usage:, elapsed: 0)
       return :turns if @turns && turns >= @turns
       return :tokens if @tokens && usage.total_tokens >= @tokens
-      return :cost if @cost_usd && usage.cost.total >= @cost_usd
+
+      if @cost_usd
+        validate_usage!(usage)
+        return :cost if usage.cost.total >= @cost_usd
+      end
       return :wall_clock if @wall_clock && elapsed >= @wall_clock
 
       nil

--- a/lib/mistri/compactor.rb
+++ b/lib/mistri/compactor.rb
@@ -145,7 +145,10 @@ module Mistri
         prompt << (previous ? UPDATE_PROMPT : CHECKPOINT_PROMPT)
         prompt << "\nAdditional focus: #{instructions}\n" if instructions
         reply = provider.stream(messages: [Message.user(prompt)], system: SUMMARIZER_SYSTEM)
-        raise CompactionError, "summarization failed: #{reply.error_message}" unless usable?(reply)
+        unless usable?(reply)
+          raise CompactionError.new("summarization failed: #{reply.error_message}",
+                                    usage: reply.usage)
+        end
 
         reply
       end

--- a/lib/mistri/errors.rb
+++ b/lib/mistri/errors.rb
@@ -77,14 +77,31 @@ module Mistri
   # A run cancelled by the host, raised only when the caller opts into raising.
   class AbortError < Error; end
 
-  # A run stopped by its turn, token, cost, or wall-clock budget.
-  class BudgetError < Error; end
+  # A cost-budgeted request returned without trustworthy accounting. Usage and
+  # provider_message preserve the uncertain attempt for host reconciliation.
+  class BudgetError < Error
+    attr_reader :usage, :provider_message
+
+    def initialize(message = nil, usage: nil, provider_message: nil)
+      @usage = usage
+      @provider_message = provider_message
+      super(message)
+    end
+  end
 
   # A text edit that did not match uniquely, or overlapped another edit.
   class EditError < Error; end
 
-  # Compaction could not produce a usable summary.
-  class CompactionError < Error; end
+  # Compaction could not produce a usable summary. Usage preserves any billed
+  # provider attempt even though no checkpoint was written.
+  class CompactionError < Error
+    attr_reader :usage
+
+    def initialize(message = nil, usage: nil)
+      @usage = usage
+      super(message)
+    end
+  end
 
   # The machine-readable shape of a stream failure, carried on errored
   # assistant messages so retry policies and hosts can classify without

--- a/lib/mistri/models.rb
+++ b/lib/mistri/models.rb
@@ -1,58 +1,137 @@
 # frozen_string_literal: true
 
+require "json"
+
 module Mistri
   # The model catalog: capability data for known models, with graceful
   # passthrough for unknown ones. An id missing here still works everywhere;
-  # the catalog only improves defaults (output ceilings, provider inference),
-  # so a brand-new model is usable the day it ships.
+  # the catalog supplies capability defaults and paid direct-API pricing, so a
+  # brand-new model remains usable unless the host requests a cost ceiling.
   module Models
+    EMPTY_PRICING = [].freeze
+
+    # One request's standard rates and optional prompt-size tier.
+    RateCard = Data.define(:rates, :above, :higher) do
+      def initialize(rates:, above: nil, higher: nil)
+        if above.nil? != higher.nil?
+          raise ArgumentError, "a pricing threshold needs both above and higher"
+        end
+
+        super(rates: rates.freeze, above:, higher: higher&.freeze)
+      end
+
+      def rates_for(usage)
+        usage && above && usage.prompt_tokens > above ? higher : rates
+      end
+    end
+
+    # A rate card that becomes active at one absolute instant.
+    Schedule = Data.define(:effective_at, :card)
+
     # thinking is how the model accepts a reasoning request: :adaptive (the
     # model decides), :budget (a token budget), or :effort. It is what keeps
     # a provider from sending an unsupported thinking shape that 400s.
     #
-    # rates is the published API price in USD per million tokens; assemblers
-    # price each turn's usage from it. cache_write is the 5-minute write
-    # rate; the 1-hour slice bills at 2x input, which Usage#with_cost applies
-    # on its own. An uncatalogued model reports zero cost, so a cost budget
-    # never stops it. Long-context premium tiers (Gemini Pro and GPT past
-    # 200k input) are not modeled; those turns under-count.
-    Model = Data.define(:id, :provider, :max_output, :context_window, :thinking, :rates) do
-      def initialize(id:, provider:, max_output:, context_window:, thinking:, rates: nil)
-        super(id:, provider:, max_output:, context_window:, thinking:, rates: rates.freeze)
+    # Pricing is selected per request from its prompt size. Rates are paid
+    # standard direct-API list prices. cache_write is the 5-minute write rate;
+    # Usage applies the 1-hour rate separately.
+    Model = Data.define(:id, :provider, :max_output, :context_window, :thinking) do
+      def initialize(id:, provider:, max_output:, context_window:, thinking:, pricing: [])
+        @pricing = pricing.sort_by(&:effective_at).freeze
+        super(id:, provider:, max_output:, context_window:, thinking:)
       end
+
+      def rates(usage: nil, at: Time.now)
+        pricing.reverse_each.find { |entry| entry.effective_at <= at }&.card&.rates_for(usage)
+      end
+
+      def priced? = !pricing.empty?
+
+      def with(**changes)
+        updated_pricing = changes.delete(:pricing) { pricing }
+        self.class.new(**to_h, **changes, pricing: updated_pricing)
+      end
+
+      def ==(other) = super && pricing == other.send(:pricing)
+
+      alias_method :eql?, :==
+
+      def hash = [super, pricing].hash
+
+      def _dump(_level)
+        serialized = pricing.map do |entry|
+          { effective_at: entry.effective_at.to_i, rates: entry.card.rates,
+            above: entry.card.above, higher: entry.card.higher }
+        end
+        JSON.generate(to_h.merge(pricing: serialized))
+      end
+
+      def self._load(payload)
+        attributes = JSON.parse(payload, symbolize_names: true)
+        serialized = attributes.delete(:pricing)
+        pricing = serialized.map do |entry|
+          card = RateCard.new(rates: entry[:rates], above: entry[:above],
+                              higher: entry[:higher])
+          Schedule.new(effective_at: Time.at(entry[:effective_at]).utc, card:)
+        end
+        attributes[:provider] = attributes[:provider].to_sym
+        attributes[:thinking] = attributes[:thinking].to_sym
+        new(**attributes, pricing:)
+      end
+
+      private
+
+      def pricing = @pricing || EMPTY_PRICING
     end
+
+    EPOCH = Time.at(0).utc.freeze
+
+    def self.price(rates = nil, from: EPOCH, above: nil, higher: nil, **flat_rates)
+      rates ||= flat_rates
+      Schedule.new(effective_at: from,
+                   card: RateCard.new(rates:, above:, higher:))
+    end
+    private_class_method :price
 
     CATALOG = [
       ["claude-fable-5", :anthropic, 128_000, 200_000, :adaptive,
-       { input: 10.0, output: 50.0, cache_read: 1.0, cache_write: 12.5 }],
+       [price(input: 10.0, output: 50.0, cache_read: 1.0, cache_write: 12.5)]],
       ["claude-opus-4-8", :anthropic, 128_000, 200_000, :adaptive,
-       { input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25 }],
+       [price(input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25)]],
       ["claude-opus-4-7", :anthropic, 128_000, 200_000, :adaptive,
-       { input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25 }],
+       [price(input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25)]],
       ["claude-opus-4-6", :anthropic, 128_000, 200_000, :adaptive,
-       { input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25 }],
-      # Introductory pricing through 2026-08-31; 3.0/15.0 (0.3/3.75) after.
+       [price(input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25)]],
       ["claude-sonnet-5", :anthropic, 128_000, 200_000, :adaptive,
-       { input: 2.0, output: 10.0, cache_read: 0.2, cache_write: 2.5 }],
+       [price(input: 2.0, output: 10.0, cache_read: 0.2, cache_write: 2.5),
+        price({ input: 3.0, output: 15.0, cache_read: 0.3, cache_write: 3.75 },
+              from: Time.utc(2026, 9, 1))]],
       ["claude-sonnet-4-6", :anthropic, 128_000, 200_000, :adaptive,
-       { input: 3.0, output: 15.0, cache_read: 0.3, cache_write: 3.75 }],
+       [price(input: 3.0, output: 15.0, cache_read: 0.3, cache_write: 3.75)]],
       ["claude-haiku-4-5", :anthropic, 64_000, 200_000, :budget,
-       { input: 1.0, output: 5.0, cache_read: 0.1, cache_write: 1.25 }],
+       [price(input: 1.0, output: 5.0, cache_read: 0.1, cache_write: 1.25)]],
       ["gpt-5.5", :openai, 128_000, 400_000, :effort,
-       { input: 5.0, output: 30.0, cache_read: 0.5 }],
+       [price({ input: 5.0, output: 30.0, cache_read: 0.5 },
+              above: 272_000, higher: { input: 10.0, output: 45.0, cache_read: 1.0 })]],
       ["gpt-5.4", :openai, 128_000, 400_000, :effort,
-       { input: 2.5, output: 15.0, cache_read: 0.25 }],
+       [price({ input: 2.5, output: 15.0, cache_read: 0.25 },
+              above: 272_000, higher: { input: 5.0, output: 22.5, cache_read: 0.5 })]],
       ["gpt-5-nano", :openai, 128_000, 400_000, :effort,
-       { input: 0.05, output: 0.4, cache_read: 0.005 }],
+       [price(input: 0.05, output: 0.4, cache_read: 0.005)]],
       ["gemini-3.5-flash", :gemini, 65_536, 1_048_576, :level,
-       { input: 1.5, output: 9.0, cache_read: 0.15 }],
+       [price(input: 1.5, output: 9.0, cache_read: 0.15)]],
       ["gemini-3.1-pro-preview", :gemini, 65_536, 1_048_576, :level,
-       { input: 2.0, output: 12.0, cache_read: 0.2 }],
+       [price({ input: 2.0, output: 12.0, cache_read: 0.2 },
+              above: 200_000, higher: { input: 4.0, output: 18.0, cache_read: 0.4 })]],
       ["gemini-2.5-pro", :gemini, 65_536, 1_048_576, :budget,
-       { input: 1.25, output: 10.0, cache_read: 0.125 }],
+       [price({ input: 1.25, output: 10.0, cache_read: 0.125 },
+              above: 200_000, higher: { input: 2.5, output: 15.0, cache_read: 0.25 })]],
       ["gemini-2.5-flash", :gemini, 65_536, 1_048_576, :budget,
-       { input: 0.3, output: 2.5, cache_read: 0.03 }]
-    ].to_h { |row| [row.first, Model.new(*row)] }.freeze
+       [price(input: 0.3, output: 2.5, cache_read: 0.03)]]
+    ].to_h do |row|
+      id, provider, max_output, context_window, thinking, pricing = row
+      [id, Model.new(id:, provider:, max_output:, context_window:, thinking:, pricing:)]
+    end.freeze
 
     # Dated aliases resolve to their base entry: claude-opus-4-8-20260115 and
     # gpt-5.4-2025-04-14 both match their base ids.
@@ -64,6 +143,8 @@ module Mistri
 
     def self.thinking(id) = find(id)&.thinking
 
-    def self.rates(id) = find(id)&.rates
+    def self.rates(id, usage: nil, at: Time.now) = find(id)&.rates(usage:, at:)
+
+    def self.priced?(id) = find(id)&.priced? || false
   end
 end

--- a/lib/mistri/providers/anthropic.rb
+++ b/lib/mistri/providers/anthropic.rb
@@ -10,33 +10,40 @@ module Mistri
     # raising: the loop decides whether to retry, and the host always gets a
     # message back.
     class Anthropic
+      DEFAULT_ORIGIN = "https://api.anthropic.com"
       VERSION_HEADER = "2023-06-01"
       DEFAULT_THINKING = { type: "adaptive", display: "summarized" }.freeze
 
       # Messages API parameters passed through verbatim from a stream override.
-      PASSTHROUGH = %i[temperature top_p top_k stop_sequences metadata
-                       tool_choice service_tier].freeze
+      PASSTHROUGH = %i[temperature top_p top_k stop_sequences metadata tool_choice].freeze
       # The ceiling for an uncatalogued model: high enough for headroom, low
       # enough that every current model accepts it. Catalog a model to unlock
       # its real output limit.
       UNKNOWN_MODEL_MAX_TOKENS = 64_000
 
-      def initialize(api_key:, model: "claude-opus-4-8", origin: "https://api.anthropic.com",
+      def initialize(api_key:, model: "claude-opus-4-8", origin: DEFAULT_ORIGIN,
                      max_tokens: nil, thinking: DEFAULT_THINKING, cache: true,
+                     service_tier: nil, catalog_pricing: nil,
                      **transport_options)
         @api_key = api_key
         @model = model
         @max_tokens = max_tokens
         @thinking = thinking
         @cache = cache
+        @service_tier = service_tier
+        @catalog_pricing = catalog_pricing.nil? ? official_origin?(origin) : catalog_pricing
         @transport = Transport.new(origin: origin, **transport_options)
       end
 
       attr_reader :model
 
+      def prices_usage?
+        @catalog_pricing && Models.priced?(model) && @service_tier.to_s == "standard_only"
+      end
+
       def stream(messages:, system: nil, tools: [], signal: nil, **overrides, &emit)
         model = overrides.fetch(:model, @model)
-        assembler = Anthropic::Assembler.new(model: model)
+        assembler = Anthropic::Assembler.new(model: model, catalog_pricing: @catalog_pricing)
         body = build_body(model, messages, system, tools, overrides)
         outcome = @transport.stream_post("/v1/messages", body: body, headers: headers,
                                                          signal: signal) do |record|
@@ -53,6 +60,8 @@ module Mistri
 
       private
 
+      def official_origin?(origin) = origin.to_s.delete_suffix("/") == DEFAULT_ORIGIN
+
       def build_body(model, messages, system, tools, overrides)
         body = {
           model: model,
@@ -63,6 +72,8 @@ module Mistri
         system_blocks = Serializer.system_blocks(system, cache: @cache)
         body[:system] = system_blocks if system_blocks
         body[:tools] = Serializer.tools(tools) if tools.any?
+        service_tier = overrides.fetch(:service_tier, @service_tier)
+        body[:service_tier] = service_tier if service_tier
         thinking = thinking_for(model, overrides)
         body[:thinking] = thinking if thinking
         if (schema = overrides[:output_schema])

--- a/lib/mistri/providers/anthropic/assembler.rb
+++ b/lib/mistri/providers/anthropic/assembler.rb
@@ -11,19 +11,20 @@ module Mistri
       # Unknown event and block types are skipped by contract: the API adds
       # types over time and a live stream must survive them.
       class Assembler
-        def initialize(model:)
+        def initialize(model:, catalog_pricing: true)
           @model = model
-          @rates = Models.rates(model)
+          @catalog_pricing = catalog_pricing
+          @pricing_at = Time.now
           @blocks = []
           @current = nil
-          @usage = Usage.zero
+          @usage = Usage.new
           @stop_reason = nil
           @done = false
         end
 
         def feed(record, &)
           case record["type"]
-          when "message_start" then @usage = priced(parse_usage(record.dig("message", "usage")))
+          when "message_start" then message_start(record)
           when "content_block_start" then start_block(record, &)
           when "content_block_delta" then delta_block(record, &)
           when "content_block_stop" then stop_block(record, &)
@@ -39,9 +40,13 @@ module Mistri
         # reading as a cancellation.
         def finish(&emit)
           return fail_stream(@error, &emit) if @error
-          return fail_stream(refusal_error, &emit) if @refused
+          if @refused
+            return fail_stream(refusal_error,
+                               usage_known: @done && @usage_authoritative, &emit)
+          end
           return fail_stream("stream ended without message_stop", &emit) unless @done
 
+          invalidate_cost unless @usage_authoritative
           @message = assemble(stop_reason: @stop_reason || StopReason::STOP)
           emit&.call(Event.new(type: :done, reason: @message.stop_reason, message: @message))
           @message
@@ -49,6 +54,7 @@ module Mistri
 
         def abort(&emit)
           finalize_current
+          invalidate_cost
           @message = assemble(stop_reason: StopReason::ABORTED, error_message: "aborted")
           emit&.call(Event.new(type: :error, reason: StopReason::ABORTED, message: @message,
                                error_message: "aborted"))
@@ -63,8 +69,9 @@ module Mistri
           klass.new(message)
         end
 
-        def fail_stream(reason, &emit)
+        def fail_stream(reason, usage_known: false, &emit)
           finalize_current
+          invalidate_cost unless usage_known
           text = case reason
                  when ProviderError then "#{reason.class}: #{reason.describe}"
                  when Exception then "#{reason.class}: #{reason.message}"
@@ -82,6 +89,12 @@ module Mistri
         Builder = Struct.new(:kind, :index, :text, :json, :signature, :id, :name, :redacted)
 
         private
+
+        def message_start(record)
+          raw = record.dig("message", "usage")
+          @service_tier = raw&.fetch("service_tier", nil)
+          @usage = priced(parse_usage(raw))
+        end
 
         def start_block(record, &)
           block = record["content_block"] || {}
@@ -144,7 +157,10 @@ module Mistri
           # message_delta usage is cumulative; merge output counts over the
           # opening snapshot rather than summing.
           output = record.dig("usage", "output_tokens")
-          @usage = priced(@usage.with(output: output.to_i)) if output
+          return unless output
+
+          @usage = priced(@usage.with(output: output.to_i))
+          @usage_authoritative = true
         end
 
         def finalize_current
@@ -209,7 +225,7 @@ module Mistri
         end
 
         def parse_usage(raw)
-          return Usage.zero unless raw
+          return Usage.new unless raw
 
           cache_creation = raw["cache_creation"] || {}
           Usage.new(input: raw["input_tokens"].to_i, output: raw["output_tokens"].to_i,
@@ -218,7 +234,17 @@ module Mistri
                     cache_write_1h: cache_creation["ephemeral_1h_input_tokens"].to_i)
         end
 
-        def priced(usage) = @rates ? usage.with_cost(@rates) : usage
+        def priced(usage)
+          return usage unless @catalog_pricing
+          return usage unless @service_tier == "standard"
+
+          rates = Models.rates(@model, usage:, at: @pricing_at)
+          rates ? usage.with_cost(rates) : usage
+        end
+
+        def invalidate_cost
+          @usage = @usage.with(cost: @usage.cost.with(known: false))
+        end
       end
     end
   end

--- a/lib/mistri/providers/fake.rb
+++ b/lib/mistri/providers/fake.rb
@@ -26,9 +26,14 @@ module Mistri
 
       def initialize(turns: [], chunk_size: 12)
         @turns = turns.map { |turn| turn.transform_keys(&:to_sym) }
+        @prices_usage = @turns.all? do |turn|
+          !turn[:usage] || turn[:usage].cost.known?
+        end
         @chunk_size = [chunk_size, 1].max
         @requests = []
       end
+
+      def prices_usage? = @prices_usage
 
       def stream(messages: [], **options, &emit)
         # Snapshot the array: the loop appends replies to it in place.
@@ -104,7 +109,7 @@ module Mistri
       def finish_error(turn, blocks, emit)
         error = { "type" => turn.fetch(:error_type, "Error") }
         error["status"] = turn[:status] if turn[:status]
-        message = assemble(blocks, usage: Usage.zero, stop_reason: StopReason::ERROR,
+        message = assemble(blocks, usage: turn[:usage] || Usage.zero, stop_reason: StopReason::ERROR,
                                    error_message: turn[:error], error: error)
         emit&.call(Event.new(type: :error, reason: StopReason::ERROR, message:,
                              error_message: turn[:error]))

--- a/lib/mistri/providers/gemini.rb
+++ b/lib/mistri/providers/gemini.rb
@@ -11,22 +11,32 @@ module Mistri
     # maxOutputTokens is omitted for the same reason: the API defaults to the
     # model's ceiling.
     class Gemini
+      DEFAULT_ORIGIN = "https://generativelanguage.googleapis.com"
       DEFAULT_THINKING = { includeThoughts: true }.freeze
 
       def initialize(api_key:, model: "gemini-2.5-flash",
-                     origin: "https://generativelanguage.googleapis.com",
-                     thinking: DEFAULT_THINKING, **transport_options)
+                     origin: DEFAULT_ORIGIN, thinking: DEFAULT_THINKING,
+                     service_tier: nil, catalog_pricing: nil, **transport_options)
         @api_key = api_key
         @model = model
         @thinking = thinking
+        @service_tier = service_tier
+        @catalog_pricing = catalog_pricing.nil? ? official_origin?(origin) : catalog_pricing
         @transport = Transport.new(origin: origin, **transport_options)
       end
 
       attr_reader :model
 
+      def prices_usage?
+        tier_known = @service_tier.nil? || %w[unspecified standard].include?(@service_tier.to_s)
+        @catalog_pricing && Models.priced?(model) && tier_known
+      end
+
       def stream(messages:, system: nil, tools: [], signal: nil, **overrides, &emit)
         model = overrides.fetch(:model, @model)
-        assembler = Gemini::Assembler.new(model: model)
+        service_tier = overrides.fetch(:service_tier, @service_tier)
+        assembler = Gemini::Assembler.new(model: model, catalog_pricing: @catalog_pricing,
+                                          service_tier:)
         body = build_body(messages, system, tools, overrides)
         path = "/v1beta/models/#{model}:streamGenerateContent?alt=sse"
         outcome = @transport.stream_post(path, body: body, headers: headers,
@@ -43,11 +53,15 @@ module Mistri
 
       private
 
+      def official_origin?(origin) = origin.to_s.delete_suffix("/") == DEFAULT_ORIGIN
+
       def build_body(messages, system, tools, overrides)
         body = { contents: Serializer.contents(messages) }
         instruction = Serializer.system_instruction(system)
         body[:systemInstruction] = instruction if instruction
         body[:tools] = Serializer.tools(tools) if tools.any?
+        service_tier = overrides.fetch(:service_tier, @service_tier)
+        body[:serviceTier] = service_tier if service_tier
         config = {}
         thinking = overrides.fetch(:thinking, @thinking)
         config[:thinkingConfig] = thinking if thinking

--- a/lib/mistri/providers/gemini/assembler.rb
+++ b/lib/mistri/providers/gemini/assembler.rb
@@ -13,12 +13,14 @@ module Mistri
       # Thought signatures ride on individual parts and are captured onto the
       # block they arrived with, verbatim, for replay.
       class Assembler
-        def initialize(model:)
+        def initialize(model:, catalog_pricing: true, service_tier: nil)
           @model = model
-          @rates = Models.rates(model)
+          @catalog_pricing = catalog_pricing
+          @service_tier = service_tier
+          @pricing_at = Time.now
           @blocks = []
           @current = nil
-          @usage = Usage.zero
+          @usage = Usage.new
           @finish_reason = nil
         end
 
@@ -47,7 +49,11 @@ module Mistri
           candidate = record.dig("candidates", 0) || {}
           Array(candidate.dig("content", "parts")).each { |part| fold_part(part, &) }
           @finish_reason = candidate["finishReason"] if candidate["finishReason"]
-          @usage = priced(parse_usage(record["usageMetadata"])) if record["usageMetadata"]
+          if (raw_usage = record["usageMetadata"])
+            @service_tier = raw_usage["serviceTier"] if raw_usage.key?("serviceTier")
+            @usage = priced(parse_usage(raw_usage))
+            @usage_authoritative = true if @finish_reason || @block_reason
+          end
         end
 
         # A stream that ended without a finishReason was truncated, not
@@ -55,11 +61,12 @@ module Mistri
         def finish(&emit)
           return fail_stream(@error, &emit) if @error
           if (refused = blocked)
-            return fail_stream(refused, &emit)
+            return fail_stream(refused, usage_known: @usage_authoritative, &emit)
           end
           return fail_stream("stream ended without a finish reason", &emit) unless @finish_reason
 
           close_current(&emit)
+          invalidate_cost unless @usage_authoritative
           @message = assemble(stop_reason: stop_reason)
           emit&.call(Event.new(type: :done, reason: @message.stop_reason, message: @message))
           @message
@@ -67,11 +74,13 @@ module Mistri
 
         def abort(&)
           close_current
+          invalidate_cost
           terminal(StopReason::ABORTED, "aborted", &)
         end
 
-        def fail_stream(reason, &)
+        def fail_stream(reason, usage_known: false, &)
           close_current
+          invalidate_cost unless usage_known
           text = case reason
                  when ProviderError then "#{reason.class}: #{reason.describe}"
                  when Exception then "#{reason.class}: #{reason.message}"
@@ -194,7 +203,19 @@ module Mistri
                     cache_read: cache_read, reasoning: reasoning)
         end
 
-        def priced(usage) = @rates ? usage.with_cost(@rates) : usage
+        def priced(usage)
+          return usage unless @catalog_pricing
+
+          standard = @service_tier.nil? || %w[unspecified standard].include?(@service_tier.to_s)
+          return usage unless standard
+
+          rates = Models.rates(@model, usage:, at: @pricing_at)
+          rates ? usage.with_cost(rates) : usage
+        end
+
+        def invalidate_cost
+          @usage = @usage.with(cost: @usage.cost.with(known: false))
+        end
       end
     end
   end

--- a/lib/mistri/providers/openai.rb
+++ b/lib/mistri/providers/openai.rb
@@ -11,21 +11,29 @@ module Mistri
     # Provider failures fold into the stream as an error turn rather than
     # raising, matching the Anthropic provider's contract.
     class OpenAI
+      DEFAULT_ORIGIN = "https://api.openai.com"
       DEFAULT_REASONING = { summary: "auto" }.freeze
 
-      def initialize(api_key:, model: "gpt-5.5", origin: "https://api.openai.com",
-                     reasoning: DEFAULT_REASONING, **transport_options)
+      def initialize(api_key:, model: "gpt-5.5", origin: DEFAULT_ORIGIN,
+                     reasoning: DEFAULT_REASONING, service_tier: nil,
+                     catalog_pricing: nil, **transport_options)
         @api_key = api_key
         @model = model
         @reasoning = reasoning
+        @service_tier = service_tier
+        @catalog_pricing = catalog_pricing.nil? ? official_origin?(origin) : catalog_pricing
         @transport = Transport.new(origin: origin, **transport_options)
       end
 
       attr_reader :model
 
+      def prices_usage?
+        @catalog_pricing && Models.priced?(model) && @service_tier.to_s == "default"
+      end
+
       def stream(messages:, system: nil, tools: [], signal: nil, **overrides, &emit)
         model = overrides.fetch(:model, @model)
-        assembler = OpenAI::Assembler.new(model: model)
+        assembler = OpenAI::Assembler.new(model: model, catalog_pricing: @catalog_pricing)
         body = build_body(model, messages, system, tools, overrides)
         outcome = @transport.stream_post("/v1/responses", body: body, headers: headers,
                                                           signal: signal) do |record|
@@ -42,6 +50,8 @@ module Mistri
 
       private
 
+      def official_origin?(origin) = origin.to_s.delete_suffix("/") == DEFAULT_ORIGIN
+
       def build_body(model, messages, system, tools, overrides)
         body = {
           model: model,
@@ -52,6 +62,8 @@ module Mistri
         }
         body[:instructions] = system if system && !system.empty?
         body[:tools] = Serializer.tools(tools) if tools.any?
+        service_tier = overrides.fetch(:service_tier, @service_tier)
+        body[:service_tier] = service_tier if service_tier
         reasoning = overrides.fetch(:reasoning, @reasoning)
         body[:reasoning] = reasoning if reasoning
         if (schema = overrides[:output_schema])

--- a/lib/mistri/providers/openai/assembler.rb
+++ b/lib/mistri/providers/openai/assembler.rb
@@ -12,12 +12,13 @@ module Mistri
       #
       # Unknown event and item types are skipped by contract.
       class Assembler
-        def initialize(model:)
+        def initialize(model:, catalog_pricing: true)
           @model = model
-          @rates = Models.rates(model)
+          @catalog_pricing = catalog_pricing
+          @pricing_at = Time.now
           @blocks = []
           @current = nil
-          @usage = Usage.zero
+          @usage = Usage.new
           @status = nil
           @incomplete_reason = nil
         end
@@ -163,6 +164,7 @@ module Mistri
           @status = response["status"] || "completed"
           @incomplete_reason = response.dig("incomplete_details", "reason")
           @error = failure_error(response["error"]) if @status == "failed"
+          @service_tier = response["service_tier"]
           usage = response["usage"]
           @usage = priced(parse_usage(usage)) if usage
         end
@@ -235,7 +237,13 @@ module Mistri
                     reasoning: output_details["reasoning_tokens"].to_i)
         end
 
-        def priced(usage) = @rates ? usage.with_cost(@rates) : usage
+        def priced(usage)
+          return usage unless @catalog_pricing
+          return usage unless @service_tier == "default"
+
+          rates = Models.rates(@model, usage:, at: @pricing_at)
+          rates ? usage.with_cost(rates) : usage
+        end
       end
     end
   end

--- a/lib/mistri/result.rb
+++ b/lib/mistri/result.rb
@@ -10,7 +10,7 @@ module Mistri
   # Reads delegate to the final message, so result.text works whether the run
   # completed or suspended.
   # output is a task's validated value, nil on plain runs. usage is the
-  # run's own accounting: every persisted turn plus compaction calls, summed
+  # run's own accounting: every provider attempt plus compaction calls, summed
   # (a resumed run counts from the resume; task sums across its fix passes).
   # handed_off marks a run that ended because an ends_turn tool executed:
   # complete, but the final word was the tool's, and whatever comes next (a

--- a/lib/mistri/usage.rb
+++ b/lib/mistri/usage.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json"
+
 module Mistri
   # Token accounting for an assistant turn, and the dollar cost of those tokens.
   #
@@ -9,36 +11,76 @@ module Mistri
   # of `cache_write` held for an hour, which bills at twice the input rate.
   class Usage < Data.define(:input, :output, :cache_read, :cache_write,
                             :cache_write_1h, :reasoning, :cost)
+    # Dollar amounts plus whether every contributing token had known pricing.
+    # Known stays outside the released Data shape so pattern matching and
+    # positional construction remain compatible.
     Cost = Data.define(:input, :output, :cache_read, :cache_write, :total) do
-      def self.zero = new(input: 0.0, output: 0.0, cache_read: 0.0, cache_write: 0.0, total: 0.0)
+      def initialize(input:, output:, cache_read:, cache_write:, total:, known: true)
+        @known = known == true
+        super(input:, output:, cache_read:, cache_write:, total:)
+      end
+
+      def self.zero
+        new(input: 0.0, output: 0.0, cache_read: 0.0, cache_write: 0.0,
+            total: 0.0, known: true)
+      end
+
+      def self.unknown
+        new(input: 0.0, output: 0.0, cache_read: 0.0, cache_write: 0.0,
+            total: 0.0, known: false)
+      end
+
+      def known? = defined?(@known) ? @known : true
+
+      def with(**changes)
+        self.class.new(**to_h, **changes)
+      end
 
       def +(other)
         self.class.new(input: input + other.input, output: output + other.output,
                        cache_read: cache_read + other.cache_read,
                        cache_write: cache_write + other.cache_write,
-                       total: total + other.total)
+                       total: total + other.total, known: known? && other.known?)
       end
+
+      def ==(other) = super && known? == other.known?
+
+      alias_method :eql?, :==
+
+      def hash = [super, known?].hash
+
+      def to_h = super.merge(known: known?)
+
+      def _dump(_level) = JSON.generate(to_h)
+
+      def self._load(payload) = new(**JSON.parse(payload, symbolize_names: true))
     end
 
     def initialize(input: 0, output: 0, cache_read: 0, cache_write: 0,
-                   cache_write_1h: 0, reasoning: 0, cost: Cost.zero)
+                   cache_write_1h: 0, reasoning: 0, cost: Cost.unknown)
       super
     end
 
-    def self.zero = new
+    def self.zero = new(cost: Cost.zero)
 
     def self.from_h(hash)
       h = (hash || {}).transform_keys(&:to_s)
       c = (h["cost"] || {}).transform_keys(&:to_s)
-      new(input: h.fetch("input", 0).to_i, output: h.fetch("output", 0).to_i,
-          cache_read: h.fetch("cache_read", 0).to_i, cache_write: h.fetch("cache_write", 0).to_i,
-          cache_write_1h: h.fetch("cache_write_1h", 0).to_i,
-          reasoning: h.fetch("reasoning", 0).to_i,
-          cost: Cost.new(input: c.fetch("input", 0).to_f, output: c.fetch("output", 0).to_f,
-                         cache_read: c.fetch("cache_read", 0).to_f,
-                         cache_write: c.fetch("cache_write", 0).to_f,
-                         total: c.fetch("total", 0).to_f))
+      counts = { input: h.fetch("input", 0).to_i, output: h.fetch("output", 0).to_i,
+                 cache_read: h.fetch("cache_read", 0).to_i,
+                 cache_write: h.fetch("cache_write", 0).to_i,
+                 cache_write_1h: h.fetch("cache_write_1h", 0).to_i,
+                 reasoning: h.fetch("reasoning", 0).to_i }
+      amounts = { input: c.fetch("input", 0).to_f, output: c.fetch("output", 0).to_f,
+                  cache_read: c.fetch("cache_read", 0).to_f,
+                  cache_write: c.fetch("cache_write", 0).to_f,
+                  total: c.fetch("total", 0).to_f }
+      known = c.fetch("known", false) == true
+      known ||= !c.key?("known") && counts.values.all?(&:zero?) && amounts.values.all?(&:zero?)
+      new(**counts, cost: Cost.new(**amounts, known:))
     end
+
+    def prompt_tokens = input + cache_read + cache_write
 
     def total_tokens = input + output + cache_read + cache_write
 
@@ -54,7 +96,9 @@ module Mistri
         cache_read: rate(rates, :cache_read) * cache_read,
         cache_write: (rate(rates, :cache_write) * short) + (long_write_rate(rates) * long)
       }
-      with(cost: Cost.new(**computed, total: computed.values.sum))
+      with(cost: Cost.new(**computed,
+                          total: computed.values.sum,
+                          known: rates_cover?(rates, short, long)))
     end
 
     def +(other)
@@ -74,6 +118,14 @@ module Mistri
 
     def long_write_rate(rates)
       rates.key?(:cache_write_1h) ? rate(rates, :cache_write_1h) : rate(rates, :input) * 2
+    end
+
+    def rates_cover?(rates, short, long)
+      (input.zero? || rates.key?(:input)) &&
+        (output.zero? || rates.key?(:output)) &&
+        (cache_read.zero? || rates.key?(:cache_read)) &&
+        (short.zero? || rates.key?(:cache_write)) &&
+        (long.zero? || rates.key?(:cache_write_1h) || rates.key?(:input))
     end
   end
 end

--- a/test/test_agent.rb
+++ b/test/test_agent.rb
@@ -94,6 +94,101 @@ class TestAgent < Minitest::Test
     assert_equal "budget_cost", message.error_message
   end
 
+  def test_a_cost_budget_rejects_a_provider_without_known_pricing
+    provider = Mistri::Providers::OpenAI.new(api_key: "test", model: "gpt-next",
+                                             service_tier: "default")
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Agent.new(provider:, budget: Mistri::Budget.new(cost_usd: 1.00))
+    end
+
+    assert_match(/deterministic standard service tier/, error.message)
+    Mistri::Agent.new(provider:)
+  ensure
+    provider&.close
+  end
+
+  def test_a_cost_budget_rejects_nondeterministic_service_tier_policy
+    provider = Mistri::Providers::OpenAI.new(api_key: "test", service_tier: "flex")
+
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::Agent.new(provider:, budget: Mistri::Budget.new(cost_usd: 1.00))
+    end
+  ensure
+    provider&.close
+  end
+
+  def test_a_provider_cannot_claim_pricing_then_return_unknown_cost
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "done" }])
+    provider.define_singleton_method(:prices_usage?) { true }
+    provider.define_singleton_method(:stream) do |**_options|
+      Mistri::Message.assistant(content: "done", stop_reason: :stop)
+    end
+    agent = Mistri::Agent.new(provider:, budget: Mistri::Budget.new(cost_usd: 1.00))
+
+    error = assert_raises(Mistri::BudgetError) { agent.run("go") }
+    entry = agent.session.entries.find { |item| item["type"] == "unpriced_attempt" }
+
+    refute_predicate error.usage.cost, :known?
+    assert_equal "done", error.provider_message.text
+    assert_equal "turn", entry["kind"]
+  end
+
+  def test_compaction_cost_is_checked_before_the_next_model_turn
+    session = session_ready_for_compaction
+    summary_usage = Mistri::Usage.new(input: 1_000_000).with_cost(input: 2.0)
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "## Goal\nContinue.",
+                                                     usage: summary_usage },
+                                                   { text: "must not run" }])
+    agent = Mistri::Agent.new(provider:, session:, budget: Mistri::Budget.new(cost_usd: 1.00),
+                              compaction: Mistri::Compaction.new(window: 1_000, reserve: 50,
+                                                                 keep_recent: 10))
+
+    result = agent.run("next")
+
+    assert_predicate result, :stopped_by_budget?
+    assert_equal "budget_cost", result.message.error_message
+    assert_equal 1, provider.requests.length
+  end
+
+  def test_a_failed_compaction_attempt_still_counts_toward_run_usage
+    failed_usage = Mistri::Usage.new(input: 1_000).with_cost(input: 1.0)
+    turn_usage = Mistri::Usage.new(input: 500).with_cost(input: 1.0)
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { error: "summary failed", usage: failed_usage },
+                                             { text: "done", usage: turn_usage }
+                                           ])
+    agent = Mistri::Agent.new(provider:, session: session_ready_for_compaction,
+                              budget: Mistri::Budget.new(cost_usd: 1.00),
+                              compaction: compacting_settings)
+
+    result = agent.run("next")
+
+    assert_equal 1_500, result.usage.input
+    assert_in_delta 0.0015, result.usage.cost.total
+    assert_equal 2, provider.requests.length
+  end
+
+  def test_a_failed_compaction_without_usage_fails_a_cost_budget_closed
+    calls = 0
+    provider = Mistri::Providers::Fake.new
+    provider.define_singleton_method(:stream) do |**_options|
+      calls += 1
+      Mistri::Message.assistant(content: "", stop_reason: :error,
+                                error_message: "summary failed")
+    end
+    agent = Mistri::Agent.new(provider:, session: session_ready_for_compaction,
+                              budget: Mistri::Budget.new(cost_usd: 1.00),
+                              compaction: compacting_settings)
+
+    error = assert_raises(Mistri::BudgetError) { agent.run("next") }
+    entry = agent.session.entries.find { |item| item["type"] == "unpriced_attempt" }
+
+    refute_predicate error.usage.cost, :known?
+    assert_equal "compaction", entry["kind"]
+    assert_equal 1, calls
+  end
+
   def test_empty_input_and_duplicate_tools_fail_loudly
     provider = Mistri::Providers::Fake.new
     ping = Mistri::Tool.define("ping", "Ping.") { "pong" }
@@ -159,5 +254,22 @@ class TestAgent < Minitest::Test
 
     assert_equal 1, result.output["x"]
     assert_equal 100, result.usage.input, "both passes count"
+  end
+
+  private
+
+  def session_ready_for_compaction
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    session.append_message(Mistri::Message.user("old context " * 100))
+    session.append_message(Mistri::Message.assistant(content: "old answer " * 100,
+                                                     stop_reason: :stop,
+                                                     usage: Mistri::Usage.new(input: 900,
+                                                                              output: 100)))
+    session.append_message(Mistri::Message.user("keep this"))
+    session
+  end
+
+  def compacting_settings
+    Mistri::Compaction.new(window: 1_000, reserve: 50, keep_recent: 10)
   end
 end

--- a/test/test_agent_retry.rb
+++ b/test/test_agent_retry.rb
@@ -39,6 +39,75 @@ class TestAgentRetry < Minitest::Test
            "the failed attempt never becomes a message")
   end
 
+  def test_retry_attempt_usage_is_included_in_the_run_total
+    failed = Mistri::Usage.new(input: 1_000_000).with_cost(input: 1.0)
+    recovered = Mistri::Usage.new(input: 1_000_000).with_cost(input: 1.0)
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { error: "overloaded", status: 529, usage: failed },
+                                             { text: "recovered", usage: recovered }
+                                           ])
+    agent = Mistri::Agent.new(provider:, retries: FAST,
+                              budget: Mistri::Budget.new(cost_usd: 1.50))
+
+    result = agent.run("go")
+    retry_entry = agent.session.entries.find { |entry| entry["type"] == "retry" }
+
+    assert_predicate result, :completed?, "the ceiling is soft through the completed turn"
+    assert_in_delta 2.0, result.usage.cost.total
+    assert_in_delta 1.0, retry_entry.dig("usage", "cost", "total")
+  end
+
+  def test_a_retry_without_usage_records_that_its_cost_is_unknown
+    turns = [
+      Mistri::Message.assistant(stop_reason: :error, error_message: "overloaded",
+                                error: { "type" => "OverloadedError" }),
+      Mistri::Message.assistant(content: "recovered", stop_reason: :stop,
+                                usage: Mistri::Usage.zero)
+    ]
+    provider = Mistri::Providers::Fake.new
+    provider.define_singleton_method(:stream) { |**_options| turns.shift }
+    agent = Mistri::Agent.new(provider:, retries: FAST)
+
+    result = agent.run("go")
+    retry_entry = agent.session.entries.find { |entry| entry["type"] == "retry" }
+
+    refute_predicate result.usage.cost, :known?
+    refute retry_entry.dig("usage", "cost", "known")
+  end
+
+  def test_a_cost_budget_does_not_retry_an_unmetered_failure
+    calls = 0
+    turns = [
+      Mistri::Message.assistant(stop_reason: :error, error_message: "overloaded",
+                                error: { "type" => "OverloadedError" }),
+      Mistri::Message.assistant(content: "must not run", stop_reason: :stop,
+                                usage: Mistri::Usage.zero)
+    ]
+    provider = Mistri::Providers::Fake.new
+    provider.define_singleton_method(:stream) do |**_options|
+      calls += 1
+      turns.shift
+    end
+    agent = Mistri::Agent.new(provider:, retries: FAST,
+                              budget: Mistri::Budget.new(cost_usd: 1.00))
+    events = []
+
+    error = assert_raises(Mistri::BudgetError) do
+      agent.run("go") { |event| events << event }
+    end
+    entry = agent.session.entries.find { |item| item["type"] == "unpriced_attempt" }
+
+    assert_match(/not retrying/, error.message)
+    assert_equal "overloaded", error.provider_message.error_message
+    refute_predicate error.usage.cost, :known?
+    assert_equal "turn", entry["kind"]
+    assert_equal 1, events.count(&:terminal?)
+    assert_equal Mistri::StopReason::BUDGET, events.last.reason
+    assert_equal Mistri::StopReason::BUDGET, agent.session.messages.last.stop_reason
+    assert_equal 1, calls
+    refute(agent.session.entries.any? { |entry| entry["type"] == "retry" })
+  end
+
   # Providers intermittently finish with an empty candidate: no text, no
   # tool calls, nothing. That is never a real answer, so it retries like a
   # transient failure instead of ending the run in silence.

--- a/test/test_anthropic_assembler.rb
+++ b/test/test_anthropic_assembler.rb
@@ -89,11 +89,12 @@ class TestAnthropicAssembler < Minitest::Test
     assert_equal "opaque", message.content.first.signature
   end
 
-  def test_usage_prices_from_the_catalog_and_unknown_models_stay_zero
+  def test_usage_prices_from_the_catalog_and_unknown_models_stay_unknown
     message = drive([], [
                       { "type" => "message_start",
                         "message" => { "usage" => { "input_tokens" => 1000,
-                                                    "cache_read_input_tokens" => 2000 } } },
+                                                    "cache_read_input_tokens" => 2000,
+                                                    "service_tier" => "standard" } } },
                       { "type" => "message_delta", "delta" => { "stop_reason" => "end_turn" },
                         "usage" => { "output_tokens" => 500 } },
                       { "type" => "message_stop" }
@@ -103,6 +104,7 @@ class TestAnthropicAssembler < Minitest::Test
                 (rates[:output] * 500)) / 1_000_000.0
 
     assert_operator message.usage.cost.total, :>, 0
+    assert_predicate message.usage.cost, :known?
     assert_in_delta expected, message.usage.cost.total,
                     1e-9, "the delta's output count must be repriced, not left stale"
 
@@ -111,7 +113,68 @@ class TestAnthropicAssembler < Minitest::Test
                    "message" => { "usage" => { "input_tokens" => 1000 } } })
     unknown.feed({ "type" => "message_stop" })
 
-    assert_in_delta 0.0, unknown.finish.usage.cost.total
+    refute_predicate unknown.finish.usage.cost, :known?
+  end
+
+  def test_usage_is_unknown_without_catalog_pricing_or_wire_usage
+    unpriced = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8",
+                                                           catalog_pricing: false)
+    unpriced.feed({ "type" => "message_start",
+                    "message" => { "usage" => { "input_tokens" => 1000 } } })
+    unpriced.feed({ "type" => "message_stop" })
+
+    refute_predicate unpriced.finish.usage.cost, :known?
+
+    missing = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")
+    missing.feed({ "type" => "message_stop" })
+
+    refute_predicate missing.finish.usage.cost, :known?
+  end
+
+  def test_priority_service_tier_usage_is_unknown
+    priority = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")
+    priority.feed({ "type" => "message_start",
+                    "message" => { "usage" => { "input_tokens" => 1000,
+                                                "service_tier" => "priority" } } })
+    priority.feed({ "type" => "message_stop" })
+
+    refute_predicate priority.finish.usage.cost, :known?
+  end
+
+  def test_usage_without_a_reported_service_tier_is_unknown
+    assembler = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")
+    assembler.feed({ "type" => "message_start",
+                     "message" => { "usage" => { "input_tokens" => 1000 } } })
+    assembler.feed({ "type" => "message_stop" })
+
+    refute_predicate assembler.finish.usage.cost, :known?
+  end
+
+  def test_a_truncated_stream_keeps_partial_dollars_but_marks_them_unknown
+    assembler = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")
+    assembler.feed({ "type" => "message_start",
+                     "message" => { "usage" => { "input_tokens" => 1000,
+                                                 "service_tier" => "standard" } } })
+
+    message = assembler.finish
+
+    assert_equal :error, message.stop_reason
+    assert_operator message.usage.cost.total, :>, 0
+    refute_predicate message.usage.cost, :known?
+  end
+
+  def test_message_stop_without_final_output_usage_is_unpriced
+    assembler = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")
+    assembler.feed({ "type" => "message_start",
+                     "message" => { "usage" => { "input_tokens" => 1000,
+                                                 "service_tier" => "standard" } } })
+    assembler.feed({ "type" => "message_stop" })
+
+    message = assembler.finish
+
+    assert_equal :stop, message.stop_reason
+    assert_equal 0, message.usage.output
+    refute_predicate message.usage.cost, :known?
   end
 
   # The API's own guidance for a refusal is a different model, never a

--- a/test/test_anthropic_live.rb
+++ b/test/test_anthropic_live.rb
@@ -10,7 +10,8 @@ class TestAnthropicLive < Minitest::Test
   end
 
   def test_a_text_turn_streams_and_lands
-    provider = Mistri::Providers::Anthropic.new(api_key: ENV.fetch("ANTHROPIC_API_KEY"))
+    provider = Mistri::Providers::Anthropic.new(api_key: ENV.fetch("ANTHROPIC_API_KEY"),
+                                                service_tier: "standard_only")
     events = []
 
     message = provider.stream(
@@ -23,12 +24,14 @@ class TestAnthropicLive < Minitest::Test
     assert events.any? { |e| e.type == :text_delta }, "expected streamed text deltas"
     assert_operator message.usage.output, :>, 0
     assert_operator message.usage.cost.total, :>, 0, "catalog pricing must ride live usage"
+    assert_predicate message.usage.cost, :known?
   ensure
     provider&.close
   end
 
   def test_a_tool_call_turn_stops_for_tool_use_with_parsed_arguments
-    provider = Mistri::Providers::Anthropic.new(api_key: ENV.fetch("ANTHROPIC_API_KEY"))
+    provider = Mistri::Providers::Anthropic.new(api_key: ENV.fetch("ANTHROPIC_API_KEY"),
+                                                service_tier: "standard_only")
     events = []
     weather = { name: "get_weather", description: "Current weather for a city.",
                 input_schema: { type: "object", properties: { city: { type: "string" } },

--- a/test/test_budget.rb
+++ b/test/test_budget.rb
@@ -8,6 +8,7 @@ class TestBudget < Minitest::Test
 
     assert_predicate budget, :none?
     assert_nil budget.exceeded(turns: 999, usage: Mistri::Usage.zero, elapsed: 99_999)
+    refute_predicate budget, :cost?
   end
 
   def test_each_ceiling_reports_its_own_reason
@@ -19,5 +20,14 @@ class TestBudget < Minitest::Test
     assert_equal :wall_clock,
                  Mistri::Budget.new(wall_clock: 60).exceeded(turns: 0, usage: usage, elapsed: 61)
     assert_nil Mistri::Budget.new(turns: 4, cost_usd: 0.006).exceeded(turns: 3, usage: usage)
+    assert_predicate Mistri::Budget.new(cost_usd: 1), :cost?
+  end
+
+  def test_a_cost_ceiling_rejects_unknown_cost
+    budget = Mistri::Budget.new(cost_usd: 1)
+
+    assert_raises(Mistri::BudgetError) do
+      budget.exceeded(turns: 0, usage: Mistri::Usage.new(input: 1))
+    end
   end
 end

--- a/test/test_gemini_assembler.rb
+++ b/test/test_gemini_assembler.rb
@@ -64,20 +64,21 @@ class TestGeminiAssembler < Minitest::Test
     assert_equal 500, failed.error["status"], "the wire code rides as a status"
   end
 
-  def test_usage_prices_from_the_catalog_and_unknown_models_stay_zero
+  def test_usage_prices_from_the_catalog_and_unknown_models_stay_unknown
     message = drive([], [
-                      { "candidates" => [{ "content" => { "parts" => [{ "text" => "hi" }] } }],
+                      { "candidates" => [{ "content" => { "parts" => [{ "text" => "hi" }] },
+                                           "finishReason" => "STOP" }],
                         "usageMetadata" => { "promptTokenCount" => 1000,
                                              "cachedContentTokenCount" => 400,
                                              "candidatesTokenCount" => 100,
-                                             "thoughtsTokenCount" => 50 } },
-                      { "candidates" => [{ "finishReason" => "STOP" }] }
+                                             "thoughtsTokenCount" => 50 } }
                     ])
     rates = Mistri::Models.rates("gemini-2.5-flash")
     expected = ((rates[:input] * 600) + (rates[:cache_read] * 400) +
                 (rates[:output] * 150)) / 1_000_000.0
 
     assert_operator message.usage.cost.total, :>, 0
+    assert_predicate message.usage.cost, :known?
     assert_in_delta expected, message.usage.cost.total, 1e-9
 
     unknown = Mistri::Providers::Gemini::Assembler.new(model: "gemini-hypothetical")
@@ -85,7 +86,62 @@ class TestGeminiAssembler < Minitest::Test
                    "usageMetadata" => { "promptTokenCount" => 1000,
                                         "candidatesTokenCount" => 200 } })
 
-    assert_in_delta 0.0, unknown.finish.usage.cost.total
+    refute_predicate unknown.finish.usage.cost, :known?
+
+    unpriced = Mistri::Providers::Gemini::Assembler.new(model: "gemini-2.5-flash",
+                                                        catalog_pricing: false)
+    unpriced.feed({ "candidates" => [{ "finishReason" => "STOP" }],
+                    "usageMetadata" => { "promptTokenCount" => 1000,
+                                         "candidatesTokenCount" => 200 } })
+
+    refute_predicate unpriced.finish.usage.cost, :known?
+
+    missing = Mistri::Providers::Gemini::Assembler.new(model: "gemini-2.5-flash")
+    missing.feed({ "candidates" => [{ "finishReason" => "STOP" }] })
+
+    refute_predicate missing.finish.usage.cost, :known?
+  end
+
+  def test_pro_usage_is_priced_at_the_higher_request_tier
+    assembler = Mistri::Providers::Gemini::Assembler.new(model: "gemini-2.5-pro")
+    assembler.feed({ "candidates" => [{ "finishReason" => "STOP" }],
+                     "usageMetadata" => { "promptTokenCount" => 200_001,
+                                          "candidatesTokenCount" => 100 } })
+    usage = assembler.finish.usage
+
+    assert_in_delta 0.5000025, usage.cost.input, 1e-9
+    assert_in_delta 0.0015, usage.cost.output, 1e-9
+  end
+
+  def test_nonstandard_service_tier_usage_is_unknown
+    assembler = Mistri::Providers::Gemini::Assembler.new(model: "gemini-2.5-flash")
+    assembler.feed({ "candidates" => [{ "finishReason" => "STOP" }],
+                     "usageMetadata" => { "promptTokenCount" => 1000,
+                                          "candidatesTokenCount" => 100,
+                                          "serviceTier" => "priority" } })
+
+    refute_predicate assembler.finish.usage.cost, :known?
+
+    requested = Mistri::Providers::Gemini::Assembler.new(model: "gemini-2.5-flash",
+                                                         service_tier: "flex")
+    requested.feed({ "candidates" => [{ "finishReason" => "STOP" }],
+                     "usageMetadata" => { "promptTokenCount" => 1000,
+                                          "candidatesTokenCount" => 100 } })
+
+    refute_predicate requested.finish.usage.cost, :known?
+  end
+
+  def test_a_truncated_stream_keeps_partial_dollars_but_marks_them_unknown
+    assembler = Mistri::Providers::Gemini::Assembler.new(model: "gemini-2.5-flash")
+    assembler.feed({ "usageMetadata" => { "promptTokenCount" => 1000,
+                                          "candidatesTokenCount" => 100,
+                                          "serviceTier" => "standard" } })
+
+    message = assembler.finish
+
+    assert_equal :error, message.stop_reason
+    assert_operator message.usage.cost.total, :>, 0
+    refute_predicate message.usage.cost, :known?
   end
 
   # Verdict finish reasons are the provider's ruling on the content; the

--- a/test/test_gemini_live.rb
+++ b/test/test_gemini_live.rb
@@ -23,6 +23,7 @@ class TestGeminiLive < Minitest::Test
     assert(events.any? { |e| e.type == :text_delta })
     assert_operator message.usage.output, :>, 0
     assert_operator message.usage.cost.total, :>, 0, "catalog pricing must ride live usage"
+    assert_predicate message.usage.cost, :known?
   ensure
     provider&.close
   end

--- a/test/test_model_matrix_live.rb
+++ b/test/test_model_matrix_live.rb
@@ -6,14 +6,13 @@ require_relative "test_helper"
 # that must land :stop with text and non-zero usage. This is what proves a
 # catalog entry is real, its default thinking mode is accepted, and its wire
 # path works end to end. Run with MISTRI_LIVE=1.
-#
-# A model the account cannot reach (a preview not enabled on this key) skips
-# with the provider's message rather than failing the suite.
 class TestModelMatrixLive < Minitest::Test
   PROVIDERS = {
-    anthropic: { klass: Mistri::Providers::Anthropic, key: "ANTHROPIC_API_KEY" },
-    openai: { klass: Mistri::Providers::OpenAI, key: "OPENAI_API_KEY" },
-    gemini: { klass: Mistri::Providers::Gemini, key: "GEMINI_API_KEY" }
+    anthropic: { klass: Mistri::Providers::Anthropic, key: "ANTHROPIC_API_KEY",
+                 options: { service_tier: "standard_only" } },
+    openai: { klass: Mistri::Providers::OpenAI, key: "OPENAI_API_KEY",
+              options: { service_tier: "default" } },
+    gemini: { klass: Mistri::Providers::Gemini, key: "GEMINI_API_KEY", options: {} }
   }.freeze
 
   Mistri::Models::CATALOG.each_value do |model|
@@ -29,21 +28,20 @@ class TestModelMatrixLive < Minitest::Test
   private
 
   def verify_model(model, config)
-    provider = config[:klass].new(api_key: ENV.fetch(config[:key]), model: model.id)
+    provider = config[:klass].new(api_key: ENV.fetch(config[:key]), model: model.id,
+                                  **config[:options])
     events = []
     message = provider.stream(
       messages: [Mistri::Message.user("Reply with exactly: ok")]
     ) { |event| events << event }
 
-    skip "#{model.id} unreachable: #{message.error_message}" if message.stop_reason == :error
-
     assert_equal :stop, message.stop_reason, "#{model.id} did not finish cleanly"
     assert_match(/ok/i, message.text, "#{model.id} produced no usable text")
     assert(events.any? { |e| e.type == :text_delta }, "#{model.id} did not stream")
     assert_operator message.usage.output, :>, 0, "#{model.id} reported no output tokens"
-  # The unreachable-model skip fires after the provider opens, so closing its
-  # connection in ensure is intended.
-  ensure # rubocop:disable Minitest/SkipEnsure
+    assert_predicate message.usage.cost, :known?
+    assert_operator message.usage.cost.total, :>, 0, "#{model.id} usage was not priced"
+  ensure
     provider&.close
   end
 end

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -8,6 +8,17 @@ class TestModels < Minitest::Test
   def test_known_models_carry_their_output_ceiling
     assert_equal 128_000, Mistri::Models.max_output("claude-opus-4-8")
     assert_equal 64_000, Mistri::Models.max_output("claude-haiku-4-5")
+    assert_equal %i[id provider max_output context_window thinking],
+                 Mistri::Models::Model.members
+  end
+
+  def test_pricing_participates_in_model_value_semantics_and_marshalling
+    model = Mistri::Models.find("gpt-5.5")
+    unpriced = model.with(pricing: [])
+
+    refute_equal model, unpriced
+    refute_equal model.hash, unpriced.hash
+    assert_equal model, Marshal.load(Marshal.dump(model))
   end
 
   def test_dated_aliases_resolve_and_unknown_ids_pass_through
@@ -24,8 +35,113 @@ class TestModels < Minitest::Test
     assert_predicate rates, :frozen?
 
     assert_nil Mistri::Models.rates("claude-next-9000"), "unknown models carry no rates"
-    assert(Mistri::Models::CATALOG.each_value.all?(&:rates),
+    assert(Mistri::Models::CATALOG.each_value.all?(&:priced?),
            "every catalogued model carries verified rates")
+  end
+
+  def test_openai_long_context_pricing_uses_each_requests_prompt_size
+    boundary = Mistri::Usage.new(input: 200_000, cache_read: 72_000)
+    over = boundary.with(cache_read: 72_001)
+
+    { "gpt-5.5" => [5.0, 10.0, 1.0, 45.0],
+      "gpt-5.4" => [2.5, 5.0, 0.5, 22.5] }.each do |model, values|
+      base, higher, cache_read, output = values
+
+      assert_in_delta base, Mistri::Models.rates(model, usage: boundary)[:input]
+      rates = Mistri::Models.rates(model, usage: over)
+
+      assert_in_delta higher, rates[:input]
+      assert_in_delta cache_read, rates[:cache_read]
+      assert_in_delta output, rates[:output]
+    end
+  end
+
+  def test_gemini_pro_long_context_pricing_starts_above_200k
+    boundary = Mistri::Usage.new(input: 100_000, cache_read: 100_000)
+    over = boundary.with(cache_read: 100_001)
+
+    { "gemini-3.1-pro-preview" => [2.0, 4.0, 0.4, 18.0],
+      "gemini-2.5-pro" => [1.25, 2.5, 0.25, 15.0] }.each do |model, values|
+      base, higher, cache_read, output = values
+
+      assert_in_delta base, Mistri::Models.rates(model, usage: boundary)[:input]
+      rates = Mistri::Models.rates(model, usage: over)
+
+      assert_in_delta higher, rates[:input]
+      assert_in_delta cache_read, rates[:cache_read]
+      assert_in_delta output, rates[:output]
+    end
+  end
+
+  def test_flat_pricing_does_not_change_for_large_prompts
+    usage = Mistri::Usage.new(input: 900_000)
+
+    assert_equal Mistri::Models.rates("gpt-5-nano"),
+                 Mistri::Models.rates("gpt-5-nano", usage:)
+    assert_equal Mistri::Models.rates("gemini-3.5-flash"),
+                 Mistri::Models.rates("gemini-3.5-flash", usage:)
+  end
+
+  def test_sonnet_5_pricing_changes_at_the_published_instant
+    before = Mistri::Models.rates("claude-sonnet-5", at: Time.utc(2026, 8, 31, 23, 59, 59))
+    after = Mistri::Models.rates("claude-sonnet-5", at: Time.utc(2026, 9, 1))
+
+    assert_in_delta 2.0, before[:input]
+    assert_in_delta 10.0, before[:output]
+    assert_in_delta 3.0, after[:input]
+    assert_in_delta 15.0, after[:output]
+  end
+
+  def test_catalog_pricing_requires_an_official_origin_or_explicit_opt_in
+    configurations = [
+      [Mistri::Providers::Anthropic, Mistri::Providers::Anthropic::DEFAULT_ORIGIN,
+       { service_tier: "standard_only" }],
+      [Mistri::Providers::OpenAI, Mistri::Providers::OpenAI::DEFAULT_ORIGIN,
+       { service_tier: "default" }],
+      [Mistri::Providers::Gemini, Mistri::Providers::Gemini::DEFAULT_ORIGIN, {}]
+    ]
+    providers = configurations.flat_map do |klass, origin, options|
+      [klass.new(api_key: "test", origin: "#{origin}/", **options),
+       klass.new(api_key: "test", origin: "https://gateway.example", **options),
+       klass.new(api_key: "test", origin: "https://gateway.example",
+                 catalog_pricing: true, **options)]
+    end
+
+    providers.each_slice(3) do |official, custom, opted_in|
+      assert_predicate official, :prices_usage?
+      refute_predicate custom, :prices_usage?
+      assert_predicate opted_in, :prices_usage?
+    end
+  ensure
+    providers&.each(&:close)
+  end
+
+  def test_cost_budget_readiness_requires_a_deterministic_standard_tier
+    cases = [
+      [Mistri::Providers::Anthropic, nil, false],
+      [Mistri::Providers::Anthropic, "auto", false],
+      [Mistri::Providers::Anthropic, "priority", false],
+      [Mistri::Providers::Anthropic, "standard_only", true],
+      [Mistri::Providers::OpenAI, nil, false],
+      [Mistri::Providers::OpenAI, "auto", false],
+      [Mistri::Providers::OpenAI, "flex", false],
+      [Mistri::Providers::OpenAI, "priority", false],
+      [Mistri::Providers::OpenAI, "default", true],
+      [Mistri::Providers::Gemini, nil, true],
+      [Mistri::Providers::Gemini, "", false],
+      [Mistri::Providers::Gemini, "unspecified", true],
+      [Mistri::Providers::Gemini, "standard", true],
+      [Mistri::Providers::Gemini, "flex", false],
+      [Mistri::Providers::Gemini, "priority", false]
+    ]
+    providers = cases.map do |klass, tier, expected|
+      provider = klass.new(api_key: "test", service_tier: tier)
+
+      assert_equal expected, provider.prices_usage?, "#{klass.name} #{tier.inspect}"
+      provider
+    end
+  ensure
+    providers&.each(&:close)
   end
 
   def test_the_provider_sends_the_model_ceiling_as_max_tokens
@@ -34,17 +150,74 @@ class TestModels < Minitest::Test
       server.sse_data(socket, { "type" => "message_stop" })
       server.finish_sse(socket)
     end
-    provider = Mistri::Providers::Anthropic.new(api_key: "test", origin: server.origin)
+    automatic = Mistri::Providers::Anthropic.new(api_key: "test", origin: server.origin,
+                                                 catalog_pricing: true)
+    standard = Mistri::Providers::Anthropic.new(api_key: "test", origin: server.origin,
+                                                catalog_pricing: true,
+                                                service_tier: "standard_only")
 
     seen = []
-    provider.stream(messages: [Mistri::Message.user("hi")]) { |event| seen << event }
+    automatic.stream(messages: [Mistri::Message.user("hi")]) { |event| seen << event }
+    standard.stream(messages: [Mistri::Message.user("hi")])
     body = JSON.parse(server.requests.first[:body])
+    standard_body = JSON.parse(server.requests.last[:body])
 
     assert_equal 128_000, body["max_tokens"]
     assert_equal "claude-opus-4-8", body["model"]
+    refute body.key?("service_tier"), "catalog pricing must not choose host policy"
+    assert_equal "standard_only", standard_body["service_tier"]
     assert_equal({ "type" => "adaptive", "display" => "summarized" }, body["thinking"])
   ensure
-    provider&.close
+    automatic&.close
+    standard&.close
+    server&.stop
+  end
+
+  def test_service_tiers_are_explicit_provider_policy
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.start_sse(socket)
+      server.sse_data(socket, { "type" => "response.completed",
+                                "response" => { "status" => "completed", "usage" => {} } })
+      server.finish_sse(socket)
+    end
+    automatic = Mistri::Providers::OpenAI.new(api_key: "test", origin: server.origin,
+                                              catalog_pricing: true)
+    standard = Mistri::Providers::OpenAI.new(api_key: "test", origin: server.origin,
+                                             catalog_pricing: true, service_tier: "default")
+
+    automatic.stream(messages: [Mistri::Message.user("hi")])
+    standard.stream(messages: [Mistri::Message.user("hi")])
+    automatic_body, standard_body = server.requests.map { |request| JSON.parse(request[:body]) }
+
+    refute automatic_body.key?("service_tier"), "catalog pricing must not choose host policy"
+    assert_equal "default", standard_body["service_tier"]
+  ensure
+    automatic&.close
+    standard&.close
+    server&.stop
+  end
+
+  def test_gemini_service_tier_is_explicit_provider_policy
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.start_sse(socket)
+      server.sse_data(socket, { "candidates" => [{ "finishReason" => "STOP" }],
+                                "usageMetadata" => { "serviceTier" => "standard" } })
+      server.finish_sse(socket)
+    end
+    automatic = Mistri::Providers::Gemini.new(api_key: "test", origin: server.origin,
+                                              catalog_pricing: true)
+    priority = Mistri::Providers::Gemini.new(api_key: "test", origin: server.origin,
+                                             catalog_pricing: true, service_tier: "priority")
+
+    automatic.stream(messages: [Mistri::Message.user("hi")])
+    priority.stream(messages: [Mistri::Message.user("hi")])
+    automatic_body, priority_body = server.requests.map { |request| JSON.parse(request[:body]) }
+
+    refute automatic_body.key?("serviceTier"), "catalog pricing must not choose host policy"
+    assert_equal "priority", priority_body["serviceTier"]
+  ensure
+    automatic&.close
+    priority&.close
     server&.stop
   end
 end

--- a/test/test_openai_assembler.rb
+++ b/test/test_openai_assembler.rb
@@ -167,11 +167,12 @@ class TestOpenAIAssembler < Minitest::Test
     assert_includes terse.error_message, "the response failed"
   end
 
-  def test_usage_prices_from_the_catalog_and_unknown_models_stay_zero
+  def test_usage_prices_from_the_catalog_and_unknown_models_stay_unknown
     message = drive([], [
                       { "type" => "response.completed",
                         "response" => {
                           "status" => "completed",
+                          "service_tier" => "default",
                           "usage" => { "input_tokens" => 1000,
                                        "input_tokens_details" => { "cached_tokens" => 400 },
                                        "output_tokens" => 200 }
@@ -182,6 +183,7 @@ class TestOpenAIAssembler < Minitest::Test
                 (rates[:output] * 200)) / 1_000_000.0
 
     assert_operator message.usage.cost.total, :>, 0
+    assert_predicate message.usage.cost, :known?
     assert_in_delta expected, message.usage.cost.total, 1e-9
 
     unknown = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-hypothetical")
@@ -190,7 +192,49 @@ class TestOpenAIAssembler < Minitest::Test
                                    "usage" => { "input_tokens" => 1000,
                                                 "output_tokens" => 200 } } })
 
-    assert_in_delta 0.0, unknown.finish.usage.cost.total
+    refute_predicate unknown.finish.usage.cost, :known?
+
+    unpriced = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.5",
+                                                        catalog_pricing: false)
+    unpriced.feed({ "type" => "response.completed",
+                    "response" => { "status" => "completed",
+                                    "usage" => { "input_tokens" => 1000,
+                                                 "output_tokens" => 200 } } })
+
+    refute_predicate unpriced.finish.usage.cost, :known?
+
+    missing = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.5")
+    missing.feed({ "type" => "response.completed", "response" => { "status" => "completed" } })
+
+    refute_predicate missing.finish.usage.cost, :known?
+
+    flex = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.5")
+    flex.feed({ "type" => "response.completed",
+                "response" => { "status" => "completed", "service_tier" => "flex",
+                                "usage" => { "input_tokens" => 1000, "output_tokens" => 200 } } })
+
+    refute_predicate flex.finish.usage.cost, :known?
+  end
+
+  def test_long_context_usage_is_priced_at_the_higher_request_tier
+    assembler = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.5")
+    assembler.feed({ "type" => "response.completed",
+                     "response" => { "status" => "completed", "service_tier" => "default",
+                                     "usage" => { "input_tokens" => 272_001,
+                                                  "output_tokens" => 100 } } })
+    usage = assembler.finish.usage
+
+    assert_in_delta 2.72001, usage.cost.input, 1e-9
+    assert_in_delta 0.0045, usage.cost.output, 1e-9
+  end
+
+  def test_usage_without_a_reported_service_tier_is_unknown
+    assembler = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.5")
+    assembler.feed({ "type" => "response.completed",
+                     "response" => { "status" => "completed",
+                                     "usage" => { "input_tokens" => 1000 } } })
+
+    refute_predicate assembler.finish.usage.cost, :known?
   end
 
   def test_a_stream_that_ends_without_a_terminal_event_is_an_error

--- a/test/test_openai_live.rb
+++ b/test/test_openai_live.rb
@@ -10,7 +10,8 @@ class TestOpenAILive < Minitest::Test
   end
 
   def test_a_text_turn_streams_and_lands
-    provider = Mistri::Providers::OpenAI.new(api_key: ENV.fetch("OPENAI_API_KEY"))
+    provider = Mistri::Providers::OpenAI.new(api_key: ENV.fetch("OPENAI_API_KEY"),
+                                             service_tier: "default")
     events = []
 
     message = provider.stream(
@@ -23,6 +24,7 @@ class TestOpenAILive < Minitest::Test
     assert(events.any? { |e| e.type == :text_delta })
     assert_operator message.usage.output, :>, 0
     assert_operator message.usage.cost.total, :>, 0, "catalog pricing must ride live usage"
+    assert_predicate message.usage.cost, :known?
   ensure
     provider&.close
   end
@@ -31,7 +33,8 @@ class TestOpenAILive < Minitest::Test
   # items must round-trip through our signatures, or the second request 400s
   # on broken pairing.
   def test_a_tool_turn_replays_cleanly_into_a_final_answer
-    provider = Mistri::Providers::OpenAI.new(api_key: ENV.fetch("OPENAI_API_KEY"))
+    provider = Mistri::Providers::OpenAI.new(api_key: ENV.fetch("OPENAI_API_KEY"),
+                                             service_tier: "default")
     weather = { name: "get_weather", description: "Current weather for a city.",
                 input_schema: { type: "object", properties: { city: { type: "string" } },
                                 required: ["city"], additionalProperties: false } }

--- a/test/test_usage.rb
+++ b/test/test_usage.rb
@@ -19,6 +19,28 @@ class TestUsage < Minitest::Test
     assert_equal 1110, total.total_tokens
   end
 
+  def test_prompt_tokens_include_every_input_price_class
+    usage = Mistri::Usage.new(input: 100, cache_read: 200, cache_write: 300, output: 400)
+
+    assert_equal 600, usage.prompt_tokens
+  end
+
+  def test_unpriced_usage_is_unknown_but_zero_usage_is_known
+    refute_predicate Mistri::Usage.new(input: 1).cost, :known?
+    assert_predicate Mistri::Usage.zero.cost, :known?
+    refute_equal Mistri::Usage::Cost.unknown, Mistri::Usage::Cost.zero
+    assert_equal %i[input output cache_read cache_write total], Mistri::Usage::Cost.members
+  end
+
+  def test_aggregate_cost_is_known_only_when_every_turn_is_priced
+    priced = Mistri::Usage.new(input: 10).with_cost(input: 1.0)
+    mixed = priced + Mistri::Usage.new(input: 5)
+
+    assert_predicate priced.cost, :known?
+    refute_predicate mixed.cost, :known?
+    assert_operator mixed.cost.total, :>, 0
+  end
+
   def test_cost_bills_the_1h_cache_write_slice_at_twice_the_input_rate
     usage = Mistri::Usage.new(input: 1_000_000, cache_write: 100, cache_write_1h: 40)
     priced = usage.with_cost(input: 3.0, output: 15.0, cache_write: 3.75)
@@ -29,10 +51,52 @@ class TestUsage < Minitest::Test
     assert_in_delta priced.cost.input + priced.cost.cache_write, priced.cost.total
   end
 
+  def test_a_missing_rate_keeps_cost_unknown
+    usage = Mistri::Usage.new(input: 10, output: 5).with_cost(input: 1.0)
+
+    refute_predicate usage.cost, :known?
+  end
+
   def test_nonzero_costs_survive_a_json_round_trip
     usage = Mistri::Usage.new(input: 10, output: 5, cache_write: 100, cache_write_1h: 40)
                          .with_cost(input: 3.0, output: 15.0, cache_write: 3.75)
 
     assert_equal usage, Mistri::Usage.from_h(JSON.parse(JSON.generate(usage.to_h)))
+  end
+
+  def test_unknown_cost_survives_a_json_round_trip
+    usage = Mistri::Usage.new(input: 10)
+
+    assert_equal usage, Mistri::Usage.from_h(JSON.parse(JSON.generate(usage.to_h)))
+  end
+
+  def test_known_state_survives_a_marshal_round_trip
+    [Mistri::Usage::Cost.zero, Mistri::Usage::Cost.unknown].each do |cost|
+      assert_equal cost, Marshal.load(Marshal.dump(cost))
+    end
+  end
+
+  def test_legacy_cost_without_a_known_marker_is_conservative
+    usage = Mistri::Usage.from_h("input" => 10,
+                                 "cost" => { "input" => 0.1, "total" => 0.1 })
+
+    refute_predicate usage.cost, :known?
+  end
+
+  def test_legacy_serialized_zero_usage_remains_known_zero
+    legacy = { "input" => 0, "output" => 0, "cache_read" => 0, "cache_write" => 0,
+               "cache_write_1h" => 0, "reasoning" => 0,
+               "cost" => { "input" => 0.0, "output" => 0.0, "cache_read" => 0.0,
+                           "cache_write" => 0.0, "total" => 0.0 } }
+
+    assert_equal Mistri::Usage.zero, Mistri::Usage.from_h(legacy)
+  end
+
+  def test_only_a_literal_true_known_marker_is_trusted
+    usage = Mistri::Usage.from_h("input" => 10,
+                                 "cost" => { "input" => 0.1, "total" => 0.1,
+                                             "known" => "false" })
+
+    refute_predicate usage.cost, :known?
   end
 end


### PR DESCRIPTION
## Summary

- Select standard paid direct-API pricing per request, including GPT-5.4/5.5 and Gemini Pro long-context tiers and Sonnet 5's effective-dated rate change.
- Represent unpriced usage explicitly instead of treating it as free, and fail cost budgets closed at configuration or request time.
- Include retry and compaction attempts in run accounting, preserve uncertain attempts for reconciliation, and keep custom origins and service-tier policy host-owned.
- Preserve the released Model and Cost Data shapes and their JSON and Marshal compatibility.

## Contract

Anthropic and OpenAI cost budgets require an explicit deterministic standard tier (`standard_only` and `default`, respectively). Gemini's omitted tier is standard by contract; reported Flex or Priority usage remains unpriced. Cost ceilings remain soft between model-visible turns. An attempted request without trustworthy usage raises `Mistri::BudgetError`, is not retried, and remains visible through the error and an `unpriced_attempt` session entry.

Catalog costs are standard paid list-price estimates. Contracted or regional adjustments and separately billed provider tools remain outside the total. Gemini free-tier usage is conservatively valued at the paid rate.

## Verification

- `bundle exec rake test`: 479 runs, 1,717 assertions, 0 failures
- `bundle exec rubocop`: 163 files, no offenses
- Coverage: 97.01% line, 83.13% branch
- Live streamed model matrix: Claude Haiku 4.5, GPT-5.5, and Gemini 3.1 Pro
- Live cost-budgeted Agent runs on all three providers with known positive cost
- Adversarial review covered accounting completeness, tier policy, compatibility, latency, and false-green tests

## Latency

Pricing adds one clock read when each request assembler is created and a small rate-card lookup when usage arrives. It does not add work to text-delta emission and does not buffer streamed responses.

## Official references

- [OpenAI GPT-5.5](https://developers.openai.com/api/docs/models/gpt-5.5)
- [OpenAI GPT-5.4](https://developers.openai.com/api/docs/models/gpt-5.4)
- [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
- [Anthropic service tiers](https://platform.claude.com/docs/en/api/service-tiers)
- [Gemini pricing](https://ai.google.dev/gemini-api/docs/pricing)
- [Gemini GenerateContent usage and service tiers](https://ai.google.dev/api/generate-content)