### PR TITLE
Make compaction model-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   its partial accounting. Run usage includes every retry and compaction attempt,
   and retry session entries now carry their own usage. Truncated streams preserve
   partial token counts but mark their dollar total unknown.
+- Compaction now uses the published 1M context windows for catalogued Fable,
+  Opus, and Sonnet models and the 1.05M windows for GPT-5.4 and GPT-5.5.
+  Automatic headroom protects a full next output plus framing slack when the
+  provider shares input and output capacity; Gemini's separately published
+  input limit keeps input-only headroom. An explicit `reserve:` still wins as
+  host policy.
+  `Compaction#automatic_reserve?` lets hosts distinguish the default mode from
+  an explicit 16,384-token policy without changing `Compaction#reserve`.
+  Usage reported before the latest compaction no longer makes a fresh summary
+  appear full. A single run can compact repeatedly across tool turns while
+  keeping parallel calls paired with every result. Large tool results are
+  bounded only on the lossy summarizer wire, with their beginning and end
+  retained. That shortening never mutates the stored result or an ordinary
+  request that still replays it. Compacted replay intentionally remains
+  summary plus tail. The live
+  provider harness now proves two compactions, an exact tool-token handoff,
+  and final fact recall inside one run.
 
 ## [0.5.0] - 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -203,18 +203,34 @@ store = Mistri::Stores::ActiveRecord.new(AgentEntry)
 ## Compaction
 
 Long sessions survive their context window: when the conversation grows into
-the reserve headroom, the provider writes a visible structured summary and
-replay continues from it. The full history stays in your store for
+the model's safe headroom, the provider writes a visible structured summary
+and replay continues from it. The full history stays exact in your store for
 transcript views. On by default whenever the model's window is known;
 `compaction: false` disables it.
 
+For a catalogued model, Mistri automatically reserves its full output capacity
+plus 4,096 tokens for framing and estimation when input and output share one
+context window. Gemini publishes independent input and output limits, so its
+automatic input reserve remains 16,384 tokens. An uncatalogued model with a
+host-supplied `window:` also uses that 16,384-token fallback; set `reserve:`
+explicitly when the deployment needs different output headroom. An explicit
+reserve is also a useful quality policy when you prefer an earlier checkpoint
+to counter context rot.
+
 ```ruby
-agent.context_usage   # => { tokens: 141_000, window: 200_000, fraction: 0.705 }
+agent.context_usage   # => { tokens: 141_000, window: 1_000_000, fraction: 0.141 }
 agent.compact         # the manual button
+
+Mistri::Compaction.new(reserve: 64_000) # explicit quality policy
 ```
 
 `:compacting` and `:compaction` events carry the summary, so users see
-exactly what the model still remembers.
+exactly what the model still remembers. A single run can compact between tool
+turns without splitting a tool call from its results. Very large tool results
+are shortened only in the request sent to the summarizer. That shortening
+never mutates the durable result or an ordinary request that still replays it.
+Once compaction commits, replay intentionally becomes the visible summary plus
+its kept tail.
 
 ## Task mode
 

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -135,7 +135,7 @@ module Mistri
     # meters and near-limit warnings from this; window is nil for models the
     # catalog does not know unless Compaction#window supplies one.
     def context_usage
-      tokens = Compaction.context_tokens(@session.messages)
+      tokens = @session.context_tokens
       window = context_window
       { tokens: tokens, window: window,
         fraction: window && (tokens.to_f / window).round(3) }
@@ -196,8 +196,9 @@ module Mistri
     def auto_compact(&)
       return nil unless @compaction
 
-      tokens = Compaction.context_tokens(@session.messages)
-      return nil unless @compaction.needed?(tokens, context_window)
+      tokens = @session.context_tokens
+      return nil unless @compaction.needed?(tokens, context_window,
+                                            max_output: Models.shared_output(@provider.model))
 
       Compactor.call(session: @session, provider: @provider, settings: @compaction, &)
     rescue CompactionError => e

--- a/lib/mistri/compaction.rb
+++ b/lib/mistri/compaction.rb
@@ -14,6 +14,7 @@ module Mistri
   class Compaction
     DEFAULT_RESERVE = 16_384
     DEFAULT_KEEP_RECENT = 20_000
+    OUTPUT_SAFETY = 4_096
     IMAGE_CHARS = 4_800
 
     SUMMARY_PREFACE = "The earlier conversation was compacted. This summary replaces it:"
@@ -21,28 +22,43 @@ module Mistri
     attr_reader :reserve, :keep_recent, :window, :instructions
 
     # window overrides the model catalog's context window (required for
-    # models the catalog does not know). instructions add a host-specific
-    # focus to the summary prompt.
-    def initialize(reserve: DEFAULT_RESERVE, keep_recent: DEFAULT_KEEP_RECENT,
+    # models the catalog does not know). A nil reserve selects automatic
+    # headroom; a number is explicit host policy. instructions add a
+    # host-specific focus to the summary prompt.
+    def initialize(reserve: nil, keep_recent: DEFAULT_KEEP_RECENT,
                    window: nil, instructions: nil)
-      @reserve = reserve
+      @automatic_reserve = reserve.nil?
+      @reserve = reserve || DEFAULT_RESERVE
       @keep_recent = keep_recent
       @window = window
       @instructions = instructions
     end
 
-    # Compact when the context has grown into the reserve headroom. An
-    # unknown window never triggers.
-    def needed?(tokens, window)
-      window ? tokens > window - reserve : false
+    def automatic_reserve? = @automatic_reserve
+
+    # Automatic headroom fits output that shares the context window, plus
+    # estimation and framing slack. An explicit reserve remains host policy.
+    # An unknown window never triggers.
+    def needed?(tokens, window, max_output: nil)
+      window ? tokens > window - effective_reserve(max_output) : false
+    end
+
+    private
+
+    def effective_reserve(max_output)
+      return reserve unless automatic_reserve?
+
+      max_output ? [max_output + OUTPUT_SAFETY, reserve].max : reserve
     end
 
     class << self
       # Context size for a replay: the last healthy turn's reported tokens
       # (prompt, cache, and output all sit in context next turn) plus an
       # estimate of every message after it.
-      def context_tokens(messages)
-        index = messages.rindex { |message| reported(message) }
+      def context_tokens(messages, usage_from: 0)
+        index = (usage_from...messages.length).reverse_each.find do |position|
+          reported(messages[position])
+        end
         base = index ? reported(messages[index]) : 0
         messages.drop(index ? index + 1 : 0).sum(base) { |message| estimate(message) }
       end

--- a/lib/mistri/compactor.rb
+++ b/lib/mistri/compactor.rb
@@ -9,10 +9,12 @@ module Mistri
   # transcript UIs; only what the model sees shrinks. Callable from any
   # process (a UI button, a job), with or without a running agent.
   #
-  # Cuts land only on user messages, so a tool call and its result always
-  # stay on the same side, and a parked approval's turn is never cut away
-  # from the resume that must answer it.
+  # Cuts land on user messages or assistant tool-call turns, never results,
+  # so every call/result set stays on one side. A parked approval's turn is
+  # never cut away from the resume that must answer it.
   class Compactor
+    TOOL_RESULT_MAX_CHARS = 2_000
+
     SUMMARIZER_SYSTEM = <<~PROMPT
       You are a context summarization assistant. Read the conversation and
       produce only the structured summary you are asked for. Do not continue
@@ -43,8 +45,8 @@ module Mistri
       ## Critical Context
       - [Data, names, or references needed to continue, or "(none)"]
 
-      Keep each section concise. Preserve exact identifiers, names, and error
-      messages.
+      Keep each section concise. Preserve exact identifiers, names, paths,
+      URLs, commands, numbers, and error messages.
     FORMAT
 
     CHECKPOINT_PROMPT = <<~PROMPT.freeze
@@ -82,7 +84,7 @@ module Mistri
         return nil if head.empty?
 
         emit&.call(Event.new(type: :compacting))
-        tokens_before = Compaction.context_tokens(replay.map(&:first))
+        tokens_before = session.context_tokens
         reply = summarize(provider, head, previous, settings.instructions)
         session.append("compaction", "summary" => reply.text,
                                      "kept_from" => cut, "tokens_before" => tokens_before)
@@ -95,7 +97,9 @@ module Mistri
         boundary = keep_boundary(replay, settings.keep_recent)
         return nil unless boundary
 
-        candidates = replay.filter_map { |(message, index)| index if index && message.user? }
+        candidates = replay.filter_map do |message, index|
+          index if index && cut_candidate?(message)
+        end
         cut = candidates.find { |index| index >= boundary } || candidates.last
         cut = clamp_to_open_approvals(cut, session)
         return nil unless cut
@@ -104,8 +108,12 @@ module Mistri
         first && cut > first ? cut : nil
       end
 
+      def cut_candidate?(message)
+        message.user? || (message.assistant? && message.tool_calls?)
+      end
+
       # Walk back from the tail until the keep budget is spent; the cut then
-      # snaps forward to a user message, so replay keeps at most about
+      # snaps to the next safe turn boundary, so replay keeps at most about
       # keep_recent tokens of recent turns.
       def keep_boundary(replay, keep_recent)
         kept = 0
@@ -158,7 +166,7 @@ module Mistri
       end
 
       def finish(session, reply, tokens_before, &emit)
-        tokens_after = Compaction.context_tokens(session.messages)
+        tokens_after = session.context_tokens
         emit&.call(Event.new(type: :compaction, content: reply.text))
         { summary: reply.text, tokens_before: tokens_before,
           tokens_after: tokens_after, usage: reply.usage }
@@ -172,13 +180,25 @@ module Mistri
       end
 
       def text_of(message)
-        message.content.filter_map do |block|
+        text = message.content.filter_map do |block|
           case block
           when Content::Text then block.text
           when Content::Image then "[image]"
           when ToolCall then "[called #{block.name} with #{JSON.generate(block.arguments)}]"
           end
         end.join("\n")
+        message.tool? ? truncate_tool_result(text) : text
+      end
+
+      # Large tool output remains durable and unchanged on ordinary model
+      # requests; only the lossy summary wire is bounded, with both ends kept.
+      def truncate_tool_result(text)
+        return text if text.length <= TOOL_RESULT_MAX_CHARS
+
+        marker = "\n[tool result truncated; original length: #{text.length} characters]\n"
+        visible = TOOL_RESULT_MAX_CHARS - marker.length
+        head = (visible * 0.75).floor
+        "#{text[0, head]}#{marker}#{text[-(visible - head), visible - head]}"
       end
     end
   end

--- a/lib/mistri/models.rb
+++ b/lib/mistri/models.rb
@@ -32,6 +32,10 @@ module Mistri
     # model decides), :budget (a token budget), or :effort. It is what keeps
     # a provider from sending an unsupported thinking shape that 400s.
     #
+    # context_window is the provider's published context or input limit.
+    # Anthropic and OpenAI share it with the next output; Gemini publishes a
+    # separate inputTokenLimit and outputTokenLimit.
+    #
     # Pricing is selected per request from its prompt size. Rates are paid
     # standard direct-API list prices. cache_write is the 5-minute write rate;
     # Usage applies the 1-hour rate separately.
@@ -94,26 +98,26 @@ module Mistri
     private_class_method :price
 
     CATALOG = [
-      ["claude-fable-5", :anthropic, 128_000, 200_000, :adaptive,
+      ["claude-fable-5", :anthropic, 128_000, 1_000_000, :adaptive,
        [price(input: 10.0, output: 50.0, cache_read: 1.0, cache_write: 12.5)]],
-      ["claude-opus-4-8", :anthropic, 128_000, 200_000, :adaptive,
+      ["claude-opus-4-8", :anthropic, 128_000, 1_000_000, :adaptive,
        [price(input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25)]],
-      ["claude-opus-4-7", :anthropic, 128_000, 200_000, :adaptive,
+      ["claude-opus-4-7", :anthropic, 128_000, 1_000_000, :adaptive,
        [price(input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25)]],
-      ["claude-opus-4-6", :anthropic, 128_000, 200_000, :adaptive,
+      ["claude-opus-4-6", :anthropic, 128_000, 1_000_000, :adaptive,
        [price(input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25)]],
-      ["claude-sonnet-5", :anthropic, 128_000, 200_000, :adaptive,
+      ["claude-sonnet-5", :anthropic, 128_000, 1_000_000, :adaptive,
        [price(input: 2.0, output: 10.0, cache_read: 0.2, cache_write: 2.5),
         price({ input: 3.0, output: 15.0, cache_read: 0.3, cache_write: 3.75 },
               from: Time.utc(2026, 9, 1))]],
-      ["claude-sonnet-4-6", :anthropic, 128_000, 200_000, :adaptive,
+      ["claude-sonnet-4-6", :anthropic, 128_000, 1_000_000, :adaptive,
        [price(input: 3.0, output: 15.0, cache_read: 0.3, cache_write: 3.75)]],
       ["claude-haiku-4-5", :anthropic, 64_000, 200_000, :budget,
        [price(input: 1.0, output: 5.0, cache_read: 0.1, cache_write: 1.25)]],
-      ["gpt-5.5", :openai, 128_000, 400_000, :effort,
+      ["gpt-5.5", :openai, 128_000, 1_050_000, :effort,
        [price({ input: 5.0, output: 30.0, cache_read: 0.5 },
               above: 272_000, higher: { input: 10.0, output: 45.0, cache_read: 1.0 })]],
-      ["gpt-5.4", :openai, 128_000, 400_000, :effort,
+      ["gpt-5.4", :openai, 128_000, 1_050_000, :effort,
        [price({ input: 2.5, output: 15.0, cache_read: 0.25 },
               above: 272_000, higher: { input: 5.0, output: 22.5, cache_read: 0.5 })]],
       ["gpt-5-nano", :openai, 128_000, 400_000, :effort,
@@ -140,6 +144,13 @@ module Mistri
     end
 
     def self.max_output(id) = find(id)&.max_output
+
+    # Output capacity that occupies the published context limit. Gemini's
+    # output limit is independent, so its compaction headroom is input-only.
+    def self.shared_output(id)
+      model = find(id)
+      model&.max_output unless model&.provider == :gemini
+    end
 
     def self.thinking(id) = find(id)&.thinking
 

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -51,15 +51,22 @@ module Mistri
     # brick every later turn with a provider rejection, so unsettled calls
     # get a synthesized interrupted result. Calls parked for human approval
     # stay open; resume owns those.
-    def replay
+    def replay = replay_from(entries)
+
+    # Context accounting ignores provider usage reported before the latest
+    # compaction: those prompt counts describe the larger, pre-summary replay.
+    # Until a post-compaction assistant turn reports fresh usage, the compacted
+    # replay is estimated directly.
+    def context_tokens
       log = entries
-      compaction = log.reverse_each.find { |entry| entry["type"] == "compaction" }
-      from = compaction ? compaction["kept_from"] : 0
-      pairs = log.each_with_index.filter_map do |entry, index|
-        [Message.from_h(entry["message"]), index] if index >= from && entry["type"] == "message"
-      end
-      pairs = heal(pairs, parked_call_ids(log))
-      compaction ? [[summary_message(compaction["summary"]), nil], *pairs] : pairs
+      replay = replay_from(log)
+      compacted_at = log.rindex { |entry| entry["type"] == "compaction" }
+      usage_from = if compacted_at
+                     replay.index { |(_, index)| index && index > compacted_at } || replay.length
+                   else
+                     0
+                   end
+      Compaction.context_tokens(replay.map(&:first), usage_from:)
     end
 
     def last_compaction
@@ -167,6 +174,16 @@ module Mistri
     end
 
     private
+
+    def replay_from(log)
+      compaction = log.reverse_each.find { |entry| entry["type"] == "compaction" }
+      from = compaction ? compaction["kept_from"] : 0
+      pairs = log.each_with_index.filter_map do |entry, index|
+        [Message.from_h(entry["message"]), index] if index >= from && entry["type"] == "message"
+      end
+      pairs = heal(pairs, parked_call_ids(log))
+      compaction ? [[summary_message(compaction["summary"]), nil], *pairs] : pairs
+    end
 
     def heal(pairs, parked)
       answered = pairs.map(&:first).select(&:tool?).to_set(&:tool_call_id)

--- a/test/integration/test_context_management.rb
+++ b/test/integration/test_context_management.rb
@@ -1,27 +1,77 @@
 # frozen_string_literal: true
 
+require "securerandom"
 require_relative "../support/integration"
 
-# Long-run survival: compaction preserves generated facts through its own
-# summary, skills load on demand, and memory persists what it is told.
+# Long-run survival: compaction preserves generated state across tool turns,
+# skills load on demand, and memory persists what it is told.
 class TestContextManagementIntegration < Minitest::Test
-  Integration.scenario(self, :compaction_preserves_facts_through_the_summary) do |model|
-    title = Integration.codename
+  Integration.scenario(self, :one_run_survives_two_compactions) do |model|
+    secret = Integration.codename
+    token = "continue-#{SecureRandom.hex(12)}"
+    padding = ("checkpoint context " * 80).strip
+    opened = 0
+    closed_with = []
+    open_checkpoint = Mistri::Tool.define(
+      "open_checkpoint",
+      "Call first and exactly once. Returns a secret and continuation token."
+    ) do
+      opened += 1
+      "CHECKPOINT_SECRET=#{secret}\nCONTINUATION_TOKEN=#{token}\n#{padding}"
+    end
+    close_checkpoint = Mistri::Tool.define(
+      "close_checkpoint",
+      "Call after open_checkpoint with its exact continuation token.",
+      schema: -> { string :token, "Exact continuation token", required: true }
+    ) do |args|
+      closed_with << args["token"]
+      state = args["token"] == token ? "CHECKPOINT_CLOSED=true" : "CHECKPOINT_CLOSED=false"
+      "#{state}\n#{padding}"
+    end
     session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
     settings = Mistri::Compaction.new(window: 600, reserve: 550, keep_recent: 20)
+    protocol = <<~PROMPT
+      Complete this protocol in order:
+      1. Call open_checkpoint exactly once and by itself.
+      2. Call close_checkpoint exactly once and by itself, passing the exact
+         CONTINUATION_TOKEN returned by open_checkpoint.
+      3. After close_checkpoint succeeds, answer with only the exact
+         CHECKPOINT_SECRET returned by open_checkpoint.
+      Never call both tools in one turn. Never call open_checkpoint again.
+    PROMPT
     agent = Mistri::Agent.new(provider: Mistri.provider(model), session:,
-                              compaction: settings, system: "You keep project notes. Be brief.")
+                              tools: [open_checkpoint, close_checkpoint], max_concurrency: 1,
+                              budget: Mistri::Budget.new(turns: 4), compaction: settings,
+                              system: protocol)
+    events = []
 
-    notes = "Project notes: the launch playlist is titled #{title}, the venue is " \
-            "Aurora Hall, and the sponsor is Kestrel Labs. Acknowledge briefly."
-    agent.run(notes)
-    result = agent.run("Quick check: what is the launch playlist titled?")
+    result = agent.run("Begin the checkpoint protocol now.") { |event| events << event }
 
-    assert session.entries.any? { |e| e["type"] == "compaction" }, "compaction never fired"
-    assert(session.messages.none? { |m| m.text == notes },
-           "the original message should have left the replay")
-    assert Integration.saw?(result.text, title),
-           "the fact did not survive compaction: #{result.text}"
+    compactions = session.entries.select { |entry| entry["type"] == "compaction" }
+
+    assert_predicate result, :completed?
+    assert_equal 1, opened, "open_checkpoint did not execute exactly once"
+    assert_equal [token], closed_with, "close_checkpoint did not receive the exact token"
+    assert_equal 2, compactions.length, "the run did not cross two compaction boundaries"
+    assert_equal(2, events.count { |event| event.type == :compaction })
+    refute_includes compactions.first["summary"], secret
+    assert_includes compactions.last["summary"], secret
+    assert Integration.saw?(result.text, secret),
+           "the final answer lost the secret: #{result.text.inspect}"
+
+    durable = session.entries.find do |entry|
+      entry["type"] == "message" && entry.dig("message", "tool_name") == "open_checkpoint"
+    end
+
+    assert_includes Mistri::Message.from_h(durable["message"]).text, secret
+
+    replay_before_answer = session.messages[0...-1]
+    carriers = replay_before_answer.select do |message|
+      JSON.generate(message.to_h).include?(secret)
+    end
+
+    assert_equal [replay_before_answer.first], carriers,
+                 "the compacted replay should carry the secret only in its visible summary"
   end
 
   Integration.scenario(self, :skills_load_on_demand_and_bind) do |model|

--- a/test/test_agent_compaction.rb
+++ b/test/test_agent_compaction.rb
@@ -85,14 +85,35 @@ class TestAgentCompaction < Minitest::Test
     assert_includes session.messages.first.text, "SECOND"
   end
 
-  def test_a_cut_never_splits_a_tool_pair
+  def test_one_run_compacts_twice_without_losing_tool_state
+    secret = "Spectramoor-7a91"
+    token = "continue-4f28"
+    agent, session, provider, state = checkpoint_fixture(secret, token)
+    events = []
+
+    result = agent.run(
+      "Open the checkpoint, close it with its token, then return its secret."
+    ) do |event|
+      events << event
+    end
+
+    assert_checkpoint_completion(result, state, secret, token)
+    assert_compaction_sequence(session, provider, events)
+    assert_summary_handoff(provider, secret)
+    assert_durable_checkpoint(session, secret, token)
+  end
+
+  def test_a_cut_never_splits_parallel_tool_results
     session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
-    call = Mistri::ToolCall.new(id: "c1", name: "paint", arguments: {})
+    first_call = Mistri::ToolCall.new(id: "c1", name: "paint", arguments: {})
+    second_call = Mistri::ToolCall.new(id: "c2", name: "dry", arguments: {})
     session.append_message(Mistri::Message.user("q1 " * 100))
-    session.append_message(Mistri::Message.assistant(content: [call], stop_reason: :tool_use))
+    session.append_message(Mistri::Message.assistant(content: [first_call, second_call],
+                                                     stop_reason: :tool_use))
     session.append_message(Mistri::Message.tool(content: "painted " * 100,
                                                 tool_call_id: "c1", tool_name: "paint"))
-    session.append_message(Mistri::Message.user("q2"))
+    session.append_message(Mistri::Message.tool(content: "dried " * 100,
+                                                tool_call_id: "c2", tool_name: "dry"))
     session.append_message(Mistri::Message.assistant(content: "done", stop_reason: :stop))
 
     provider = Mistri::Providers::Fake.new(turns: [{ text: "## Goal\nSummary." }])
@@ -100,6 +121,9 @@ class TestAgentCompaction < Minitest::Test
                            settings: Mistri::Compaction.new(keep_recent: 60))
 
     replayed = session.messages
+
+    assert_equal %w[c1 c2], replayed.select(&:tool?).map(&:tool_call_id)
+
     replayed.select(&:tool?).each do |result|
       called = replayed.any? do |m|
         m.assistant? && m.tool_calls.any? { |c| c.id == result.tool_call_id }
@@ -111,6 +135,50 @@ class TestAgentCompaction < Minitest::Test
     Mistri::Providers::Anthropic::Serializer.messages(replayed)
     Mistri::Providers::OpenAI::Serializer.input_items(replayed)
     Mistri::Providers::Gemini::Serializer.contents(replayed)
+  end
+
+  def test_only_the_summary_wire_truncates_large_tool_results
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = Mistri::ToolCall.new(id: "c1", name: "inspect", arguments: {})
+    output = "START:#{"x" * 3_000}MIDDLE_SENTINEL#{"y" * 3_000}:END"
+    tool_result = Mistri::Message.tool(content: output, tool_call_id: "c1",
+                                       tool_name: "inspect")
+    session.append_message(Mistri::Message.user("inspect the artifact " * 40))
+    session.append_message(Mistri::Message.assistant(content: [call], stop_reason: :tool_use))
+    session.append_message(tool_result)
+    session.append_message(Mistri::Message.user("continue " * 20))
+    session.append_message(Mistri::Message.assistant(content: "ready", stop_reason: :stop))
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "## Goal\nContinue." }])
+
+    Mistri::Compactor.call(session:, provider:,
+                           settings: Mistri::Compaction.new(keep_recent: 10))
+
+    summarized = Mistri::Compactor.send(:text_of, tool_result)
+    prompt = provider.requests.first[:messages].first.text
+
+    stored = session.entries.find do |entry|
+      entry["type"] == "message" && entry.dig("message", "tool_name") == "inspect"
+    end
+
+    assert_truncated_summary(summarized, output, prompt)
+    assert_equal output, Mistri::Message.from_h(stored["message"]).text
+  end
+
+  def test_a_failed_summary_does_not_move_the_replay_boundary
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    session.append_message(Mistri::Message.user("old context " * 80))
+    session.append_message(Mistri::Message.assistant(content: "old answer " * 80,
+                                                     stop_reason: :stop))
+    session.append_message(Mistri::Message.user("continue"))
+    provider = Mistri::Providers::Fake.new(turns: [{ error: "summarizer unavailable" }])
+    before = session.entries
+
+    assert_raises Mistri::CompactionError do
+      Mistri::Compactor.call(session:, provider:,
+                             settings: Mistri::Compaction.new(keep_recent: 10))
+    end
+    assert_equal before, session.entries
+    assert_nil session.last_compaction
   end
 
   def test_compaction_keeps_a_parked_approval_resumable
@@ -145,5 +213,96 @@ class TestAgentCompaction < Minitest::Test
 
     assert_predicate resumed, :completed?
     assert_equal [:sent], sent
+  end
+
+  private
+
+  def checkpoint_fixture(secret, token)
+    padding = ("checkpoint context " * 80).strip
+    state = { opened: 0, closed_with: [] }
+    tools = checkpoint_tools(secret, token, padding, state)
+    provider = checkpoint_provider(secret, token)
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    settings = Mistri::Compaction.new(window: 600, reserve: 550, keep_recent: 20)
+    agent = Mistri::Agent.new(provider:, session:, tools:, max_concurrency: 1,
+                              budget: Mistri::Budget.new(turns: 4), compaction: settings)
+    [agent, session, provider, state]
+  end
+
+  def checkpoint_tools(secret, token, padding, state)
+    open_checkpoint = Mistri::Tool.define(
+      "open_checkpoint", "Opens the checkpoint and returns its state."
+    ) do
+      state[:opened] += 1
+      "CHECKPOINT_SECRET=#{secret}\nCONTINUATION_TOKEN=#{token}\n#{padding}"
+    end
+    close_checkpoint = Mistri::Tool.define(
+      "close_checkpoint", "Closes the checkpoint with its continuation token.",
+      schema: -> { string :token, "Continuation token", required: true }
+    ) do |args|
+      state[:closed_with] << args["token"]
+      "checkpoint closed\n#{padding}"
+    end
+    [open_checkpoint, close_checkpoint]
+  end
+
+  def checkpoint_provider(secret, token)
+    Mistri::Providers::Fake.new(turns: [
+                                  { tool_calls: [{ id: "open", name: "open_checkpoint" }] },
+                                  { text: "## Goal\nComplete the checkpoint protocol.\n\n" \
+                                          "## Critical Context\n- (none)" },
+                                  { tool_calls: [{ id: "close", name: "close_checkpoint",
+                                                   arguments: { token: token } }] },
+                                  { text: "## Goal\nComplete the checkpoint protocol.\n\n" \
+                                          "## Critical Context\n- CHECKPOINT_SECRET=#{secret}" },
+                                  { text: secret }
+                                ])
+  end
+
+  def assert_checkpoint_completion(result, state, secret, token)
+    assert_predicate result, :completed?
+    assert_equal secret, result.text
+    assert_equal 1, state[:opened]
+    assert_equal [token], state[:closed_with]
+  end
+
+  def assert_compaction_sequence(session, provider, events)
+    assert_equal 5, provider.requests.length
+    assert_equal(2, events.count { |event| event.type == :compacting })
+    assert_equal(2, events.count { |event| event.type == :compaction })
+    assert_equal(2, session.entries.count { |entry| entry["type"] == "compaction" })
+  end
+
+  def assert_summary_handoff(provider, secret)
+    first_summary, second_summary = provider.requests.values_at(1, 3).map do |request|
+      request[:messages].first.text
+    end
+    final_request = provider.requests.last[:messages]
+    remembered = final_request.select { |message| JSON.generate(message.to_h).include?(secret) }
+
+    refute_includes first_summary, secret
+    assert_includes second_summary, secret
+    assert_equal [final_request.first], remembered
+    assert final_request.first.text.start_with?(Mistri::Compaction::SUMMARY_PREFACE)
+  end
+
+  def assert_durable_checkpoint(session, secret, token)
+    durable = session.entries.filter_map do |entry|
+      Mistri::Message.from_h(entry["message"]) if entry["type"] == "message"
+    end
+    original_result = durable.find { |message| message.tool_name == "open_checkpoint" }
+
+    assert_includes original_result.text, "CHECKPOINT_SECRET=#{secret}"
+    assert_includes original_result.text, "CONTINUATION_TOKEN=#{token}"
+  end
+
+  def assert_truncated_summary(summarized, output, prompt)
+    assert_equal Mistri::Compactor::TOOL_RESULT_MAX_CHARS, summarized.length
+    assert summarized.start_with?("START:")
+    assert summarized.end_with?(":END")
+    assert_includes summarized, "tool result truncated; original length: #{output.length}"
+    refute_includes summarized, "MIDDLE_SENTINEL"
+    assert_includes prompt, summarized
+    refute_includes prompt, "MIDDLE_SENTINEL"
   end
 end

--- a/test/test_compaction.rb
+++ b/test/test_compaction.rb
@@ -42,10 +42,66 @@ class TestCompaction < Minitest::Test
     refute compaction.needed?(1_000_000, nil)
   end
 
+  def test_automatic_headroom_covers_full_output_and_framing_slack
+    compaction = Mistri::Compaction.new
+    boundaries = [["claude-opus-4-8", 867_904],
+                  ["claude-haiku-4-5", 131_904],
+                  ["gpt-5.5", 917_904],
+                  ["gpt-5-nano", 267_904],
+                  ["gemini-3.1-pro-preview", 1_032_192]]
+
+    boundaries.each do |model_id, boundary|
+      model = Mistri::Models.find(model_id)
+      shared_output = Mistri::Models.shared_output(model_id)
+
+      refute compaction.needed?(boundary, model.context_window, max_output: shared_output)
+      assert compaction.needed?(boundary + 1, model.context_window, max_output: shared_output)
+    end
+  end
+
+  def test_explicit_reserve_wins_and_unknown_output_uses_the_legacy_fallback
+    explicit = Mistri::Compaction.new(reserve: 100)
+    automatic = Mistri::Compaction.new
+
+    refute explicit.needed?(899, 1_000, max_output: 900)
+    assert explicit.needed?(901, 1_000, max_output: 900)
+    refute automatic.needed?(983_616, 1_000_000)
+    assert automatic.needed?(983_617, 1_000_000)
+    assert_predicate automatic, :automatic_reserve?
+    refute_predicate explicit, :automatic_reserve?
+    assert_equal Mistri::Compaction::DEFAULT_RESERVE, automatic.reserve
+    assert_equal 100, explicit.reserve
+  end
+
   def test_cache_reads_count_toward_context
     usage = Mistri::Usage.new(input: 10, cache_read: 890, output: 100)
     history = [Mistri::Message.assistant(content: "ok", usage: usage, stop_reason: :stop)]
 
     assert_equal 1_000, Mistri::Compaction.context_tokens(history)
+  end
+
+  def test_session_context_ignores_stale_usage_until_a_fresh_turn_arrives
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = Mistri::ToolCall.new(id: "c1", name: "lookup", arguments: {})
+    session.append_message(Mistri::Message.user("old request"))
+    session.append_message(Mistri::Message.assistant(content: [call], stop_reason: :tool_use,
+                                                     usage: Mistri::Usage.new(input: 900,
+                                                                              output: 100)))
+    session.append_message(Mistri::Message.tool(content: "recent result", tool_call_id: "c1"))
+    session.append("compaction", "summary" => "## Goal\nContinue.",
+                                 "kept_from" => 1, "tokens_before" => 1_000)
+
+    estimated = Mistri::Compaction.context_tokens(
+      session.messages, usage_from: session.messages.length
+    )
+
+    assert_equal estimated, session.context_tokens
+    assert_operator session.context_tokens, :<, 1_000
+
+    session.append_message(Mistri::Message.assistant(content: "fresh", stop_reason: :stop,
+                                                     usage: Mistri::Usage.new(input: 200,
+                                                                              output: 20)))
+
+    assert_equal 220, session.context_tokens
   end
 end

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -12,6 +12,30 @@ class TestModels < Minitest::Test
                  Mistri::Models::Model.members
   end
 
+  def test_catalogued_models_carry_their_published_context_windows
+    million = %w[claude-fable-5 claude-opus-4-8 claude-opus-4-7 claude-opus-4-6
+                 claude-sonnet-5 claude-sonnet-4-6]
+
+    million.each { |model| assert_equal 1_000_000, Mistri::Models.find(model).context_window }
+
+    assert_equal 200_000, Mistri::Models.find("claude-haiku-4-5").context_window
+    assert_equal 1_050_000, Mistri::Models.find("gpt-5.5").context_window
+    assert_equal 1_050_000, Mistri::Models.find("gpt-5.4").context_window
+    assert_equal 400_000, Mistri::Models.find("gpt-5-nano").context_window
+    %w[gemini-3.5-flash gemini-3.1-pro-preview gemini-2.5-pro gemini-2.5-flash].each do |model|
+      assert_equal 1_048_576, Mistri::Models.find(model).context_window
+    end
+    assert_equal 1_000_000,
+                 Mistri::Models.find("claude-opus-4-8-20260701").context_window
+  end
+
+  def test_only_shared_context_windows_reserve_output_capacity
+    assert_equal 128_000, Mistri::Models.shared_output("gpt-5.5")
+    assert_equal 128_000, Mistri::Models.shared_output("claude-opus-4-8")
+    assert_nil Mistri::Models.shared_output("gemini-3.1-pro-preview")
+    assert_nil Mistri::Models.shared_output("future-model")
+  end
+
   def test_pricing_participates_in_model_value_semantics_and_marshalling
     model = Mistri::Models.find("gpt-5.5")
     unpriced = model.with(pricing: [])


### PR DESCRIPTION
## Summary

- Correct the catalogued Claude context windows to 1M tokens and GPT-5.4/5.5 to 1.05M.
- Make the default compaction reserve model-aware: shared context windows keep a full model output plus 4,096 tokens of safety; Gemini keeps its separately published input limit.
- Ignore provider usage reported before the latest compaction until a fresh turn supplies an authoritative count.
- Let a single run compact at assistant tool-call boundaries without ever splitting calls from results.
- Bound large tool results only on the summarizer wire; durable history remains exact.

## Why

The old catalog caused current Claude and OpenAI sessions to summarize hundreds of thousands of tokens early. Simply increasing those windows would make the fixed 16K reserve unsafe for models that can produce 64K or 128K outputs.

Repeated compaction also reused pre-summary usage and could not advance through a long tool-driven task because cuts were restricted to user messages.

This keeps the existing provider-neutral, visible-summary contract. It adopts the useful mechanics from [pi](https://github.com/earendil-works/pi) without bringing over branches, file tracking, provider-native compaction, or runtime catalog machinery.

## Verification

- Hermetic: 487 runs, 1,797 assertions, 0 failures
- RuboCop: 163 files, 0 offenses
- Coverage: 97.03% line, 83.32% branch
- Live single-run harness: Claude Haiku 4.5, GPT-5.5, and Gemini 3.1 Pro Preview; 3 runs, 42 assertions
- The live harness crosses two compactions, transfers an unpredictable tool token, recalls a generated secret only through the second summary, and verifies the original tool payload remains exact
- Adversarial correctness, public API, and test reviews are clean

There is no token-streaming change. The catalog lookup and session accounting run at turn boundaries; 2,000-character tool-result bounding runs only while constructing a compaction request.

## Provider references

- [Anthropic context windows](https://platform.claude.com/docs/en/build-with-claude/context-windows)
- [OpenAI GPT-5.5](https://developers.openai.com/api/docs/models/gpt-5.5)
- [OpenAI model comparison](https://developers.openai.com/api/docs/models/compare)
- [Gemini model metadata](https://ai.google.dev/api/models)

## Stack

This PR is stacked on #28. After #28 merges, the base can move to `main`; the compaction commit is independent.