### PR TITLE
Add GPT-5.6 model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- GPT-5.6 Sol, Terra, and Luna are catalogued with their 1.05M-token context,
+  128K-token output ceiling, and standard paid pricing above and below the
+  272K long-context boundary. The `gpt-5.6` alias resolves to Sol. OpenAI usage
+  now separates billable GPT-5.6 cache writes from uncached input, keeping
+  compaction, reported cost, and cost budgets accurate.
 - Directory workspaces reject existing symlinks in model-controlled paths and
   omit symlinked files from listings. In a stable, host-controlled tree, reads,
   writes, and deletes no longer follow a link outside the configured root.

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ agent.run("Draft a long essay.", signal: signal)
 budget = Mistri::Budget.new(turns: 20, cost_usd: 2.00)
 
 # Anthropic and OpenAI need an explicit standard tier for a cost budget.
-agent = Mistri.agent("gpt-5.5", budget: budget,
+agent = Mistri.agent("gpt-5.6-terra", budget: budget,
                      provider_options: { service_tier: "default" })
 
 # Transient failures (429, 5xx, timeouts) retry with backoff, invisibly to
@@ -525,7 +525,7 @@ photo = Mistri::Content::Image.from_bytes(File.binread("chart.png"), mime_type: 
 photo = Mistri::Content::Image.from_data_uri(params[:image])   # canvases and uploads
 agent.run("What trend does this chart show?", images: [photo])
 
-Mistri.agent("gpt-5.5", provider_options: { reasoning: { effort: "high" } })
+Mistri.agent("gpt-5.6", provider_options: { reasoning: { effort: "high" } })
 Mistri.agent("claude-opus-4-8", provider_options: { cache: false })
 ```
 

--- a/lib/mistri.rb
+++ b/lib/mistri.rb
@@ -71,7 +71,7 @@ module Mistri
   # reading its key from the environment unless one is passed.
   #
   #   Mistri.provider("claude-opus-4-8")
-  #   Mistri.provider("gpt-5.5", api_key: key, reasoning: { effort: "high" })
+  #   Mistri.provider("gpt-5.6", api_key: key, reasoning: { effort: "high" })
   def provider(model, api_key: nil, **)
     name = provider_name(model)
     klass = PROVIDERS.fetch(name) { raise ConfigurationError, "no provider for #{model.inspect}" }

--- a/lib/mistri/models.rb
+++ b/lib/mistri/models.rb
@@ -37,8 +37,8 @@ module Mistri
     # separate inputTokenLimit and outputTokenLimit.
     #
     # Pricing is selected per request from its prompt size. Rates are paid
-    # standard direct-API list prices. cache_write is the 5-minute write rate;
-    # Usage applies the 1-hour rate separately.
+    # standard direct-API list prices. cache_write is the provider's baseline
+    # write rate; Usage prices a reported longer-retention slice separately.
     Model = Data.define(:id, :provider, :max_output, :context_window, :thinking) do
       def initialize(id:, provider:, max_output:, context_window:, thinking:, pricing: [])
         @pricing = pricing.sort_by(&:effective_at).freeze
@@ -114,6 +114,21 @@ module Mistri
        [price(input: 3.0, output: 15.0, cache_read: 0.3, cache_write: 3.75)]],
       ["claude-haiku-4-5", :anthropic, 64_000, 200_000, :budget,
        [price(input: 1.0, output: 5.0, cache_read: 0.1, cache_write: 1.25)]],
+      ["gpt-5.6-sol", :openai, 128_000, 1_050_000, :effort,
+       [price({ input: 5.0, output: 30.0, cache_read: 0.5, cache_write: 6.25 },
+              above: 272_000,
+              higher: { input: 10.0, output: 45.0, cache_read: 1.0,
+                        cache_write: 12.5 })]],
+      ["gpt-5.6-terra", :openai, 128_000, 1_050_000, :effort,
+       [price({ input: 2.5, output: 15.0, cache_read: 0.25, cache_write: 3.125 },
+              above: 272_000,
+              higher: { input: 5.0, output: 22.5, cache_read: 0.5,
+                        cache_write: 6.25 })]],
+      ["gpt-5.6-luna", :openai, 128_000, 1_050_000, :effort,
+       [price({ input: 1.0, output: 6.0, cache_read: 0.1, cache_write: 1.25 },
+              above: 272_000,
+              higher: { input: 2.0, output: 9.0, cache_read: 0.2,
+                        cache_write: 2.5 })]],
       ["gpt-5.5", :openai, 128_000, 1_050_000, :effort,
        [price({ input: 5.0, output: 30.0, cache_read: 0.5 },
               above: 272_000, higher: { input: 10.0, output: 45.0, cache_read: 1.0 })]],
@@ -137,10 +152,15 @@ module Mistri
       [id, Model.new(id:, provider:, max_output:, context_window:, thinking:, pricing:)]
     end.freeze
 
-    # Dated aliases resolve to their base entry: claude-opus-4-8-20260115 and
-    # gpt-5.4-2025-04-14 both match their base ids.
+    ALIASES = { "gpt-5.6" => "gpt-5.6-sol" }.freeze
+
+    # Published family aliases and dated ids resolve to their canonical entry.
     def self.find(id)
-      CATALOG[id] || CATALOG[id.to_s.sub(/-\d{8}\z/, "").sub(/-\d{4}-\d{2}-\d{2}\z/, "")]
+      exact = CATALOG[id]
+      return exact if exact
+
+      base = id.to_s.sub(/-\d{8}\z/, "").sub(/-\d{4}-\d{2}-\d{2}\z/, "")
+      CATALOG[ALIASES.fetch(base, base)]
     end
 
     def self.max_output(id) = find(id)&.max_output

--- a/lib/mistri/providers/openai/assembler.rb
+++ b/lib/mistri/providers/openai/assembler.rb
@@ -232,8 +232,10 @@ module Mistri
           details = raw["input_tokens_details"] || {}
           output_details = raw["output_tokens_details"] || {}
           cache_read = details["cached_tokens"].to_i
-          Usage.new(input: [raw["input_tokens"].to_i - cache_read, 0].max,
-                    output: raw["output_tokens"].to_i, cache_read: cache_read,
+          cache_write = details["cache_write_tokens"].to_i
+          input = [raw["input_tokens"].to_i - cache_read - cache_write, 0].max
+          Usage.new(input:, output: raw["output_tokens"].to_i, cache_read:,
+                    cache_write:,
                     reasoning: output_details["reasoning_tokens"].to_i)
         end
 

--- a/test/support/integration.rb
+++ b/test/support/integration.rb
@@ -12,7 +12,7 @@ require_relative "../test_helper"
 #   MISTRI_INTEGRATION_MODELS=claude-opus-4-8 bundle exec rake integration
 #   bundle exec rake integration N=/compaction/
 module Integration
-  DEFAULT_MODELS = "claude-haiku-4-5-20251001,gpt-5.2,gemini-2.5-flash"
+  DEFAULT_MODELS = "claude-haiku-4-5-20251001,gpt-5.6-terra,gemini-2.5-flash"
 
   STARTS = %w[Spec Wraith Phan Umbra Shade Geist Vesper Haunt Grim Sable Mora Ecto].freeze
   MIDDLES = %w[a o e u ora ile ar in].freeze

--- a/test/test_compaction.rb
+++ b/test/test_compaction.rb
@@ -46,6 +46,7 @@ class TestCompaction < Minitest::Test
     compaction = Mistri::Compaction.new
     boundaries = [["claude-opus-4-8", 867_904],
                   ["claude-haiku-4-5", 131_904],
+                  ["gpt-5.6", 917_904],
                   ["gpt-5.5", 917_904],
                   ["gpt-5-nano", 267_904],
                   ["gemini-3.1-pro-preview", 1_032_192]]

--- a/test/test_entrypoint.rb
+++ b/test/test_entrypoint.rb
@@ -6,7 +6,10 @@ class TestEntrypoint < Minitest::Test
   def test_provider_is_inferred_from_the_model_id
     assert_instance_of Mistri::Providers::Anthropic,
                        Mistri.provider("claude-opus-4-8", api_key: "k")
-    assert_instance_of Mistri::Providers::OpenAI, Mistri.provider("gpt-5.5", api_key: "k")
+    openai = Mistri.provider("gpt-5.6", api_key: "k")
+
+    assert_instance_of Mistri::Providers::OpenAI, openai
+    assert_equal "gpt-5.6", openai.model, "catalog aliases stay aliases on the wire"
     assert_instance_of Mistri::Providers::Gemini, Mistri.provider("gemini-2.5-flash", api_key: "k")
   end
 

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -7,6 +7,7 @@ require_relative "support/stub_server"
 class TestModels < Minitest::Test
   def test_known_models_carry_their_output_ceiling
     assert_equal 128_000, Mistri::Models.max_output("claude-opus-4-8")
+    assert_equal 128_000, Mistri::Models.max_output("gpt-5.6")
     assert_equal 64_000, Mistri::Models.max_output("claude-haiku-4-5")
     assert_equal %i[id provider max_output context_window thinking],
                  Mistri::Models::Model.members
@@ -19,8 +20,9 @@ class TestModels < Minitest::Test
     million.each { |model| assert_equal 1_000_000, Mistri::Models.find(model).context_window }
 
     assert_equal 200_000, Mistri::Models.find("claude-haiku-4-5").context_window
-    assert_equal 1_050_000, Mistri::Models.find("gpt-5.5").context_window
-    assert_equal 1_050_000, Mistri::Models.find("gpt-5.4").context_window
+    %w[gpt-5.6 gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna gpt-5.5 gpt-5.4].each do |model|
+      assert_equal 1_050_000, Mistri::Models.find(model).context_window
+    end
     assert_equal 400_000, Mistri::Models.find("gpt-5-nano").context_window
     %w[gemini-3.5-flash gemini-3.1-pro-preview gemini-2.5-pro gemini-2.5-flash].each do |model|
       assert_equal 1_048_576, Mistri::Models.find(model).context_window
@@ -30,6 +32,7 @@ class TestModels < Minitest::Test
   end
 
   def test_only_shared_context_windows_reserve_output_capacity
+    assert_equal 128_000, Mistri::Models.shared_output("gpt-5.6")
     assert_equal 128_000, Mistri::Models.shared_output("gpt-5.5")
     assert_equal 128_000, Mistri::Models.shared_output("claude-opus-4-8")
     assert_nil Mistri::Models.shared_output("gemini-3.1-pro-preview")
@@ -45,7 +48,12 @@ class TestModels < Minitest::Test
     assert_equal model, Marshal.load(Marshal.dump(model))
   end
 
-  def test_dated_aliases_resolve_and_unknown_ids_pass_through
+  def test_provider_aliases_and_dated_ids_resolve_while_unknown_ids_pass_through
+    sol = Mistri::Models.find("gpt-5.6-sol")
+
+    assert_equal sol, Mistri::Models.find("gpt-5.6")
+    assert_equal "gpt-5.6-sol", Mistri::Models.find("gpt-5.6").id
+    assert_equal :effort, Mistri::Models.thinking("gpt-5.6")
     assert_equal 128_000, Mistri::Models.max_output("claude-sonnet-5-20260201")
     assert_nil Mistri::Models.find("claude-next-9000")
   end
@@ -78,6 +86,31 @@ class TestModels < Minitest::Test
       assert_in_delta cache_read, rates[:cache_read]
       assert_in_delta output, rates[:output]
     end
+  end
+
+  def test_gpt_5_6_pricing_includes_cache_writes_on_both_context_tiers
+    boundary = Mistri::Usage.new(input: 100_000, cache_read: 100_000, cache_write: 72_000)
+    over = boundary.with(cache_write: 72_001)
+    prices = {
+      "gpt-5.6-sol" => [
+        { input: 5.0, output: 30.0, cache_read: 0.5, cache_write: 6.25 },
+        { input: 10.0, output: 45.0, cache_read: 1.0, cache_write: 12.5 }
+      ],
+      "gpt-5.6-terra" => [
+        { input: 2.5, output: 15.0, cache_read: 0.25, cache_write: 3.125 },
+        { input: 5.0, output: 22.5, cache_read: 0.5, cache_write: 6.25 }
+      ],
+      "gpt-5.6-luna" => [
+        { input: 1.0, output: 6.0, cache_read: 0.1, cache_write: 1.25 },
+        { input: 2.0, output: 9.0, cache_read: 0.2, cache_write: 2.5 }
+      ]
+    }
+
+    prices.each do |model, (standard, higher)|
+      assert_equal standard, Mistri::Models.rates(model, usage: boundary)
+      assert_equal higher, Mistri::Models.rates(model, usage: over)
+    end
+    assert_equal Mistri::Models.rates("gpt-5.6-sol"), Mistri::Models.rates("gpt-5.6")
   end
 
   def test_gemini_pro_long_context_pricing_starts_above_200k
@@ -213,6 +246,7 @@ class TestModels < Minitest::Test
     standard.stream(messages: [Mistri::Message.user("hi")])
     automatic_body, standard_body = server.requests.map { |request| JSON.parse(request[:body]) }
 
+    assert_equal "gpt-5.5", automatic_body["model"], "the public provider default stays stable"
     refute automatic_body.key?("service_tier"), "catalog pricing must not choose host policy"
     assert_equal "default", standard_body["service_tier"]
   ensure

--- a/test/test_openai_assembler.rb
+++ b/test/test_openai_assembler.rb
@@ -216,6 +216,38 @@ class TestOpenAIAssembler < Minitest::Test
     refute_predicate flex.finish.usage.cost, :known?
   end
 
+  def test_usage_separates_cache_reads_and_writes_from_uncached_input
+    assembler = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.6-luna")
+    assembler.feed({ "type" => "response.completed",
+                     "response" => {
+                       "status" => "completed",
+                       "service_tier" => "default",
+                       "usage" => {
+                         "input_tokens" => 1000,
+                         "input_tokens_details" => {
+                           "cached_tokens" => 400,
+                           "cache_write_tokens" => 300
+                         },
+                         "output_tokens" => 100
+                       }
+                     } })
+    usage = assembler.finish.usage
+    rates = Mistri::Models.rates("gpt-5.6-luna", usage:)
+
+    assert_equal 300, usage.input
+    assert_equal 400, usage.cache_read
+    assert_equal 300, usage.cache_write
+    assert_equal 1000, usage.prompt_tokens
+    assert_equal 1100, usage.total_tokens
+    assert_predicate usage.cost, :known?
+    assert_in_delta rates[:cache_write] * 300 / 1_000_000.0,
+                    usage.cost.cache_write, 1e-9
+    expected = ((rates[:input] * 300) + (rates[:cache_read] * 400) +
+                (rates[:cache_write] * 300) + (rates[:output] * 100)) / 1_000_000.0
+
+    assert_in_delta expected, usage.cost.total, 1e-9
+  end
+
   def test_long_context_usage_is_priced_at_the_higher_request_tier
     assembler = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.5")
     assembler.feed({ "type" => "response.completed",

--- a/test/test_openai_live.rb
+++ b/test/test_openai_live.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "securerandom"
 require_relative "test_helper"
 
 # Real API calls, opt-in: MISTRI_LIVE=1 bundle exec rake test
@@ -11,6 +12,7 @@ class TestOpenAILive < Minitest::Test
 
   def test_a_text_turn_streams_and_lands
     provider = Mistri::Providers::OpenAI.new(api_key: ENV.fetch("OPENAI_API_KEY"),
+                                             model: "gpt-5.6",
                                              service_tier: "default")
     events = []
 
@@ -34,6 +36,7 @@ class TestOpenAILive < Minitest::Test
   # on broken pairing.
   def test_a_tool_turn_replays_cleanly_into_a_final_answer
     provider = Mistri::Providers::OpenAI.new(api_key: ENV.fetch("OPENAI_API_KEY"),
+                                             model: "gpt-5.6",
                                              service_tier: "default")
     weather = { name: "get_weather", description: "Current weather for a city.",
                 input_schema: { type: "object", properties: { city: { type: "string" } },
@@ -53,6 +56,24 @@ class TestOpenAILive < Minitest::Test
 
     assert_equal :stop, second.stop_reason
     assert_match(/41|sunny/i, second.text)
+  ensure
+    provider&.close
+  end
+
+  def test_gpt_5_6_cache_writes_are_accounted
+    provider = Mistri::Providers::OpenAI.new(api_key: ENV.fetch("OPENAI_API_KEY"),
+                                             model: "gpt-5.6-luna",
+                                             reasoning: { effort: "none" },
+                                             service_tier: "default")
+    prompt = [SecureRandom.hex(16), "Mistri cache accounting probe. " * 700,
+              "Reply with exactly: ok"].join(" ")
+    messages = [Mistri::Message.user(prompt)]
+
+    message = provider.stream(messages:)
+
+    assert_operator message.usage.cache_write, :>, 0
+    assert_operator message.usage.cost.cache_write, :>, 0
+    assert_predicate message.usage.cost, :known?
   ensure
     provider&.close
   end


### PR DESCRIPTION
## Summary

- Add catalog support for GPT-5.6 Sol, Terra, and Luna with their 1.05M-token context, 128K output ceiling, and standard pricing on both sides of the 272K long-context boundary.
- Resolve the `gpt-5.6` family alias to Sol metadata while preserving the caller's alias on the wire.
- Separate GPT-5.6 `cache_write_tokens` from uncached input and price writes at the provider-reported rate.
- Move the default full integration model from GPT-5.2 to Terra, while keeping the public OpenAI provider default at GPT-5.5.
- Refresh public examples and the Unreleased changelog.

## Why

Mistri's unknown-model passthrough could already send GPT-5.6 requests, but the catalog did not know their context, output, or pricing contracts. That disabled automatic compaction and cost budgets.

GPT-5.6 also makes prompt-cache writes a distinct billable input class. OpenAI includes cache reads and writes inside `input_tokens`; treating writes as ordinary input would understate their cost and make a newly enabled cost budget inaccurate. The assembler now decomposes all three input classes without changing the total prompt-token count.

## Verification

- Hermetic: 493 runs, 1,826 assertions, 0 failures
- RuboCop: 163 files, 0 offenses
- Coverage: 97.04% line, 83.35% branch
- OpenAI live harness: alias streaming, two-turn tool/reasoning replay, and billable cache-write accounting; 3 runs, 22 assertions
- Live model matrix: Sol, Terra, and Luna; 3 runs, 30 assertions
- Full Terra integration harness: 17 runs, 104 assertions across tools, structured output, approval, delegation, MCP, persistence, and two compactions
- Built `mistri-0.5.0` successfully with 82 packaged files and zero runtime dependencies
- Adversarial correctness, pricing, API, latency, and public-gem reviews are clean

There is no token-streaming latency change. Cache-write parsing adds one field lookup and integer subtraction when the terminal usage event arrives; catalog resolution remains outside the token path.

## Provider references

- [GPT-5.6 general availability](https://openai.com/index/gpt-5-6/)
- [OpenAI API changelog](https://developers.openai.com/api/docs/changelog)
- [GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model)
- [GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol)
- [GPT-5.6 Terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra)
- [GPT-5.6 Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna)
- [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching)
