### PR TITLE
Harden remote MCP and OAuth boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Remote MCP and server-side OAuth requests now default to public HTTPS and
+  direct connections. Every DNS answer is checked against the IANA
+  special-purpose registries, including embedded NAT64 destinations; one unsafe
+  answer rejects the whole set. Approved addresses are pinned without changing
+  Host, SNI, or certificate identity, alternates are tried only before request
+  transmission, and every connection cycle resolves and validates a fresh DNS
+  set, including Net::HTTP's internal reconnect cycles. Redirects and ambient
+  proxies cannot bypass the boundary. `allow_non_public:` is a narrow host
+  callback for approved internal HTTPS and explicit loopback development.
+  Client construction remains DNS-free; a reused socket adds no request-path
+  work. A new connection cycle pays one validated DNS lookup, with approved
+  candidates tried only before request transmission.
+- MCP custom headers are copied at client construction and transport-owned
+  headers are rejected; a token callable remains the dynamic authentication
+  path. Tool discovery rejects repeated cursors and defaults to at most 100
+  pages and 10,000 tools; hosts can adjust either ceiling.
+- MCP OAuth discovery now follows the required protected-resource and
+  authorization-server candidate order, uses exact candidate-aware resource and
+  issuer binding, honors challenge scope, requires S256 PKCE, and never adds
+  `offline_access` as gem policy. OAuth response bodies are uncompressed and
+  bounded to 256 KiB; token error descriptions cannot reflect credentials into
+  exceptions. A pre-registered client now requires its exact trusted `issuer:`,
+  and completion and refresh rediscover the token endpoint from that persisted
+  issuer instead of trusting a stored endpoint. New confidential flows persist
+  an explicit authentication method; legacy rows with a secret and no method
+  retain their previous `client_secret_post` behavior.
+- The MCP Rails generator now persists `issuer` instead of `token_endpoint` and
+  exposes `mcp_allow_non_public` as the host's shared egress-policy hook. Existing
+  generated models must add and pass an issuer, restart pending OAuth flows,
+  and thread their non-public policy through the client and all OAuth
+  operations. Existing connected rows must reconnect unless the application
+  independently recorded their exact historical issuer. An issuer must never
+  be inferred from a token endpoint.
 - GPT-5.6 Sol, Terra, and Luna are catalogued with their 1.05M-token context,
   128K-token output ceiling, and standard paid pricing above and below the
   272K long-context boundary. The `gpt-5.6` alias resolves to Sol. OpenAI usage

--- a/README.md
+++ b/README.md
@@ -398,11 +398,44 @@ tools = Mistri::MCP.tools(client, prefix: "linear",
 agent = Mistri.agent("claude-opus-4-8", tools: tools)
 ```
 
+Remote URLs are untrusted input. Mistri accepts public HTTPS destinations by
+default, rejects the whole DNS result when any answer is non-public, and pins an
+approved address while keeping the hostname for Host, SNI, and certificate
+verification. Each connection cycle resolves and validates every DNS answer;
+Net::HTTP's internal keep-alive reconnects start a new cycle. Approved
+candidates from one result are tried only before request bytes are sent. MCP
+and server-side OAuth requests do not follow redirects or inherit ambient HTTP
+proxy settings.
+
+Private MCP and authorization servers remain available through one narrow host
+policy, passed to the client and every OAuth operation:
+
+```ruby
+INTERNAL_RANGE = IPAddr.new("10.20.0.0/16")
+ALLOW_INTERNAL_MCP = lambda do |uri, address|
+  %w[mcp.internal.example auth.internal.example].include?(uri.hostname) &&
+    INTERNAL_RANGE.include?(address)
+end
+
+# Override this hook in a generated Rails connection model.
+class McpConnection
+  def self.mcp_allow_non_public = ALLOW_INTERNAL_MCP
+end
+
+client = Mistri::MCP::Client.new(url: "https://mcp.internal.example/mcp",
+                                 allow_non_public: ALLOW_INTERNAL_MCP)
+```
+
+The callback is consulted only for non-public addresses; it cannot permit an
+invalid URL or plaintext HTTP to a non-loopback destination. Local development
+can explicitly use `->(_uri, address) { address.loopback? }`.
+
 The bridge lists the server's tools once, at build time; `client.tools(refresh: true)`
-re-lists when a host wants a changed toolset. `prefix:` namespaces local
-names (`linear__create_issue`) because duplicate tool names raise at
-`Agent.new`: collisions fail loud instead of one server's tool silently
-shadowing another's.
+re-lists when a host wants a changed toolset. Discovery rejects repeated cursors
+and defaults to 100 pages or 10,000 tools; `max_tool_pages:` and `max_tools:`
+let a host set explicit limits. `prefix:` namespaces local names
+(`linear__create_issue`) because duplicate tool names raise at `Agent.new`:
+collisions fail loud instead of one server's tool silently shadowing another's.
 
 Local stdio servers spawn as child processes, credentials in their
 environment. That is also the whole "give the agent a browser" story:
@@ -426,7 +459,9 @@ Each row is one server connection carrying its own OAuth flow state and
 encrypted tokens. The OAuth services underneath (`Mistri::MCP::OAuth.start`,
 `.complete`, `.refresh`) are storage-agnostic, so the same flow works from a
 controller, a GraphQL mutation, or a job. Registration happens as your
-application: `client_name:` is yours to set.
+application: `client_name:` is yours to set. The generated row persists the
+authorization-server identity selected during registration; token endpoints
+are rediscovered from that exact issuer before code exchange and refresh.
 
 ```ruby
 connection, authorize_url = McpConnection.connect(
@@ -438,6 +473,25 @@ connection = McpConnection.complete(state: params[:state], code: params[:code])
 
 agent = Mistri.agent("claude-opus-4-8", tools: connection.tools(prefix: "linear"))
 ```
+
+When calling the low-level OAuth services directly, persist `flow["issuer"]`
+and `flow["resource"]`, verify callback state against `flow["state"]`, and pass
+the same `allow_non_public:` callback to `start`, `complete`, and `refresh` for
+an internal server. A pre-registered `client_id` belongs to a specific
+authorization server, so `start` requires the exact trusted `issuer:` supplied
+when that client was registered. If protected-resource metadata advertises
+more than one issuer, the host must select one explicitly. `start` still
+returns `token_endpoint` for compatibility, but `complete` and `refresh` do
+not trust it; they rediscover the current endpoint from `issuer`.
+
+Generated models copied by an older Mistri release are not rewritten when the
+gem updates. Before using this version, add an `issuer` string column, pass it
+to `complete` and `refresh`, and thread one class-owned egress policy through
+all three OAuth operations and `Client` if non-public destinations are used.
+Restart pending OAuth flows. Existing connected rows may be backfilled only
+when the application independently recorded the exact issuer used during
+registration; otherwise reconnect them. Never infer an issuer from a token
+endpoint. The current generator shows the complete wiring.
 
 ## Streaming into Rails
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,5 +14,22 @@ Notes worth knowing when assessing reports:
 - Tokens and API keys are never logged by the gem and never persisted by
   the gem itself; storage is the host application's, and the generated
   Rails models encrypt token columns.
-- MCP bearer tokens are refused over plain HTTP to non-loopback hosts, and
-  authorization server endpoints are validated HTTPS.
+- Remote MCP and OAuth URLs default to public HTTPS. Mistri rejects credentials,
+  fragments, private, loopback, link-local, shared, multicast, documentation,
+  and reserved destinations; validates every DNS answer; and pins an approved
+  address while preserving hostname-based TLS verification. Every connection
+  cycle validates a fresh DNS set, including keep-alive reconnect cycles, and
+  never falls back from an unsafe set to an old address. Approved candidates
+  from one set are tried only before request transmission. MCP and server-side
+  OAuth requests do not follow redirects or inherit ambient HTTP proxy settings.
+  The user's browser resolves the authorization endpoint independently.
+- A host can explicitly approve an internal HTTPS destination with
+  `allow_non_public:`. Plain HTTP remains limited to an explicitly approved,
+  actually resolved loopback address. The callback is part of the host's
+  security boundary and should match both an expected hostname and IP range.
+- OAuth protected-resource and issuer metadata are bound to exact identifiers.
+  Pre-registered clients require the issuer trusted at registration, and token
+  endpoints are rediscovered from that issuer before credentials are sent.
+  OAuth response bodies are read incrementally with a 256 KiB limit and
+  compression disabled; server-controlled descriptions are not copied into
+  token errors.

--- a/lib/generators/mistri/mcp/templates/migration.rb.tt
+++ b/lib/generators/mistri/mcp/templates/migration.rb.tt
@@ -12,7 +12,7 @@ class Create<%= table_name.camelize %> < ActiveRecord::Migration[<%= ActiveRecor
 
       t.string :client_id
       t.string :client_secret
-      t.string :token_endpoint
+      t.string :issuer
       t.string :token_auth_method
       t.text :access_token
       t.text :refresh_token

--- a/lib/generators/mistri/mcp/templates/model.rb.tt
+++ b/lib/generators/mistri/mcp/templates/model.rb.tt
@@ -4,15 +4,19 @@
 class <%= class_name %> < ApplicationRecord
   encrypts :access_token, :refresh_token, :client_secret
 
+  def self.mcp_allow_non_public = nil
+
   # Begin the OAuth flow: persists a pending connection and returns it with
   # the URL to send the user to.
-  def self.connect(name:, url:, client_name:, redirect_uri:, scope: nil)
+  def self.connect(name:, url:, client_name:, redirect_uri:, scope: nil, issuer: nil)
     flow = Mistri::MCP::OAuth.start(url: url, client_name: client_name,
-                                    redirect_uri: redirect_uri, scope: scope)
+                                    redirect_uri: redirect_uri, scope: scope,
+                                    issuer: issuer,
+                                    allow_non_public: mcp_allow_non_public)
     connection = create!(name: name, url: url, status: "pending",
                          state: flow["state"], code_verifier: flow["code_verifier"],
                          client_id: flow["client_id"], client_secret: flow["client_secret"],
-                         token_endpoint: flow["token_endpoint"],
+                         issuer: flow["issuer"],
                          token_auth_method: flow["token_auth_method"],
                          redirect_uri: flow["redirect_uri"])
     [connection, flow["authorize_url"]]
@@ -25,10 +29,11 @@ class <%= class_name %> < ApplicationRecord
                                          code_verifier: connection.code_verifier,
                                          client_id: connection.client_id,
                                          client_secret: connection.client_secret,
-                                         token_endpoint: connection.token_endpoint,
+                                         issuer: connection.issuer,
                                          token_auth_method: connection.token_auth_method,
                                          resource: connection.url,
-                                         redirect_uri: connection.redirect_uri)
+                                         redirect_uri: connection.redirect_uri,
+                                         allow_non_public: mcp_allow_non_public)
     connection.update!(status: "connected", state: nil, code_verifier: nil,
                        access_token: tokens["access_token"],
                        refresh_token: tokens["refresh_token"],
@@ -37,7 +42,8 @@ class <%= class_name %> < ApplicationRecord
   end
 
   def client
-    Mistri::MCP::Client.new(url: url, token: -> { bearer_token })
+    Mistri::MCP::Client.new(url: url, token: -> { bearer_token },
+                            allow_non_public: self.class.mcp_allow_non_public)
   end
 
   def tools(**options)
@@ -54,8 +60,9 @@ class <%= class_name %> < ApplicationRecord
   def refresh!
     tokens = Mistri::MCP::OAuth.refresh(refresh_token: refresh_token,
                                         client_id: client_id, client_secret: client_secret,
-                                        token_endpoint: token_endpoint,
-                                        token_auth_method: token_auth_method, resource: url)
+                                        issuer: issuer, token_auth_method: token_auth_method,
+                                        resource: url,
+                                        allow_non_public: self.class.mcp_allow_non_public)
     update!(access_token: tokens["access_token"],
             refresh_token: tokens["refresh_token"] || refresh_token,
             expires_at: tokens["expires_at"], scope: tokens["scope"] || scope)

--- a/lib/mistri/mcp.rb
+++ b/lib/mistri/mcp.rb
@@ -32,6 +32,9 @@ module Mistri
     # attached); the spec says start a fresh one, and Client does.
     class SessionExpired < Error; end
 
+    # A remote URL cannot be used without weakening the MCP network boundary.
+    class UnsafeURLError < ConfigurationError; end
+
     module_function
 
     # The server's tools as Mistri tools. allow/deny filter by remote name,
@@ -91,6 +94,9 @@ module Mistri
   end
 end
 
+require_relative "mcp/egress"
 require_relative "mcp/wires"
 require_relative "mcp/client"
 require_relative "mcp/oauth"
+
+Mistri::MCP.private_constant :Egress

--- a/lib/mistri/mcp/client.rb
+++ b/lib/mistri/mcp/client.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "uri"
-
 module Mistri
   module MCP
     # A Model Context Protocol client: the initialize handshake, tools/list
@@ -20,30 +18,30 @@ module Mistri
     # re-resolving, so a host's refresh logic lives in one lambda. A session
     # the server expires (404 with a session attached) transparently
     # re-initializes, per spec.
+    # Remote URLs default to public HTTPS. allow_non_public: is consulted only
+    # for otherwise blocked addresses and plain HTTP remains loopback-only.
     #
     # One client serializes its calls; parallel tool calls against one
     # server queue rather than interleave.
     class Client
       PROTOCOL_VERSION = "2025-11-25"
       SUPPORTED_VERSIONS = %w[2025-11-25 2025-06-18 2025-03-26 2024-11-05].freeze
-      LOOPBACK = %w[localhost 127.0.0.1 ::1].freeze
-
       attr_reader :server_info
 
       def initialize(url: nil, command: nil, env: {}, token: nil, headers: {},
-                     client_name: "mistri", open_timeout: 15, read_timeout: 120)
+                     client_name: "mistri", open_timeout: 15, read_timeout: 120,
+                     allow_non_public: nil, max_tool_pages: 100, max_tools: 10_000)
         if [url, command].compact.length != 1
           raise ConfigurationError, "pass exactly one of url: or command:"
         end
 
-        if url && token && URI(url).scheme == "http" && !LOOPBACK.include?(URI(url).host)
-          raise ConfigurationError,
-                "refusing to send a bearer token over plain HTTP to #{URI(url).host}"
-        end
+        validate_limit(:max_tool_pages, max_tool_pages)
+        validate_limit(:max_tools, max_tools)
 
         @wire = if url
                   Wires::Http.new(url: url, token: token, headers: headers,
-                                  open_timeout: open_timeout, read_timeout: read_timeout)
+                                  open_timeout: open_timeout, read_timeout: read_timeout,
+                                  allow_non_public: allow_non_public)
                 else
                   Wires::Stdio.new(command: command, env: env, read_timeout: read_timeout)
                 end
@@ -51,6 +49,8 @@ module Mistri
         @mutex = Mutex.new
         @serial = 0
         @connected = false
+        @max_tool_pages = max_tool_pages
+        @max_tools = max_tools
       end
 
       # The server's tools as it describes them: hashes with "name",
@@ -146,13 +146,32 @@ module Mistri
       def list_tools
         collected = []
         cursor = nil
-        loop do
+        seen_cursors = {}
+        @max_tool_pages.times do
           result = request("tools/list", cursor ? { cursor: cursor } : {})
-          collected.concat(Array(result["tools"]))
+          raise Error, "tools/list returned a malformed result" unless result.is_a?(Hash)
+
+          page = result["tools"]
+          raise Error, "tools/list returned a malformed tools collection" unless page.is_a?(Array)
+          if collected.length + page.length > @max_tools
+            raise Error, "tool discovery exceeded #{@max_tools} tools"
+          end
+
+          collected.concat(page)
           cursor = result["nextCursor"]
-          break unless cursor
+          return collected if cursor.nil?
+          raise Error, "tools/list returned a malformed cursor" unless cursor.is_a?(String)
+          raise Error, "tools/list repeated a cursor" if seen_cursors[cursor]
+
+          seen_cursors[cursor] = true
         end
-        collected
+        raise Error, "tool discovery exceeded #{@max_tool_pages} pages"
+      end
+
+      def validate_limit(name, value)
+        return if value.is_a?(Integer) && value.positive?
+
+        raise ConfigurationError, "#{name}: must be a positive integer"
       end
 
       def rpc_error(error)

--- a/lib/mistri/mcp/egress.rb
+++ b/lib/mistri/mcp/egress.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require "ipaddr"
+require "socket"
+require "timeout"
+require "uri"
+
+module Mistri
+  module MCP
+    # Resolves untrusted MCP URLs onto globally reachable addresses and pins
+    # that decision to the eventual connection. A host may narrowly approve a
+    # non-public address, but cannot bypass URL shape or plaintext rules.
+    module Egress
+      Target = Data.define(:uri, :address)
+      NAT64_WELL_KNOWN = IPAddr.new("64:ff9b::/96")
+      IPV6_GLOBAL_UNICAST = IPAddr.new("2000::/3")
+
+      # IANA IPv4/IPv6 Special-Purpose Address Registries, updated 2025-10-09.
+      # Broad non-global ranges contain a few globally reachable assignments.
+      # https://www.iana.org/assignments/iana-ipv4-special-registry/
+      # https://www.iana.org/assignments/iana-ipv6-special-registry/
+      # https://www.iana.org/assignments/ipv6-address-space/
+      GLOBAL_EXCEPTIONS = %w[
+        192.0.0.9/32
+        192.0.0.10/32
+        192.31.196.0/24
+        192.52.193.0/24
+        192.175.48.0/24
+        2001:1::1/128
+        2001:1::2/128
+        2001:1::3/128
+        2001:3::/32
+        2001:4:112::/48
+        2001:20::/28
+        2001:30::/28
+        2620:4f:8000::/48
+      ].map { |range| IPAddr.new(range) }.freeze
+
+      NON_GLOBAL = %w[
+        0.0.0.0/8
+        10.0.0.0/8
+        100.64.0.0/10
+        127.0.0.0/8
+        169.254.0.0/16
+        172.16.0.0/12
+        192.0.0.0/24
+        192.0.2.0/24
+        192.88.99.0/24
+        192.168.0.0/16
+        198.18.0.0/15
+        198.51.100.0/24
+        203.0.113.0/24
+        224.0.0.0/4
+        240.0.0.0/4
+        ::/96
+        64:ff9b:1::/48
+        100::/64
+        100:0:0:1::/64
+        2001::/23
+        2001:db8::/32
+        2002::/16
+        3fff::/20
+        5f00::/16
+        fc00::/7
+        fe80::/10
+        fec0::/10
+        ff00::/8
+      ].map { |range| IPAddr.new(range) }.freeze
+
+      module_function
+
+      def target(url, allow_non_public: nil, label: "URL", timeout: 15, lookup: nil)
+        targets(url, allow_non_public:, label:, timeout:, lookup:).first
+      end
+
+      def targets(url, allow_non_public: nil, label: "URL", timeout: 15, lookup: nil)
+        uri, address_resolver = resolver(url, allow_non_public:, label:, timeout:, lookup:)
+        address_resolver.call.map { |address| Target.new(uri:, address:) }
+      end
+
+      def resolver(url, allow_non_public: nil, label: "URL", timeout: 15, lookup: nil)
+        validate_exception(allow_non_public)
+        uri = normalize(url, label)
+        if uri.scheme == "http" && allow_non_public.nil?
+          raise UnsafeURLError, "#{label} must use HTTPS"
+        end
+
+        snapshot = uri.to_s.freeze
+        resolve_addresses = lambda do
+          target = URI(snapshot)
+          addresses = resolve(target, label, timeout, lookup: lookup)
+          approved_addresses(target, addresses, allow_non_public:, label:)
+            .map(&:to_s).freeze
+        end
+        [URI(snapshot), resolve_addresses]
+      end
+
+      def approved_addresses(uri, addresses, allow_non_public: nil, label: "URL")
+        validate_exception(allow_non_public)
+        if addresses.empty?
+          raise UnsafeURLError,
+                "#{label} host #{uri.hostname.inspect} resolved to no addresses"
+        end
+        rejected = addresses.reject do |address|
+          policy_uri = URI(uri.to_s).freeze
+          policy_address = address.dup.freeze
+          globally_reachable?(address) || allow_non_public&.call(policy_uri, policy_address)
+        end
+        unless rejected.empty?
+          raise UnsafeURLError,
+                "#{label} host #{uri.hostname.inspect} resolves to a non-public address"
+        end
+        if uri.scheme == "http" && !addresses.all?(&:loopback?)
+          raise UnsafeURLError, "#{label} must use HTTPS"
+        end
+
+        addresses
+      end
+
+      def approved_address(uri, addresses, allow_non_public: nil, label: "URL")
+        approved_addresses(uri, addresses, allow_non_public:, label:).first
+      end
+
+      def normalize(url, label = "URL")
+        uri = parse(url, label)
+        uri.scheme = uri.scheme.downcase
+        uri.host = uri.host.downcase
+        uri.port = nil if uri.port == uri.default_port
+        uri.path = "" if uri.path == "/"
+        uri
+      rescue URI::Error, ArgumentError
+        raise UnsafeURLError, "#{label} must be an absolute HTTP(S) URL"
+      end
+
+      def redirect_uri(url)
+        value = url.to_s
+        uri = parse(value, "redirect_uri")
+        return value if uri.scheme == "https"
+
+        address = parse_address(uri.hostname)
+        return value if uri.hostname.casecmp?("localhost") || address&.loopback?
+
+        raise UnsafeURLError, "redirect_uri must use HTTPS or an explicit loopback address"
+      end
+
+      def origin(uri)
+        value = uri.dup
+        value.path = ""
+        value.query = nil
+        value.to_s
+      end
+
+      def display(uri)
+        value = uri.dup
+        value.query = nil
+        value.to_s
+      end
+
+      def globally_reachable?(address)
+        address = address.native if address.ipv4_mapped?
+        if NAT64_WELL_KNOWN.include?(address)
+          embedded = IPAddr.new(address.to_i & 0xffffffff, Socket::AF_INET)
+          return globally_reachable?(embedded)
+        end
+        return true if GLOBAL_EXCEPTIONS.any? { |range| range.include?(address) }
+        return false if address.ipv6? && !IPV6_GLOBAL_UNICAST.include?(address)
+
+        NON_GLOBAL.none? { |range| range.include?(address) }
+      end
+
+      def resolve(uri, label, timeout, lookup: nil)
+        lookup ||= Addrinfo.method(:getaddrinfo)
+        entries = lookup.call(uri.hostname, uri.port, nil, :STREAM, timeout: timeout)
+        found = entries.filter_map do |entry|
+          address = parse_address(entry.ip_address)
+          address&.ipv4_mapped? ? address.native : address
+        end.uniq
+        if found.empty?
+          raise UnsafeURLError,
+                "#{label} host #{uri.hostname.inspect} resolved to no addresses"
+        end
+
+        found
+      rescue SocketError, IOError, Timeout::Error
+        raise UnsafeURLError, "#{label} host #{uri.hostname.inspect} could not be resolved"
+      end
+
+      def parse_address(value)
+        IPAddr.new(value)
+      rescue IPAddr::Error
+        nil
+      end
+
+      def validate_exception(exception)
+        return if exception.nil? || exception.respond_to?(:call)
+
+        raise ConfigurationError, "allow_non_public: must be callable"
+      end
+
+      def parse(url, label)
+        uri = URI.parse(url.to_s)
+        unless uri.is_a?(URI::HTTP) && %w[http https].include?(uri.scheme) &&
+               !uri.hostname.to_s.empty?
+          raise UnsafeURLError, "#{label} must be an absolute HTTP(S) URL"
+        end
+        raise UnsafeURLError, "#{label} must not contain credentials" if uri.user || uri.password
+        raise UnsafeURLError, "#{label} must not contain a fragment" if uri.fragment
+        raise UnsafeURLError, "#{label} has an invalid port" unless (1..65_535).cover?(uri.port)
+
+        uri
+      rescue URI::Error, ArgumentError
+        raise UnsafeURLError, "#{label} must be an absolute HTTP(S) URL"
+      end
+    end
+  end
+end

--- a/lib/mistri/mcp/oauth.rb
+++ b/lib/mistri/mcp/oauth.rb
@@ -3,6 +3,7 @@
 require "digest"
 require "json"
 require "net/http"
+require "openssl"
 require "securerandom"
 require "uri"
 
@@ -14,126 +15,230 @@ module Mistri
     # persist on the host's own connection record.
     #
     #   flow = Mistri::MCP::OAuth.start(url: params[:url],
-    #                                   client_name: "Sendoso",
+    #                                   client_name: "YourApp",
     #                                   redirect_uri: mcp_callback_url)
     #   # persist flow, redirect the user to flow["authorize_url"]
     #
     #   tokens = Mistri::MCP::OAuth.complete(code: params[:code], **persisted)
     #   tokens = Mistri::MCP::OAuth.refresh(**persisted)
+    #   # The host verifies callback state before complete.
     #
     # Registration happens as the APPLICATION, never as the harness:
     # client_name has no default because that identity is the host's call.
     # Servers without dynamic registration take client_id:/client_secret:
     # directly and skip it.
-    module OAuth
+    module OAuth # rubocop:disable Metrics/ModuleLength -- one flow shares one validated network chain
+      class ConnectionFailure < Error; end
+      Response = Data.define(:code, :headers, :body) do
+        def [](name) = headers[name.to_s.downcase]
+      end
+      AUTHORIZE_PARAMETERS = %w[response_type client_id redirect_uri state code_challenge
+                                code_challenge_method resource scope].freeze
+      MAX_RESPONSE_BYTES = 256 * 1024
+      WWW_AUTH_PARAM = /\A([A-Za-z0-9_-]+)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|([^\s,]+))/
+      TOKEN_ERROR_CODES = %w[
+        invalid_request invalid_client invalid_grant unauthorized_client
+        unsupported_grant_type invalid_scope invalid_target
+      ].freeze
+      TOKEN_AUTH_METHODS = %w[none client_secret_basic client_secret_post].freeze
+      private_constant :ConnectionFailure, :Response, :AUTHORIZE_PARAMETERS,
+                       :MAX_RESPONSE_BYTES, :WWW_AUTH_PARAM, :TOKEN_ERROR_CODES,
+                       :TOKEN_AUTH_METHODS
+
       module_function
 
       # Discover the server's authorization setup, register the application,
       # and build the authorize URL. Returns everything the callback and
       # refresh need: authorize_url, state, code_verifier, client_id,
-      # client_secret, token_auth_method, token_endpoint, resource,
-      # redirect_uri.
+      # client_secret, token_auth_method, issuer, resource, and redirect_uri.
+      # token_endpoint remains informational for compatibility; later
+      # operations rediscover it from issuer.
       #
-      # With no scope given, the server's advertised scopes_supported are
-      # requested, and offline_access rides along when the authorization
-      # server supports it, which is what earns a refresh token from
-      # providers that require it.
+      # With no scope given, the challenge or protected resource's advertised
+      # scopes are requested. Extra privileges are always host policy.
       def start(url:, client_name:, redirect_uri:, scope: nil,
-                client_id: nil, client_secret: nil)
+                client_id: nil, client_secret: nil, token_auth_method: nil,
+                issuer: nil, allow_non_public: nil)
+        validate_registration_input(client_id:, client_secret:, token_auth_method:, issuer:)
         resource = canonical(url)
-        resource_metadata = resource_metadata_for(url)
-        metadata = server_metadata(Array(resource_metadata["authorization_servers"]).first)
-        validate_endpoints(metadata)
-        registration = register(metadata, client_name, redirect_uri, client_id, client_secret)
+        redirect_uri = Egress.redirect_uri(redirect_uri)
+        resource_metadata, challenge_scope = resource_metadata_for(
+          resource, allow_non_public: allow_non_public
+        )
+        authority = authorization_server(resource_metadata, issuer: issuer)
+        metadata = server_metadata(authority, allow_non_public: allow_non_public)
+        validate_endpoints(metadata, allow_non_public: allow_non_public)
+        validate_pkce(metadata)
+        resolved_scope = resolve_scope(scope, challenge_scope, resource_metadata)
+        registration = register(metadata, client_name:, redirect_uri:, client_id:, client_secret:,
+                                          token_auth_method:, allow_non_public:)
         verifier = SecureRandom.urlsafe_base64(48)
         state = SecureRandom.urlsafe_base64(32)
         grant = { client_id: registration["client_id"], redirect_uri: redirect_uri,
                   verifier: verifier, state: state, resource: resource,
-                  scope: resolve_scope(scope, resource_metadata, metadata) }
+                  scope: resolved_scope }
         {
           "authorize_url" => authorize_url(metadata, grant),
           "state" => state, "code_verifier" => verifier,
           "client_id" => registration["client_id"],
           "client_secret" => registration["client_secret"],
           "token_auth_method" => registration["token_endpoint_auth_method"],
+          "issuer" => authority,
           "token_endpoint" => metadata.fetch("token_endpoint"),
           "resource" => resource, "redirect_uri" => redirect_uri
         }
       end
 
       # Exchange the callback's code for tokens.
-      def complete(code:, code_verifier:, client_id:, token_endpoint:, resource:,
-                   redirect_uri:, client_secret: nil, token_auth_method: nil, **)
+      def complete(code:, code_verifier:, client_id:, resource:, redirect_uri:, issuer: nil,
+                   client_secret: nil, token_auth_method: nil,
+                   allow_non_public: nil, **)
+        endpoint = discovered_token_endpoint(issuer, allow_non_public: allow_non_public)
         form = { "grant_type" => "authorization_code", "code" => code,
                  "code_verifier" => code_verifier, "client_id" => client_id,
-                 "redirect_uri" => redirect_uri, "resource" => resource }
-        token_request(token_endpoint, form, client_secret, token_auth_method)
+                 "redirect_uri" => Egress.redirect_uri(redirect_uri),
+                 "resource" => canonical(resource) }
+        token_request(endpoint, form, client_secret, token_auth_method,
+                      allow_non_public: allow_non_public)
       end
 
       # Trade a refresh token for a fresh set; OAuth 2.1 rotates refresh
       # tokens, so persist the returned one.
-      def refresh(refresh_token:, client_id:, token_endpoint:, resource:,
-                  client_secret: nil, token_auth_method: nil, **)
+      def refresh(refresh_token:, client_id:, resource:, issuer: nil, client_secret: nil,
+                  token_auth_method: nil, allow_non_public: nil, **)
+        endpoint = discovered_token_endpoint(issuer, allow_non_public: allow_non_public)
         form = { "grant_type" => "refresh_token", "refresh_token" => refresh_token,
-                 "client_id" => client_id, "resource" => resource }
-        token_request(token_endpoint, form, client_secret, token_auth_method)
+                 "client_id" => client_id, "resource" => canonical(resource) }
+        token_request(endpoint, form, client_secret, token_auth_method,
+                      allow_non_public: allow_non_public)
       end
 
       # -- discovery ---------------------------------------------------------
 
       # RFC 9728: a 401's WWW-Authenticate names the resource metadata URL;
       # servers that skip the header serve the well-known path.
-      def resource_metadata_for(url)
-        metadata_url = challenge_metadata_url(url) || well_known_resource_url(url)
-        document = get_json(metadata_url)
-        if Array(document["authorization_servers"]).empty?
-          raise Error, "#{metadata_url} names no authorization servers"
-        end
+      def resource_metadata_for(url, allow_non_public: nil)
+        challenge = challenge_parameters(url, allow_non_public: allow_non_public)
+        candidates = if challenge["resource_metadata"]
+                       [[challenge["resource_metadata"], url]]
+                     else
+                       resource_metadata_candidates(url)
+                     end
+        candidates.each do |metadata_url, expected_resource|
+          document = get_json(metadata_url, allow_non_public: allow_non_public, optional: true)
+          next unless document
 
-        document
+          validate_resource(document["resource"], expected_resource)
+          authorization_servers(document)
+          return [document, challenge["scope"]]
+        end
+        raise Error, "no protected resource metadata for #{Egress.display(URI(url))}"
       end
 
-      def challenge_metadata_url(url)
-        uri = URI(url)
-        response = http(uri) do |connection|
-          request = Net::HTTP::Post.new(uri)
-          request["Accept"] = "application/json, text/event-stream"
-          request["Content-Type"] = "application/json"
-          request.body = JSON.generate({ jsonrpc: "2.0", id: 0, method: "ping" })
-          connection.request(request)
-        end
-        challenge = response["WWW-Authenticate"].to_s
-        challenge[/resource_metadata="([^"]+)"/i, 1]
+      def challenge_parameters(url, allow_non_public: nil)
+        targets = Egress.targets(url, allow_non_public:, label: "MCP URL")
+        request = Net::HTTP::Post.new(targets.first.uri)
+        request["Accept"] = "application/json, text/event-stream"
+        request["Content-Type"] = "application/json"
+        request.body = JSON.generate({ jsonrpc: "2.0", id: 0, method: "ping" })
+        response = http(targets, request)
+        return {} unless response.code.to_i == 401
+
+        parse_www_authenticate(response["WWW-Authenticate"])
       end
 
-      def well_known_resource_url(url)
+      def well_known_resource_urls(url)
+        resource_metadata_candidates(url).map(&:first)
+      end
+
+      def resource_metadata_candidates(url)
         uri = URI(url)
-        path = uri.path.chomp("/")
-        origin = "#{uri.scheme}://#{uri.host}:#{uri.port}"
-        "#{origin}/.well-known/oauth-protected-resource#{path unless path.empty?}"
+        path = uri.path == "/" ? "" : uri.path.to_s
+        specific = "#{Egress.origin(uri)}/.well-known/oauth-protected-resource#{path}"
+        specific = "#{specific}?#{uri.query}" if uri.query
+        root = "#{Egress.origin(uri)}/.well-known/oauth-protected-resource"
+        [[specific, url], [root, Egress.origin(uri)]].uniq(&:first)
       end
 
       # RFC 8414 metadata, with the OpenID Connect path as a fallback since
       # large providers often serve only that document.
-      def server_metadata(authority)
-        uri = URI(authority)
-        origin = "#{uri.scheme}://#{uri.host}:#{uri.port}"
-        path = uri.path.chomp("/")
-        candidates = ["#{origin}/.well-known/oauth-authorization-server#{path unless path.empty?}",
-                      "#{origin}#{path}/.well-known/openid-configuration"]
+      def server_metadata(authority, allow_non_public: nil)
+        candidates = authorization_metadata_urls(authority)
         candidates.each do |candidate|
-          document = try_json(candidate)
-          return document if document&.key?("token_endpoint")
+          document = get_json(candidate, allow_non_public: allow_non_public, optional: true)
+          next unless document
+
+          unless document["issuer"] == authority
+            raise Error, "authorization server metadata issuer does not match #{authority}"
+          end
+
+          return document
         end
         raise Error, "no authorization server metadata at #{authority}"
+      end
+
+      def discovered_token_endpoint(issuer, allow_non_public: nil)
+        unless issuer.is_a?(String) && !issuer.empty?
+          raise ConfigurationError,
+                "issuer: is required; persist flow[\"issuer\"] from OAuth.start"
+        end
+
+        metadata = server_metadata(issuer, allow_non_public: allow_non_public)
+        endpoint = metadata["token_endpoint"]
+        raise Error, "authorization server metadata has no token_endpoint" unless endpoint
+
+        Egress.resolver(endpoint, allow_non_public:, label: "token_endpoint")
+        endpoint
+      end
+
+      def authorization_metadata_urls(authority)
+        uri = Egress.normalize(authority, "authorization server")
+        raise Error, "authorization server must not contain a query" if uri.query
+
+        origin = Egress.origin(uri)
+        path = uri.path.to_s.chomp("/")
+        if path.empty?
+          ["#{origin}/.well-known/oauth-authorization-server",
+           "#{origin}/.well-known/openid-configuration"]
+        else
+          ["#{origin}/.well-known/oauth-authorization-server#{path}",
+           "#{origin}/.well-known/openid-configuration#{path}",
+           "#{origin}#{path}/.well-known/openid-configuration"]
+        end
+      end
+
+      def authorization_servers(document)
+        servers = document["authorization_servers"]
+        unless servers.is_a?(Array) && servers.any? &&
+               servers.all? { |server| server.is_a?(String) && !server.empty? }
+          raise Error, "protected resource metadata names no authorization servers"
+        end
+
+        servers.uniq
+      end
+
+      # Authorization-server selection is host policy whenever discovery
+      # offers a choice. Pre-registered client identities are always bound to
+      # the exact issuer supplied when they were provisioned.
+      def authorization_server(document, issuer: nil)
+        servers = authorization_servers(document)
+        if issuer
+          return issuer if servers.include?(issuer)
+
+          raise Error, "protected resource metadata does not name the configured issuer"
+        end
+        return servers.first if servers.one?
+
+        raise ConfigurationError, "multiple authorization servers advertised; pass issuer:"
       end
 
       # RFC 7591 dynamic registration, as the application. Servers without a
       # registration endpoint require a pre-registered client id. The
       # returned hash keeps the token endpoint auth method the server
       # granted, so token requests authenticate the way it expects.
-      def register(metadata, client_name, redirect_uri, client_id, client_secret)
-        return { "client_id" => client_id, "client_secret" => client_secret } if client_id
+      def register(metadata, client_name:, redirect_uri:, client_id:, client_secret:,
+                   token_auth_method:, allow_non_public:)
+        return pre_registered_client(client_id, client_secret, token_auth_method) if client_id
 
         endpoint = metadata["registration_endpoint"]
         unless endpoint
@@ -141,47 +246,155 @@ module Mistri
                        "pass client_id:/client_secret: from a manual registration"
         end
 
+        requested_method = registration_auth_method(metadata)
         registration = post_json(endpoint, {
                                    "client_name" => client_name,
                                    "redirect_uris" => [redirect_uri],
                                    "grant_types" => %w[authorization_code refresh_token],
                                    "response_types" => ["code"],
-                                   "token_endpoint_auth_method" => "client_secret_post"
-                                 })
-        {
+                                   "token_endpoint_auth_method" => requested_method
+                                 }, allow_non_public: allow_non_public)
+        result = {
           "client_id" => presence(registration["client_id"]) ||
-            raise(Error, "registration returned no client_id"),
+                         raise(Error, "registration returned no client_id"),
           "client_secret" => presence(registration["client_secret"]),
           "token_endpoint_auth_method" => presence(registration["token_endpoint_auth_method"])
         }
-      end
-
-      # No scope given: request what the resource advertises, and add
-      # offline_access when the authorization server supports it (that is
-      # what earns a refresh token from providers that require it). An
-      # unsupported offline_access is stripped rather than sent blind.
-      def resolve_scope(scope, resource_metadata, metadata)
-        scopes = scope.to_s.split
-        scopes = Array(resource_metadata["scopes_supported"]) if scopes.empty?
-        supported = Array(metadata["scopes_supported"])
-        if supported.include?("offline_access")
-          scopes |= ["offline_access"]
-        else
-          scopes -= ["offline_access"]
+        default_method = result["client_secret"] ? requested_method : "none"
+        result["token_endpoint_auth_method"] ||= default_method
+        validate_token_auth_method(result["token_endpoint_auth_method"])
+        if result["token_endpoint_auth_method"] != "none" && !result["client_secret"]
+          raise Error, "registration selected secret authentication without a client_secret"
         end
-        scopes.empty? ? nil : scopes.join(" ")
+        if result["token_endpoint_auth_method"] == "none" && result["client_secret"]
+          raise Error, "registration returned a client_secret for an unauthenticated client"
+        end
+
+        result
       end
 
-      # The spec requires authorization server endpoints over HTTPS;
-      # loopback stays allowed for development.
-      def validate_endpoints(metadata)
+      def pre_registered_client(client_id, client_secret, token_auth_method)
+        token_auth_method ||= client_secret ? "client_secret_basic" : "none"
+        validate_token_auth_method(token_auth_method)
+        if token_auth_method != "none" && !client_secret
+          raise Error, "#{token_auth_method} requires a client_secret"
+        end
+
+        { "client_id" => client_id, "client_secret" => client_secret,
+          "token_endpoint_auth_method" => token_auth_method }
+      end
+
+      def registration_auth_method(metadata)
+        supported = metadata["token_endpoint_auth_methods_supported"]
+        supported = ["client_secret_basic"] if supported.nil?
+        unless supported.is_a?(Array) && supported.all?(String)
+          raise Error, "authorization server token auth methods are malformed"
+        end
+
+        preferred = %w[client_secret_basic client_secret_post none]
+        preferred.find { |method| supported.include?(method) } ||
+          raise(Error, "authorization server offers no supported token auth method")
+      end
+
+      def validate_registration_input(client_id:, client_secret:, token_auth_method:, issuer:)
+        validate_client_id(client_id) if client_id
+        validate_client_secret(client_secret) if client_secret
+        validate_issuer_argument(issuer) if issuer
+        validate_token_auth_argument(token_auth_method) if token_auth_method
+        validate_registration_relationships(client_id, client_secret, token_auth_method, issuer)
+      end
+
+      def validate_client_id(client_id)
+        return if client_id.is_a?(String) && !client_id.strip.empty?
+
+        raise ConfigurationError, "client_id: must be a non-empty string"
+      end
+
+      def validate_client_secret(client_secret)
+        return if client_secret.is_a?(String) && !client_secret.empty?
+
+        raise ConfigurationError, "client_secret: must be a non-empty string"
+      end
+
+      def validate_issuer_argument(issuer)
+        return if issuer.is_a?(String) && !issuer.empty?
+
+        raise ConfigurationError, "issuer: must be a non-empty string"
+      end
+
+      def validate_token_auth_argument(token_auth_method)
+        return if TOKEN_AUTH_METHODS.include?(token_auth_method)
+
+        raise ConfigurationError,
+              "unsupported token endpoint authentication method #{token_auth_method.inspect}"
+      end
+
+      def validate_registration_relationships(client_id, client_secret, token_auth_method, issuer)
+        if client_secret && !client_id
+          raise ConfigurationError, "client_secret: requires client_id:"
+        end
+        if token_auth_method && !client_id
+          raise ConfigurationError, "token_auth_method: requires client_id:"
+        end
+        if client_id && !issuer
+          raise ConfigurationError,
+                "issuer: is required for a pre-registered client_id"
+        end
+        secret_methods = %w[client_secret_basic client_secret_post]
+        if client_id && secret_methods.include?(token_auth_method) && !client_secret
+          raise ConfigurationError, "#{token_auth_method} requires a client_secret"
+        end
+        return unless client_secret && token_auth_method == "none"
+
+        raise ConfigurationError, "token_auth_method: none cannot be paired with client_secret:"
+      end
+
+      # Explicit host policy wins; otherwise the 401 challenge and then the
+      # protected resource metadata define the least-privilege request.
+      def resolve_scope(scope, challenge_scope, resource_metadata)
+        challenged = challenge_scope.to_s.split.uniq
+        if scope
+          requested = scope.to_s.split.uniq
+          missing = challenged - requested
+          unless missing.empty?
+            raise ConfigurationError,
+                  "scope: must include every scope required by the MCP challenge"
+          end
+
+          return requested.empty? ? nil : requested.join(" ")
+        end
+        return challenged.join(" ") unless challenged.empty?
+
+        supported = resource_metadata["scopes_supported"]
+        return nil if supported.nil?
+        unless supported.is_a?(Array) && supported.all?(String)
+          raise Error, "protected resource scopes_supported is malformed"
+        end
+
+        supported.empty? ? nil : supported.uniq.join(" ")
+      end
+
+      def validate_endpoints(metadata, allow_non_public: nil)
+        %w[authorization_endpoint token_endpoint].each do |required|
+          raise Error, "authorization server metadata has no #{required}" unless metadata[required]
+        end
         %w[authorization_endpoint token_endpoint registration_endpoint].each do |key|
           value = metadata[key] or next
-          uri = URI(value)
-          next if uri.scheme == "https" || %w[localhost 127.0.0.1 ::1].include?(uri.host)
-
-          raise Error, "#{key} #{value} is not HTTPS"
+          Egress.target(value, allow_non_public:, label: key)
         end
+      end
+
+      def validate_pkce(metadata)
+        methods = metadata["code_challenge_methods_supported"]
+        return if methods.is_a?(Array) && methods.include?("S256")
+
+        raise Error, "authorization server does not advertise S256 PKCE support"
+      end
+
+      def validate_token_auth_method(method)
+        return if TOKEN_AUTH_METHODS.include?(method)
+
+        raise Error, "unsupported token endpoint authentication method"
       end
 
       def presence(value)
@@ -196,91 +409,227 @@ module Mistri
                    "resource" => grant[:resource] }
         params["scope"] = grant[:scope] if grant[:scope]
         endpoint = URI(metadata.fetch("authorization_endpoint"))
-        endpoint.query = [endpoint.query, URI.encode_www_form(params)].compact.join("&")
+        existing = URI.decode_www_form(endpoint.query.to_s)
+        existing.reject! { |key, _value| AUTHORIZE_PARAMETERS.include?(key) }
+        endpoint.query = URI.encode_www_form(existing + params.to_a)
         endpoint.to_s
       end
 
       # -- plumbing ----------------------------------------------------------
 
-      # RFC 8707 canonical form: lowercase scheme and host, no fragment.
+      # RFC 8707 canonical form: lowercase scheme and host, with no default
+      # port or semantically empty root path.
       def canonical(url)
-        uri = URI(url)
-        uri.fragment = nil
-        uri.scheme = uri.scheme.downcase
-        uri.host = uri.host.downcase if uri.host
-        uri.to_s
+        Egress.normalize(url, "resource").to_s
       end
 
-      def token_request(endpoint, form, client_secret, auth_method = nil)
-        basic = client_secret && auth_method == "client_secret_basic"
-        form = form.merge("client_secret" => client_secret) if client_secret && !basic
-        credentials = basic ? [form["client_id"], client_secret] : nil
-        payload = post_form(endpoint, form, basic_auth: credentials)
+      def token_request(endpoint, form, client_secret, auth_method = nil, allow_non_public: nil)
+        # 0.5.0 persisted no method and sent the secret in the form. New flows
+        # always persist an explicit method; keep old connected rows usable.
+        auth_method ||= client_secret ? "client_secret_post" : "none"
+        validate_token_auth_method(auth_method)
+        form, credentials = token_authentication(form, client_secret, auth_method)
+        payload = post_form(endpoint, form, basic_auth: credentials,
+                                            allow_non_public: allow_non_public)
+        validate_token_response(payload)
+
         expires_in = payload["expires_in"]
         {
-          "access_token" => payload.fetch("access_token"),
+          "access_token" => payload["access_token"],
           "refresh_token" => payload["refresh_token"],
           "scope" => payload["scope"],
           "expires_at" => expires_in ? Time.now.utc + expires_in.to_i : nil
         }
       end
 
-      def get_json(url)
-        uri = URI(url)
-        response = http(uri) { |connection| connection.request(Net::HTTP::Get.new(uri)) }
-        raise Error, "GET #{url} answered #{response.code}" unless response.code.to_i == 200
-
-        JSON.parse(response.body)
-      end
-
-      def try_json(url)
-        get_json(url)
-      rescue Error, JSON::ParserError
-        nil
-      end
-
-      def post_json(url, body)
-        uri = URI(url)
-        response = http(uri) do |connection|
-          request = Net::HTTP::Post.new(uri)
-          request["Content-Type"] = "application/json"
-          request.body = JSON.generate(body)
-          connection.request(request)
+      def token_authentication(form, client_secret, auth_method)
+        if auth_method == "none" && client_secret
+          raise Error, "token_endpoint_auth_method none cannot use a client_secret"
         end
+
+        credentials = nil
+        case auth_method
+        when "client_secret_basic"
+          raise Error, "client_secret_basic requires a client_secret" unless client_secret
+
+          credentials = [form["client_id"], client_secret].map do |part|
+            URI.encode_www_form_component(part)
+          end
+        when "client_secret_post"
+          raise Error, "client_secret_post requires a client_secret" unless client_secret
+
+          form = form.merge("client_secret" => client_secret)
+        end
+
+        [form, credentials]
+      end
+
+      def validate_token_response(payload)
+        token_type = payload["token_type"]
+        unless token_type.is_a?(String) && token_type.casecmp?("Bearer")
+          raise Error, "token endpoint returned unsupported token_type"
+        end
+
+        access_token = payload["access_token"]
+        return if access_token.is_a?(String) && !access_token.strip.empty?
+
+        raise Error, "token endpoint returned no access_token"
+      end
+
+      def get_json(url, allow_non_public: nil, optional: false)
+        targets = Egress.targets(url, allow_non_public:, label: "metadata URL")
+        location = Egress.display(targets.first.uri)
+        request = Net::HTTP::Get.new(targets.first.uri)
+        request["Accept"] = "application/json"
+        response = http(targets, request)
+        return nil if optional && response.code.to_i != 200
+        raise Error, "GET #{location} answered #{response.code}" unless response.code.to_i == 200
+
+        object = JSON.parse(response.body)
+        raise Error, "GET #{location} did not return a JSON object" unless object.is_a?(Hash)
+
+        object
+      rescue ConnectionFailure
+        return nil if optional
+
+        raise
+      rescue JSON::ParserError
+        raise Error, "GET #{location} returned invalid JSON"
+      end
+
+      def post_json(url, body, allow_non_public: nil)
+        targets = Egress.targets(url, allow_non_public:, label: "registration_endpoint")
+        location = Egress.display(targets.first.uri)
+        request = Net::HTTP::Post.new(targets.first.uri)
+        request["Content-Type"] = "application/json"
+        request["Accept"] = "application/json"
+        request.body = JSON.generate(body)
+        response = http(targets, request)
         unless %w[200 201].include?(response.code)
-          raise Error, "POST #{url} answered #{response.code}: #{response.body.to_s[0, 200]}"
+          raise Error, "POST #{location} answered #{response.code}"
         end
 
-        JSON.parse(response.body)
+        object = JSON.parse(response.body)
+        raise Error, "registration endpoint did not return a JSON object" unless object.is_a?(Hash)
+
+        object
+      rescue JSON::ParserError
+        raise Error, "registration endpoint returned invalid JSON"
       end
 
-      def post_form(url, form, basic_auth: nil)
-        uri = URI(url)
-        response = http(uri) do |connection|
-          request = Net::HTTP::Post.new(uri)
-          request["Content-Type"] = "application/x-www-form-urlencoded"
-          request["Accept"] = "application/json"
-          request.basic_auth(*basic_auth) if basic_auth
-          request.body = URI.encode_www_form(form)
-          connection.request(request)
-        end
+      def post_form(url, form, basic_auth: nil, allow_non_public: nil)
+        targets = Egress.targets(url, allow_non_public:, label: "token_endpoint")
+        request = Net::HTTP::Post.new(targets.first.uri)
+        request["Content-Type"] = "application/x-www-form-urlencoded"
+        request["Accept"] = "application/json"
+        request.basic_auth(*basic_auth) if basic_auth
+        request.body = URI.encode_www_form(form)
+        response = http(targets, request)
         payload = begin
           JSON.parse(response.body)
-        rescue StandardError
+        rescue JSON::ParserError
+          raise Error, "token endpoint returned invalid JSON" if response.code.to_i == 200
+
           {}
         end
-        unless response.code.to_i == 200
-          reason = payload["error_description"] || payload["error"] || response.body.to_s[0, 200]
-          raise Error, "token request failed (#{response.code}): #{reason}"
-        end
+        raise Error, "token endpoint did not return a JSON object" unless payload.is_a?(Hash)
 
+        unless response.code.to_i == 200
+          reason = payload["error"]
+          reason = nil unless TOKEN_ERROR_CODES.include?(reason)
+          detail = reason ? ": #{reason}" : ""
+          raise Error, "token request failed (#{response.code})#{detail}"
+        end
         payload
       end
 
-      def http(uri, &)
-        Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https",
-                                            open_timeout: 15, read_timeout: 30, &)
+      def http(targets, request)
+        request["Accept-Encoding"] = "identity"
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 15
+        targets.each do |target|
+          remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          break unless remaining.positive?
+
+          connection = oauth_connection(target, open_timeout: remaining)
+          begin
+            connection.start
+          rescue IOError, SocketError, SystemCallError, Timeout::Error,
+                 Net::HTTPBadResponse, OpenSSL::SSL::SSLError
+            next
+          end
+
+          begin
+            return bounded_response(connection, request)
+          rescue IOError, SocketError, SystemCallError, Timeout::Error,
+                 Net::HTTPBadResponse, OpenSSL::SSL::SSLError
+            raise ConnectionFailure, "OAuth connection failed"
+          ensure
+            finish_connection(connection)
+          end
+        end
+        raise ConnectionFailure, "OAuth connection failed"
       end
-    end
+
+      def oauth_connection(target, open_timeout:)
+        Net::HTTP.new(target.uri.hostname, target.uri.port, nil).tap do |connection|
+          connection.ipaddr = target.address
+          connection.use_ssl = target.uri.scheme == "https"
+          connection.open_timeout = open_timeout
+          connection.read_timeout = 30
+          connection.max_retries = 0
+        end
+      end
+
+      def bounded_response(connection, request)
+        result = nil
+        connection.request(request) do |response|
+          body = +""
+          response.read_body do |chunk|
+            if body.bytesize + chunk.bytesize > MAX_RESPONSE_BYTES
+              raise Error, "OAuth response exceeded #{MAX_RESPONSE_BYTES} bytes"
+            end
+
+            body << chunk
+          end
+          headers = response.to_hash.transform_values { |values| values.join(", ") }
+          result = Response.new(code: response.code, headers: headers, body: body)
+        end
+        result
+      end
+
+      def finish_connection(connection)
+        connection.finish if connection.started?
+      rescue IOError, SystemCallError, OpenSSL::SSL::SSLError
+        nil
+      end
+
+      def validate_resource(candidate, expected)
+        raise Error, "protected resource metadata has no resource" unless candidate.is_a?(String)
+
+        resource = canonical(candidate)
+        return if resource == canonical(expected)
+
+        raise Error,
+              "protected resource metadata resource does not match " \
+              "#{Egress.display(URI(expected))}"
+      end
+
+      def parse_www_authenticate(header)
+        match = header.to_s.match(/(?:\A|,)\s*Bearer(?:\s+|\z)/i)
+        return {} unless match
+
+        cursor = match.end(0)
+        params = {}
+        while cursor < header.length
+          rest = header[cursor..].sub(/\A\s*,?\s*/, "")
+          pair = rest.match(WWW_AUTH_PARAM)
+          break unless pair
+
+          params[pair[1].downcase] = pair[2] ? pair[2].gsub(/\\(.)/, '\\1') : pair[3]
+          cursor = header.length - rest.length + pair.end(0)
+        end
+        params
+      end
+    end # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/mistri/mcp/wires.rb
+++ b/lib/mistri/mcp/wires.rb
@@ -13,14 +13,23 @@ module Mistri
       # Streamable HTTP: requests POST to one endpoint, responses arrive as
       # JSON or an SSE stream. Sessions and bearer auth live here.
       class Http
-        def initialize(url:, token:, headers:, open_timeout:, read_timeout:)
-          uri = URI(url)
+        HEADER_NAME = /\A[!#$%&'*+\-.^_`|~0-9A-Za-z]+\z/
+        INVALID_HEADER_VALUE = /[\x00-\x1F\x7F]/n
+        RESERVED_HEADERS = %w[host content-length transfer-encoding connection keep-alive
+                              proxy-authenticate proxy-authorization proxy-connection te trailer
+                              upgrade accept content-type accept-encoding mcp-session-id
+                              mcp-protocol-version].freeze
+        private_constant :HEADER_NAME, :INVALID_HEADER_VALUE, :RESERVED_HEADERS
+
+        def initialize(url:, token:, headers:, open_timeout:, read_timeout:, allow_non_public:)
+          uri, resolver = Egress.resolver(url, allow_non_public:, label: "MCP URL",
+                                               timeout: open_timeout)
           @path = uri.path.empty? ? "/" : uri.path
           @path = "#{@path}?#{uri.query}" if uri.query
-          @transport = Transport.new(origin: "#{uri.scheme}://#{uri.host}:#{uri.port}",
+          @transport = Transport.new(origin: Egress.origin(uri), address_resolver: resolver,
                                      open_timeout: open_timeout, read_timeout: read_timeout)
           @token = token
-          @headers = headers
+          @headers = normalized_headers(headers)
           @session_id = nil
           @protocol_version = nil
         end
@@ -49,6 +58,24 @@ module Mistri
         def close = @transport.close
 
         private
+
+        def normalized_headers(headers)
+          headers.each_with_object({}) do |(key, value), copy|
+            name = key.to_s
+            content = value.to_s
+            unless name.ascii_only? && HEADER_NAME.match?(name)
+              raise ConfigurationError, "#{name.inspect} is not a valid HTTP header name"
+            end
+            if RESERVED_HEADERS.include?(name.downcase)
+              raise ConfigurationError, "#{name} is managed by the MCP transport"
+            end
+            if INVALID_HEADER_VALUE.match?(content.b)
+              raise ConfigurationError, "#{name} contains invalid control characters"
+            end
+
+            copy[name.dup.freeze] = content.dup.freeze
+          end.freeze
+        end
 
         def request_headers
           headers = { "Accept" => "application/json, text/event-stream" }

--- a/lib/mistri/transport.rb
+++ b/lib/mistri/transport.rb
@@ -15,15 +15,57 @@ module Mistri
   # Streaming reads abort two ways: cooperatively between fragments, and hard,
   # by closing the socket from the abort signal's callback, so a stalled read
   # stops immediately instead of waiting out the read timeout.
+  # An address_resolver supplies a fresh validated set for each connection
+  # cycle; candidates are tried before the request is sent while the original
+  # hostname still owns Host, SNI, and TLS validation.
   class Transport
     KEEP_ALIVE_SECONDS = 30
+    CONNECT_ERRORS = [IOError, SocketError, SystemCallError, Timeout::Error,
+                      Net::HTTPBadResponse, OpenSSL::SSL::SSLError].freeze
 
-    def initialize(origin:, open_timeout: 15, read_timeout: 300, write_timeout: 60)
+    # Net::HTTP reconnects expired keep-alives internally. Resolving inside
+    # connect makes every MCP connection cycle cross the egress boundary.
+    class ResolvedHTTP < Net::HTTP
+      attr_writer :address_resolver
+
+      private
+
+      def connect
+        addresses = Array(@address_resolver.call)
+        raise ConfigurationError, "address_resolver returned no addresses" if addresses.empty?
+
+        original_timeout = @open_timeout
+        deadline = if original_timeout
+                     Process.clock_gettime(Process::CLOCK_MONOTONIC) + original_timeout
+                   end
+        failure = nil
+        addresses.each do |address|
+          remaining = deadline && (deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC))
+          break if remaining && !remaining.positive?
+
+          @ipaddr = address
+          @open_timeout = remaining if remaining
+          begin
+            return super
+          rescue *CONNECT_ERRORS => e
+            failure = e
+          end
+        end
+        raise failure || Net::OpenTimeout.new("all approved addresses timed out")
+      ensure
+        @open_timeout = original_timeout if original_timeout
+      end
+    end
+    private_constant :ResolvedHTTP, :CONNECT_ERRORS
+
+    def initialize(origin:, open_timeout: 15, read_timeout: 300, write_timeout: 60,
+                   address_resolver: nil)
       @origin = origin.to_s.chomp("/")
       @uri = URI(@origin)
       @open_timeout = open_timeout
       @read_timeout = read_timeout
       @write_timeout = write_timeout
+      @address_resolver = address_resolver
       @mutex = Mutex.new
       @connection = nil
     end
@@ -180,13 +222,21 @@ module Mistri
     end
 
     def connection
-      @connection ||= Net::HTTP.new(@uri.host, @uri.port).tap do |http|
+      @connection ||= begin
+        http = if @address_resolver
+                 ResolvedHTTP.new(@uri.hostname, @uri.port, nil).tap do |resolved|
+                   resolved.address_resolver = @address_resolver
+                 end
+               else
+                 Net::HTTP.new(@uri.hostname, @uri.port)
+               end
         http.use_ssl = @uri.scheme == "https"
         http.open_timeout = @open_timeout
         http.read_timeout = @read_timeout
         http.write_timeout = @write_timeout
         http.keep_alive_timeout = KEEP_ALIVE_SECONDS
         http.start
+        http
       end
     end
 

--- a/test/support/mcp_stub_server.rb
+++ b/test/support/mcp_stub_server.rb
@@ -15,7 +15,8 @@ module Mistri
 
       def initialize(tools: {}, sse: true, session: nil, page_size: nil,
                      require_token: nil, expire_after: nil, protocol: "2025-11-25",
-                     drop_after: nil, malformed_after: nil, empty_after: nil)
+                     drop_after: nil, malformed_after: nil, empty_after: nil,
+                     next_cursor: nil)
         @tools = tools
         @sse = sse
         @session = session
@@ -26,6 +27,7 @@ module Mistri
         @drop_after = drop_after
         @malformed_after = malformed_after
         @empty_after = empty_after
+        @next_cursor = next_cursor
         @dropped = false
         @malformed = false
         @emptied = false
@@ -104,7 +106,12 @@ module Mistri
         start = cursor.to_i
         slice = specs[start, @page_size] || []
         result = { "tools" => slice }
-        result["nextCursor"] = (start + @page_size).to_s if start + @page_size < specs.length
+        next_cursor = if @next_cursor
+                        @next_cursor.call(cursor)
+                      elsif start + @page_size < specs.length
+                        (start + @page_size).to_s
+                      end
+        result["nextCursor"] = next_cursor unless next_cursor.nil?
         result
       end
 

--- a/test/support/oauth_stub_server.rb
+++ b/test/support/oauth_stub_server.rb
@@ -14,20 +14,51 @@ module Mistri
       attr_reader :registrations, :token_requests
 
       def initialize(challenge_header: true, registration: true, openid_only: false,
-                     resource_scopes: [], as_scopes: [], basic_token_auth: false)
+                     resource_scopes: [], as_scopes: [], basic_token_auth: false,
+                     challenge_scope: nil, challenge_metadata: :default,
+                     path_metadata: true, root_metadata: false, resource: :default,
+                     authorization_server: :default, authorization_servers: nil,
+                     issuer: :default, pkce: ["S256"], endpoints: {},
+                     metadata_redirect: nil, oauth_metadata_status: nil,
+                     path_metadata_status: nil, token_response: nil,
+                     token_error: "invalid_grant", token_error_description: nil,
+                     token_auth_methods: nil,
+                     registration_secret: "shh", registration_auth_method: nil,
+                     query: nil)
         @challenge_header = challenge_header
+        @challenge_scope = challenge_scope
+        @challenge_metadata = challenge_metadata
         @registration = registration
         @openid_only = openid_only
+        @path_metadata = path_metadata
+        @root_metadata = root_metadata
+        @path_metadata_status = path_metadata_status
+        @resource = resource
+        @authorization_server = authorization_server
+        @authorization_servers = authorization_servers
+        @issuer = issuer
+        @pkce = pkce
+        @endpoints = endpoints
+        @metadata_redirect = metadata_redirect
+        @oauth_metadata_status = oauth_metadata_status
         @resource_scopes = resource_scopes
         @as_scopes = as_scopes
         @basic_token_auth = basic_token_auth
+        @token_response = token_response
+        @token_error = token_error
+        @token_error_description = token_error_description
+        @token_auth_methods = token_auth_methods
+        @registration_secret = registration_secret
+        @registration_auth_method = registration_auth_method
+        @query = query
         @registrations = []
         @token_requests = []
         @stub = StubServer.new { |socket, request| route(socket, request) }
       end
 
       def origin = @stub.origin
-      def url = "#{origin}/mcp"
+      def url = @query ? "#{origin}/mcp?#{@query}" : "#{origin}/mcp"
+      def requests = @stub.requests
       def stop = @stub.stop
 
       private
@@ -36,7 +67,15 @@ module Mistri
         verb, path, = request[:line].split
         case [verb, path.split("?").first]
         in ["POST", "/mcp"] then challenge(socket)
-        in ["GET", "/.well-known/oauth-protected-resource/mcp"] then resource_metadata(socket)
+        in ["GET", "/.well-known/oauth-protected-resource/mcp"]
+          if @path_metadata_status
+            @stub.respond_json(socket, { "error" => "path metadata" },
+                               status: @path_metadata_status)
+          else
+            @path_metadata ? resource_metadata(socket, root: false) : not_found(socket)
+          end
+        in ["GET", "/.well-known/oauth-protected-resource"]
+          @root_metadata ? resource_metadata(socket, root: true) : not_found(socket)
         in ["GET", "/.well-known/oauth-authorization-server"] then server_metadata(socket,
                                                                                    openid: false)
         in ["GET", "/.well-known/openid-configuration"] then server_metadata(socket, openid: true)
@@ -50,35 +89,63 @@ module Mistri
       def challenge(socket)
         headers = {}
         if @challenge_header
-          metadata = "#{origin}/.well-known/oauth-protected-resource/mcp"
-          headers["WWW-Authenticate"] = "Bearer resource_metadata=\"#{metadata}\""
+          metadata = if @challenge_metadata == :default
+                       "#{origin}/.well-known/oauth-protected-resource/mcp"
+                     else
+                       @challenge_metadata
+                     end
+          params = []
+          params << "resource_metadata=\"#{metadata}\"" if metadata
+          params << "scope=\"#{@challenge_scope}\"" if @challenge_scope
+          headers["WWW-Authenticate"] = "Basic realm=\"stub\", Bearer #{params.join(", ")}"
         end
         @stub.respond_json(socket, { "error" => "unauthorized" }, status: 401, headers: headers)
       end
 
-      def resource_metadata(socket)
-        document = { "resource" => url, "authorization_servers" => [origin] }
+      def resource_metadata(socket, root:)
+        if @metadata_redirect
+          return @stub.respond_json(socket, "", status: 302,
+                                                headers: { "Location" => @metadata_redirect })
+        end
+
+        resource = setting(@resource, root ? origin : url)
+        authority = setting(@authorization_server, origin)
+        servers = @authorization_servers ? setting(@authorization_servers, nil) : [authority]
+        document = { "authorization_servers" => servers }
+        document["resource"] = resource if resource
         document["scopes_supported"] = @resource_scopes if @resource_scopes.any?
         @stub.respond_json(socket, document)
       end
 
       def server_metadata(socket, openid:)
+        if !openid && @oauth_metadata_status
+          return @stub.respond_json(socket, { "error" => "oauth metadata" },
+                                    status: @oauth_metadata_status)
+        end
         if @openid_only != openid
           return @stub.respond_json(socket, { "error" => "not found" }, status: 404)
         end
 
-        metadata = { "issuer" => origin,
+        issuer = setting(@issuer, origin)
+        metadata = { "issuer" => issuer,
                      "authorization_endpoint" => "#{origin}/authorize",
                      "token_endpoint" => "#{origin}/token" }
+        metadata["code_challenge_methods_supported"] = @pkce if @pkce
         metadata["scopes_supported"] = @as_scopes if @as_scopes.any?
+        if @token_auth_methods
+          metadata["token_endpoint_auth_methods_supported"] = @token_auth_methods
+        end
         metadata["registration_endpoint"] = "#{origin}/register" if @registration
+        @endpoints.each { |key, value| metadata[key] = setting(value, value) }
         @stub.respond_json(socket, metadata)
       end
 
       def register(socket, request)
         @registrations << JSON.parse(request[:body])
-        method = @basic_token_auth ? "client_secret_basic" : "client_secret_post"
-        @stub.respond_json(socket, { "client_id" => "app-123", "client_secret" => "shh",
+        method = @registration_auth_method ||
+                 (@basic_token_auth ? "client_secret_basic" : "client_secret_post")
+        @stub.respond_json(socket, { "client_id" => "app-123",
+                                     "client_secret" => @registration_secret,
                                      "token_endpoint_auth_method" => method },
                            status: 201)
       end
@@ -89,21 +156,37 @@ module Mistri
         case form["grant_type"]
         when "authorization_code"
           if form["code"] == "good-code" && !form["code_verifier"].to_s.empty?
-            @stub.respond_json(socket, { "access_token" => "at-1", "refresh_token" => "rt-1",
-                                         "expires_in" => 3600, "scope" => "tools" })
+            response = @token_response ||
+                       { "access_token" => "at-1", "refresh_token" => "rt-1",
+                         "token_type" => "Bearer", "expires_in" => 3600, "scope" => "tools" }
+            @stub.respond_json(socket, response)
           else
-            @stub.respond_json(socket, { "error" => "invalid_grant" }, status: 400)
+            error = { "error" => @token_error }
+            error["error_description"] = @token_error_description if @token_error_description
+            @stub.respond_json(socket, error, status: 400)
           end
         when "refresh_token"
           if form["refresh_token"] == "rt-1"
-            @stub.respond_json(socket, { "access_token" => "at-2", "refresh_token" => "rt-2",
-                                         "expires_in" => 3600 })
+            response = @token_response ||
+                       { "access_token" => "at-2", "refresh_token" => "rt-2",
+                         "token_type" => "Bearer", "expires_in" => 3600 }
+            @stub.respond_json(socket, response)
           else
             @stub.respond_json(socket, { "error" => "invalid_grant" }, status: 400)
           end
         else
           @stub.respond_json(socket, { "error" => "unsupported_grant_type" }, status: 400)
         end
+      end
+
+      def not_found(socket)
+        @stub.respond_json(socket, { "error" => "not found" }, status: 404)
+      end
+
+      def setting(value, fallback)
+        return fallback if value == :default
+
+        value.respond_to?(:call) ? value.call(self) : value
       end
     end
   end

--- a/test/support/tls_stub_server.rb
+++ b/test/support/tls_stub_server.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "json"
+require "openssl"
+require "socket"
+
+module Mistri
+  module Test
+    # A trusted local TLS endpoint that records the hostname presented through
+    # SNI and HTTP while the client connects to a pinned loopback address.
+    class TlsStubServer
+      attr_reader :ca_certificate, :requests, :server_name
+
+      def initialize(hostname:, certificate_hostname: hostname)
+        @hostname = hostname
+        @certificate_hostname = certificate_hostname
+        @requests = []
+        @tcp = TCPServer.new("127.0.0.1", 0)
+        @ca_certificate, certificate, key = certificates
+        context = OpenSSL::SSL::SSLContext.new
+        context.cert = certificate
+        context.key = key
+        context.servername_cb = lambda do |*arguments|
+          arguments = arguments.first if arguments.one? && arguments.first.is_a?(Array)
+          socket, name = arguments
+          @server_name = name || socket.hostname
+          nil
+        end
+        @server = OpenSSL::SSL::SSLServer.new(@tcp, context)
+        @thread = Thread.new { serve }
+      end
+
+      def origin = "https://#{@hostname}:#{@tcp.addr[1]}"
+
+      def stop
+        @tcp.close
+        @thread.kill
+        @thread.join
+      end
+
+      private
+
+      def serve
+        loop do
+          socket = @server.accept
+          request = read_request(socket)
+          @requests << request
+          payload = JSON.generate("ok" => true)
+          socket.write("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" \
+                       "Content-Length: #{payload.bytesize}\r\nConnection: close\r\n\r\n#{payload}")
+          socket.close
+        end
+      rescue IOError, OpenSSL::SSL::SSLError
+        nil
+      end
+
+      def read_request(socket)
+        line = socket.gets
+        headers = {}
+        while (header = socket.gets) && header != "\r\n"
+          key, value = header.split(": ", 2)
+          headers[key.downcase] = value.to_s.strip
+        end
+        socket.read(headers["content-length"].to_i)
+        { line: line, headers: headers }
+      end
+
+      def certificates
+        ca_key = OpenSSL::PKey::RSA.new(2048)
+        fingerprint = OpenSSL::Digest::SHA256.hexdigest(ca_key.public_key.to_der)[0, 16]
+        ca = certificate("Mistri test CA #{fingerprint}", ca_key, serial: 1)
+        extension(ca, "basicConstraints", "CA:TRUE", critical: true)
+        extension(ca, "keyUsage", "keyCertSign,cRLSign", critical: true)
+        ca.sign(ca_key, OpenSSL::Digest.new("SHA256"))
+
+        key = OpenSSL::PKey::RSA.new(2048)
+        leaf = certificate(@certificate_hostname, key, serial: 2, issuer: ca.subject)
+        extension(leaf, "basicConstraints", "CA:FALSE", critical: true)
+        extension(leaf, "keyUsage", "digitalSignature,keyEncipherment", critical: true)
+        extension(leaf, "extendedKeyUsage", "serverAuth")
+        extension(leaf, "subjectAltName", "DNS:#{@certificate_hostname}")
+        leaf.sign(ca_key, OpenSSL::Digest.new("SHA256"))
+        [ca, leaf, key]
+      end
+
+      def certificate(name, key, serial:, issuer: nil)
+        OpenSSL::X509::Certificate.new.tap do |cert|
+          cert.version = 2
+          cert.serial = serial
+          cert.subject = OpenSSL::X509::Name.parse("/CN=#{name}")
+          cert.issuer = issuer || cert.subject
+          cert.public_key = key.public_key
+          cert.not_before = Time.now - 60
+          cert.not_after = Time.now + 3600
+        end
+      end
+
+      def extension(certificate, name, value, critical: false)
+        factory = OpenSSL::X509::ExtensionFactory.new
+        factory.subject_certificate = certificate
+        factory.issuer_certificate = certificate
+        certificate.add_extension(factory.create_extension(name, value, critical))
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,3 +38,9 @@ end
 
 require "mistri"
 require "minitest/autorun"
+
+module Mistri
+  module Test
+    ALLOW_LOOPBACK = ->(_uri, address) { address.loopback? }
+  end
+end

--- a/test/test_mcp_bridge.rb
+++ b/test/test_mcp_bridge.rb
@@ -6,6 +6,11 @@ require_relative "support/mcp_stub_server"
 # The bridge: MCP tools become Mistri tools, results become model-readable
 # content, and the harness's own features compose on top.
 class TestMcpBridge < Minitest::Test
+  def remote_client(server)
+    Mistri::MCP::Client.new(url: server.url,
+                            allow_non_public: Mistri::Test::ALLOW_LOOPBACK)
+  end
+
   def test_tools_map_with_prefix_filters_and_gates
     listed = [{ "name" => "create", "description" => "Creates.",
                 "inputSchema" => { "type" => "object",
@@ -49,7 +54,7 @@ class TestMcpBridge < Minitest::Test
     tools = { "lookup" => { description: "Looks up facts.",
                             handler: ->(args) { "fact: #{args["q"]} is 42" } } }
     server = Mistri::Test::McpStubServer.new(tools: tools, session: "s")
-    client = Mistri::MCP::Client.new(url: server.url)
+    client = remote_client(server)
     provider = Mistri::Providers::Fake.new(turns: [
                                              { tool_calls: [{ name: "kb__lookup",
                                                               arguments: { "q" => "answer" } }] },
@@ -69,7 +74,7 @@ class TestMcpBridge < Minitest::Test
   def test_an_ambiguous_delivery_warns_the_model_not_to_retry
     tools = { "send" => { description: "Sends once.", handler: ->(_) { "sent" } } }
     server = Mistri::Test::McpStubServer.new(tools: tools, drop_after: "tools/call")
-    client = Mistri::MCP::Client.new(url: server.url)
+    client = remote_client(server)
     provider = Mistri::Providers::Fake.new(turns: [
                                              { tool_calls: [{ name: "send", arguments: {} }] },
                                              { text: "I will verify before retrying." }
@@ -90,7 +95,7 @@ class TestMcpBridge < Minitest::Test
   def test_an_approval_gate_parks_a_bridged_tool_before_the_server_sees_it
     tools = { "send" => { description: "Sends.", handler: ->(_) { "sent" } } }
     server = Mistri::Test::McpStubServer.new(tools: tools)
-    client = Mistri::MCP::Client.new(url: server.url)
+    client = remote_client(server)
     bridged = Mistri::MCP.tools(client, gates: { "send" => true })
     provider = Mistri::Providers::Fake.new(turns: [
                                              { tool_calls: [{ name: "send", arguments: {} }] }

--- a/test/test_mcp_client.rb
+++ b/test/test_mcp_client.rb
@@ -17,9 +17,14 @@ class TestMcpClient < Minitest::Test
     server.stop
   end
 
+  def remote_client(server, **)
+    Mistri::MCP::Client.new(url: server.url,
+                            allow_non_public: Mistri::Test::ALLOW_LOOPBACK, **)
+  end
+
   def test_the_handshake_negotiates_and_announces
     with_server(session: "sess") do |server|
-      client = Mistri::MCP::Client.new(url: server.url)
+      client = remote_client(server)
       client.connect
 
       assert_equal "stub", client.server_info["name"]
@@ -47,7 +52,7 @@ class TestMcpClient < Minitest::Test
               "b" => { description: "B.", handler: ->(_) { "b" } },
               "c" => { description: "C.", handler: ->(_) { "c" } } }
     with_server(tools: tools, page_size: 2) do |server|
-      client = Mistri::MCP::Client.new(url: server.url)
+      client = remote_client(server, max_tool_pages: 2, max_tools: 3)
 
       assert_equal(%w[a b c], client.tools.map { |t| t["name"] })
 
@@ -59,9 +64,72 @@ class TestMcpClient < Minitest::Test
     end
   end
 
+  def test_tool_discovery_rejects_a_repeated_cursor
+    with_server(page_size: 1, next_cursor: ->(_cursor) { "same" }) do |server|
+      client = remote_client(server)
+
+      error = assert_raises(Mistri::MCP::Error) { client.tools }
+      list_calls = server.bodies.count { |body| body["method"] == "tools/list" }
+
+      assert_match(/repeated a cursor/, error.message)
+      assert_equal 2, list_calls
+    end
+  end
+
+  def test_tool_discovery_has_host_configurable_page_and_tool_limits
+    with_server(page_size: 1, next_cursor: ->(cursor) { cursor ? cursor.succ : "a" }) do |server|
+      client = remote_client(server, max_tool_pages: 2)
+
+      error = assert_raises(Mistri::MCP::Error) { client.tools }
+      list_calls = server.bodies.count { |body| body["method"] == "tools/list" }
+
+      assert_match(/exceeded 2 pages/, error.message)
+      assert_equal 2, list_calls
+    end
+
+    tools = {
+      "a" => { description: "A", handler: ->(_) {} },
+      "b" => { description: "B", handler: ->(_) {} }
+    }
+    with_server(tools: tools) do |server|
+      error = assert_raises(Mistri::MCP::Error) do
+        remote_client(server, max_tools: 1).tools
+      end
+
+      assert_match(/exceeded 1 tools/, error.message)
+    end
+  end
+
+  def test_tool_discovery_limits_must_be_positive_integers
+    [[:max_tool_pages, 0], [:max_tools, 1.5]].each do |name, value|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::MCP::Client.new(command: ["unused"], name => value)
+      end
+
+      assert_match(/#{name}: must be a positive integer/, error.message)
+    end
+  end
+
+  def test_tool_discovery_rejects_malformed_page_shapes
+    cases = [
+      [nil, /malformed result/],
+      [{ "tools" => nil }, /malformed tools collection/],
+      [{ "tools" => [], "nextCursor" => 7 }, /malformed cursor/]
+    ]
+
+    cases.each do |response, message|
+      client = Mistri::MCP::Client.new(command: ["unused"])
+      client.define_singleton_method(:request) { |_method, _params| response }
+
+      error = assert_raises(Mistri::MCP::Error) { client.tools }
+
+      assert_match message, error.message
+    end
+  end
+
   def test_plain_json_servers_work_identically
     with_server(sse: false) do |server|
-      client = Mistri::MCP::Client.new(url: server.url)
+      client = remote_client(server)
       result = client.call_tool("echo", { "text" => "json mode" })
 
       assert_equal "echo: json mode", result.dig("content", 0, "text")
@@ -77,7 +145,7 @@ class TestMcpClient < Minitest::Test
         resolved << value
         value
       end
-      client = Mistri::MCP::Client.new(url: server.url, token: token)
+      client = remote_client(server, token: token)
       result = client.call_tool("echo", { "text" => "hi" })
 
       assert_equal "echo: hi", result.dig("content", 0, "text")
@@ -88,15 +156,26 @@ class TestMcpClient < Minitest::Test
 
   def test_a_static_token_401_raises
     with_server(require_token: "right") do |server|
-      client = Mistri::MCP::Client.new(url: server.url, token: "wrong")
+      client = remote_client(server, token: "wrong")
 
       assert_raises(Mistri::AuthenticationError) { client.call_tool("echo", {}) }
     end
   end
 
+  def test_custom_headers_are_snapshotted_at_construction
+    with_server do |server|
+      value = +"tenant-one"
+      client = remote_client(server, headers: { "X-Tenant" => value })
+      value.replace("tenant-two")
+      client.connect
+
+      assert_equal "tenant-one", server.requests.first[:headers]["x-tenant"]
+    end
+  end
+
   def test_an_expired_session_reinitializes_transparently
     with_server(session: "sess", expire_after: 3) do |server|
-      client = Mistri::MCP::Client.new(url: server.url)
+      client = remote_client(server)
       client.call_tool("echo", { "text" => "one" })
       result = client.call_tool("echo", { "text" => "two" })
 
@@ -107,7 +186,7 @@ class TestMcpClient < Minitest::Test
 
   def test_a_dropped_tool_response_does_not_replay_the_call
     with_server(drop_after: "tools/call") do |server|
-      client = Mistri::MCP::Client.new(url: server.url)
+      client = remote_client(server)
 
       error = assert_raises(Mistri::AmbiguousDeliveryError) do
         client.call_tool("echo", { "text" => "once" })
@@ -121,7 +200,7 @@ class TestMcpClient < Minitest::Test
 
   def test_a_dropped_replayable_request_reconnects_once
     with_server(drop_after: "tools/list") do |server|
-      client = Mistri::MCP::Client.new(url: server.url)
+      client = remote_client(server)
       names = client.tools.map { |tool| tool["name"] }
       list_calls = server.bodies.count { |body| body["method"] == "tools/list" }
 
@@ -132,7 +211,7 @@ class TestMcpClient < Minitest::Test
 
   def test_a_malformed_tool_response_is_ambiguous
     with_server(malformed_after: "tools/call") do |server|
-      client = Mistri::MCP::Client.new(url: server.url)
+      client = remote_client(server)
 
       error = assert_raises(Mistri::AmbiguousDeliveryError) do
         client.call_tool("echo", { "text" => "once" })
@@ -145,7 +224,7 @@ class TestMcpClient < Minitest::Test
 
   def test_a_malformed_replayable_response_is_not_replayed
     with_server(malformed_after: "tools/list") do |server|
-      client = Mistri::MCP::Client.new(url: server.url)
+      client = remote_client(server)
 
       assert_raises(Mistri::ProviderError) { client.tools }
       list_calls = server.bodies.count { |body| body["method"] == "tools/list" }
@@ -157,7 +236,7 @@ class TestMcpClient < Minitest::Test
 
   def test_a_missing_tool_response_is_ambiguous
     with_server(empty_after: "tools/call") do |server|
-      client = Mistri::MCP::Client.new(url: server.url)
+      client = remote_client(server)
 
       error = assert_raises(Mistri::AmbiguousDeliveryError) do
         client.call_tool("echo", { "text" => "once" })
@@ -170,7 +249,7 @@ class TestMcpClient < Minitest::Test
 
   def test_a_missing_replayable_response_remains_a_protocol_error
     with_server(empty_after: "tools/list") do |server|
-      client = Mistri::MCP::Client.new(url: server.url)
+      client = remote_client(server)
 
       error = assert_raises(Mistri::MCP::Error) { client.tools }
 
@@ -181,7 +260,7 @@ class TestMcpClient < Minitest::Test
 
   def test_an_unsupported_protocol_version_fails_loudly
     with_server(protocol: "1999-01-01") do |server|
-      client = Mistri::MCP::Client.new(url: server.url)
+      client = remote_client(server)
       error = assert_raises(Mistri::MCP::Error) { client.connect }
 
       assert_match(/unsupported protocol version/, error.message)

--- a/test/test_mcp_egress.rb
+++ b/test/test_mcp_egress.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require_relative "support/stub_server"
+
+# The remote MCP boundary: unsafe URL forms and non-public DNS answers fail
+# before any request can carry credentials or invoke an internal service.
+class TestMcpEgress < Minitest::Test
+  def test_rejects_non_http_absolute_and_ambiguous_urls
+    urls = [
+      "file:///etc/passwd",
+      "/mcp",
+      "https:///mcp",
+      "https://exa mple.com/mcp",
+      "https://user:secret@example.com/mcp",
+      "https://example.com/mcp#fragment",
+      "https://example.com:99999/mcp"
+    ]
+
+    urls.each do |url|
+      assert_raises(Mistri::MCP::UnsafeURLError, url) do
+        Mistri::MCP::Client.new(url: url)
+      end
+    end
+  end
+
+  def test_normalizes_case_default_ports_and_root_paths
+    egress = Mistri::MCP.const_get(:Egress, false)
+
+    assert_equal "https://example.com", egress.normalize("HTTPS://EXAMPLE.COM:443/").to_s
+  end
+
+  def test_default_rejects_every_class_of_non_public_address
+    egress = Mistri::MCP.const_get(:Egress, false)
+    urls = [
+      "https://127.1/mcp",
+      "https://2130706433/mcp",
+      "https://0x7f000001/mcp",
+      "https://017700000001/mcp",
+      "https://10.1.2.3/mcp",
+      "https://100.64.0.1/mcp",
+      "https://169.254.169.254/latest/meta-data",
+      "https://192.0.2.1/mcp",
+      "https://198.18.0.1/mcp",
+      "https://224.0.0.1/mcp",
+      "https://[::1]/mcp",
+      "https://[::ffff:127.0.0.1]/mcp",
+      "https://[fc00::1]/mcp",
+      "https://[fe80::1]/mcp",
+      "https://[2001:db8::1]/mcp"
+    ]
+
+    urls.each do |url|
+      assert_raises(Mistri::MCP::UnsafeURLError, url) do
+        egress.target(url)
+      end
+    end
+  end
+
+  def test_iana_more_specific_global_exceptions_remain_reachable
+    egress = Mistri::MCP.const_get(:Egress, false)
+
+    assert egress.globally_reachable?(IPAddr.new("192.0.0.9"))
+    assert egress.globally_reachable?(IPAddr.new("192.31.196.1"))
+    assert egress.globally_reachable?(IPAddr.new("2001:1::1"))
+    assert egress.globally_reachable?(IPAddr.new("2620:4f:8000::1"))
+    assert egress.globally_reachable?(IPAddr.new("2606:4700:4700::1111"))
+    refute egress.globally_reachable?(IPAddr.new("4000::1"))
+  end
+
+  def test_nat64_addresses_inherit_the_embedded_ipv4_policy
+    egress = Mistri::MCP.const_get(:Egress, false)
+
+    refute egress.globally_reachable?(IPAddr.new("64:ff9b::a9fe:a9fe"))
+    assert egress.globally_reachable?(IPAddr.new("64:ff9b::808:808"))
+    refute egress.globally_reachable?(IPAddr.new("::ffff:127.0.0.1"))
+    assert egress.globally_reachable?(IPAddr.new("::ffff:8.8.8.8"))
+  end
+
+  def test_loopback_http_requires_an_explicit_narrow_exception
+    egress = Mistri::MCP.const_get(:Egress, false)
+    target = egress.target("http://127.1/mcp",
+                           allow_non_public: Mistri::Test::ALLOW_LOOPBACK)
+
+    assert_equal "127.0.0.1", target.address
+    assert_raises(Mistri::MCP::UnsafeURLError) do
+      egress.target("http://127.1/mcp")
+    end
+    assert_raises(Mistri::MCP::UnsafeURLError) do
+      egress.target("http://10.0.0.1/mcp",
+                    allow_non_public: ->(_uri, _address) { true })
+    end
+  end
+
+  def test_internal_https_can_be_approved_by_host_and_range
+    network = IPAddr.new("10.20.0.0/16")
+    seen = []
+    allow_internal = lambda do |uri, address|
+      seen << [uri.hostname, address]
+      uri.hostname == "10.20.1.4" && network.include?(address)
+    end
+
+    egress = Mistri::MCP.const_get(:Egress, false)
+    target = egress.target("HTTPS://10.20.1.4:443/mcp", allow_non_public: allow_internal)
+
+    assert_equal "10.20.1.4", seen.first.first
+    assert_equal IPAddr.new("10.20.1.4"), seen.first.last
+    assert_equal "https://10.20.1.4/mcp", target.uri.to_s
+  end
+
+  def test_empty_and_mixed_dns_answers_fail_closed
+    egress = Mistri::MCP.const_get(:Egress, false)
+    uri = egress.normalize("https://mixed.example/mcp")
+    answers = [IPAddr.new("93.184.216.34"), IPAddr.new("127.0.0.1")]
+
+    assert_raises(Mistri::MCP::UnsafeURLError) do
+      egress.approved_addresses(uri, [])
+    end
+    assert_raises(Mistri::MCP::UnsafeURLError) do
+      egress.approved_address(uri, answers)
+    end
+  end
+
+  def test_dns_failure_and_non_callable_exceptions_fail_closed
+    egress = Mistri::MCP.const_get(:Egress, false)
+    failures = [SocketError.new("missing"), IOError.new("failed"), Timeout::Error.new("slow")]
+
+    failures.each do |failure|
+      lookup = ->(*, **) { raise failure }
+
+      assert_raises(Mistri::MCP::UnsafeURLError) do
+        egress.target("https://missing.invalid/mcp", lookup: lookup)
+      end
+    end
+    assert_raises(Mistri::MCP::UnsafeURLError) do
+      egress.target("https://empty.example/mcp", lookup: ->(*, **) { [] })
+    end
+
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::MCP::Client.new(url: "https://example.com/mcp", allow_non_public: true)
+    end
+  end
+
+  def test_malformed_dns_answers_fail_closed
+    egress = Mistri::MCP.const_get(:Egress, false)
+    malformed = Object.new
+    malformed.define_singleton_method(:ip_address) { "not-an-address" }
+
+    assert_raises(Mistri::MCP::UnsafeURLError) do
+      egress.target("https://malformed.example/mcp", lookup: ->(*, **) { [malformed] })
+    end
+  end
+
+  def test_client_construction_is_lazy_but_eagerly_rejects_known_bad_input
+    policy = ->(*) { flunk "construction resolved DNS" }
+    client = Mistri::MCP::Client.new(url: "https://127.0.0.1/mcp",
+                                     allow_non_public: policy)
+    client.close
+
+    assert_raises(Mistri::MCP::UnsafeURLError) do
+      Mistri::MCP::Client.new(url: "http://mcp.example/mcp")
+    end
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::MCP::Client.new(url: "https://mcp.example/mcp", allow_non_public: true)
+    end
+  end
+
+  def test_redirect_uri_validation_uses_one_stable_snapshot
+    values = ["https://app.example/callback", "http://internal.example/callback"]
+    source = Object.new
+    source.define_singleton_method(:to_s) { values.shift }
+
+    assert_equal "https://app.example/callback",
+                 Mistri::MCP.const_get(:Egress, false).redirect_uri(source)
+    assert_equal ["http://internal.example/callback"], values
+  end
+
+  def test_redirect_uri_allows_only_https_or_explicit_loopback_http
+    egress = Mistri::MCP.const_get(:Egress, false)
+
+    assert_equal "http://localhost/callback", egress.redirect_uri("http://localhost/callback")
+    assert_equal "http://127.0.0.1/callback", egress.redirect_uri("http://127.0.0.1/callback")
+    assert_equal "http://[::1]/callback", egress.redirect_uri("http://[::1]/callback")
+    assert_raises(Mistri::MCP::UnsafeURLError) do
+      egress.redirect_uri("http://internal.example/callback")
+    end
+    assert_raises(Mistri::MCP::UnsafeURLError) do
+      egress.redirect_uri("http://10.0.0.1/callback")
+    end
+  end
+
+  def test_policy_callback_cannot_mutate_the_dial_target
+    egress = Mistri::MCP.const_get(:Egress, false)
+    policy = lambda do |uri, address|
+      uri.host.replace("changed.example")
+      assert_raises(FrozenError) { address.prefix = 24 }
+      true
+    end
+    target = egress.target("https://10.20.1.4/mcp", allow_non_public: policy)
+
+    assert_equal "10.20.1.4", target.uri.hostname
+    assert_equal "10.20.1.4", target.address
+  end
+
+  def test_approved_dns_answers_fail_over_before_sending_the_request
+    transport = nil
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.respond_json(socket, { "ok" => true })
+    end
+    egress = Mistri::MCP.const_get(:Egress, false)
+    port = URI(server.origin).port
+    dns_calls = 0
+    lookup = lambda do |*, **|
+      dns_calls += 1
+      [Addrinfo.tcp("::1", port), Addrinfo.tcp("127.0.0.1", port)]
+    end
+
+    uri, resolver = egress.resolver("http://mcp.example:#{port}/mcp",
+                                    allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+                                    lookup: lookup)
+    transport = Mistri::Transport.new(origin: egress.origin(uri),
+                                      address_resolver: resolver, open_timeout: 1)
+
+    assert_equal({ "ok" => true }, transport.post("/mcp", body: {}))
+
+    assert_equal 1, dns_calls
+    assert_equal 1, server.requests.length
+    assert_equal "mcp.example:#{port}", server.requests.first[:headers]["host"]
+  ensure
+    transport&.close
+    server&.stop
+  end
+
+  def test_internal_keep_alive_reconnect_revalidates_dns
+    transport = nil
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.respond_json(socket, { "ok" => true }, headers: { "Connection" => "close" })
+    end
+    egress = Mistri::MCP.const_get(:Egress, false)
+    port = URI(server.origin).port
+    answers = [
+      [Addrinfo.tcp("127.0.0.1", port)],
+      [Addrinfo.tcp("127.0.0.1", port), Addrinfo.tcp("10.0.0.1", port)]
+    ]
+    lookup = ->(*, **) { answers.shift || flunk("unexpected DNS lookup") }
+
+    uri, resolver = egress.resolver("http://mcp.example:#{port}/mcp",
+                                    allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+                                    lookup: lookup)
+    transport = Mistri::Transport.new(origin: egress.origin(uri),
+                                      address_resolver: resolver)
+
+    assert_equal({ "ok" => true }, transport.post("/mcp", body: {}))
+    assert_raises(Mistri::MCP::UnsafeURLError) do
+      transport.post("/mcp", body: {})
+    end
+
+    assert_empty answers
+    assert_equal 1, server.requests.length
+  ensure
+    transport&.close
+    server&.stop
+  end
+
+  def test_plain_http_and_reserved_headers_cannot_bypass_the_boundary
+    assert_raises(Mistri::MCP::UnsafeURLError) do
+      Mistri::MCP::Client.new(url: "http://mcp.example.com/mcp",
+                              headers: { "authorization" => "Bearer secret" })
+    end
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::MCP::Client.new(url: "http://127.0.0.1/mcp",
+                              headers: { "hOsT" => "internal" },
+                              allow_non_public: Mistri::Test::ALLOW_LOOPBACK)
+    end
+  end
+
+  def test_malformed_custom_header_names_cannot_smuggle_managed_headers
+    names = ["X-Test\r\nHost", "X-Test\nTransfer-Encoding", "X:Test", "X Test", "X\0Test",
+             "Host ", "Transfer-Encoding "]
+
+    names.each do |name|
+      assert_raises(Mistri::ConfigurationError, name.inspect) do
+        Mistri::MCP::Client.new(url: "https://mcp.example/mcp",
+                                headers: { name => "value" })
+      end
+    end
+  end
+
+  def test_custom_header_values_reject_control_characters
+    ["line\rbreak", "line\nbreak", "nul\0byte", "tab\tvalue", "delete\x7Fvalue"].each do |value|
+      assert_raises(Mistri::ConfigurationError, value.inspect) do
+        Mistri::MCP::Client.new(url: "https://mcp.example/mcp",
+                                headers: { "X-Test" => value })
+      end
+    end
+  end
+end

--- a/test/test_mcp_generator.rb
+++ b/test/test_mcp_generator.rb
@@ -25,10 +25,17 @@ if defined?(Mistri::Generators::McpGenerator)
         assert_match(/class ToolConnection < ApplicationRecord/, model)
         assert_match(/encrypts :access_token, :refresh_token, :client_secret/, model)
         assert_match(/Mistri::MCP::OAuth\.start/, model)
+        assert_match(/def self\.mcp_allow_non_public = nil/, model)
+        assert_match(/scope: nil, issuer: nil/, model)
+        assert_match(/issuer: issuer/, model)
+        assert_match(/issuer: flow\["issuer"\]/, model)
+        assert_equal 4, model.scan("allow_non_public:").length
         assert_match(/def tools/, model)
       end
       assert_migration "db/migrate/create_tool_connections.rb" do |migration|
         assert_match(/t\.string :state/, migration)
+        assert_match(/t\.string :issuer/, migration)
+        refute_match(/t\.string :token_endpoint/, migration)
         assert_match(/t\.text :access_token/, migration)
         assert_match(/add_index :tool_connections, :state, unique: true/, migration)
       end

--- a/test/test_mcp_oauth.rb
+++ b/test/test_mcp_oauth.rb
@@ -3,12 +3,13 @@
 require_relative "test_helper"
 require_relative "support/oauth_stub_server"
 require "digest"
+require "socket"
 require "uri"
 
 # The OAuth services against a real socket: discovery both ways, dynamic
 # registration as the application, PKCE-correct authorize URLs, code
 # exchange, and rotating refresh.
-class TestMcpOauth < Minitest::Test
+class TestMcpOauth < Minitest::Test # rubocop:disable Metrics/ClassLength -- one real-socket flow
   def with_server(**)
     server = Mistri::Test::OauthStubServer.new(**)
     yield server
@@ -16,9 +17,11 @@ class TestMcpOauth < Minitest::Test
     server.stop
   end
 
-  def start_flow(server, **)
+  def start_flow(server, **options)
+    options[:issuer] = server.origin if options[:client_id] && !options.key?(:issuer)
     Mistri::MCP::OAuth.start(url: server.url, client_name: "Sendoso",
-                             redirect_uri: "https://app.example.com/mcp/callback", **)
+                             redirect_uri: "https://app.example.com/mcp/callback",
+                             allow_non_public: Mistri::Test::ALLOW_LOOPBACK, **options)
   end
 
   def test_start_discovers_registers_and_builds_a_pkce_authorize_url
@@ -30,8 +33,10 @@ class TestMcpOauth < Minitest::Test
       assert_equal "Sendoso", registration["client_name"],
                    "registration happens as the application, never the harness"
       assert_equal ["https://app.example.com/mcp/callback"], registration["redirect_uris"]
+      assert_equal "client_secret_basic", registration["token_endpoint_auth_method"]
 
       assert_equal "app-123", flow["client_id"]
+      assert_equal server.origin, flow["issuer"]
       assert_equal "#{server.origin}/token", flow["token_endpoint"]
 
       query = URI.decode_www_form(URI(flow["authorize_url"]).query).to_h
@@ -63,12 +68,176 @@ class TestMcpOauth < Minitest::Test
     end
   end
 
+  def test_authorization_server_discovery_requires_metadata
+    with_server(oauth_metadata_status: 404) do |server|
+      error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+      assert_equal "no authorization server metadata at #{server.origin}", error.message
+    end
+  end
+
+  def test_metadata_discovery_advances_after_non_success_responses
+    with_server(challenge_header: false, path_metadata_status: 500,
+                root_metadata: true, oauth_metadata_status: 405,
+                openid_only: true) do |server|
+      flow = start_flow(server)
+
+      assert_equal server.origin, flow["issuer"]
+      paths = server.requests.filter_map do |request|
+        verb, path, = request[:line].split
+        path if verb == "GET"
+      end
+
+      assert_includes paths, "/.well-known/oauth-protected-resource"
+      assert_includes paths, "/.well-known/openid-configuration"
+    end
+  end
+
+  def test_well_known_urls_keep_resource_query_and_issuer_path_order
+    assert_equal [
+      "https://mcp.example/.well-known/oauth-protected-resource/public/mcp?tenant=one",
+      "https://mcp.example/.well-known/oauth-protected-resource"
+    ], Mistri::MCP::OAuth.well_known_resource_urls(
+      "https://mcp.example/public/mcp?tenant=one"
+    )
+    assert_equal [
+      "https://auth.example/.well-known/oauth-authorization-server/tenant",
+      "https://auth.example/.well-known/openid-configuration/tenant",
+      "https://auth.example/tenant/.well-known/openid-configuration"
+    ], Mistri::MCP::OAuth.authorization_metadata_urls("https://auth.example/tenant")
+  end
+
   def test_a_pre_registered_client_skips_registration
     with_server do |server|
       flow = start_flow(server, client_id: "static-9", client_secret: "s")
 
       assert_equal "static-9", flow["client_id"]
       assert_empty server.registrations
+    end
+  end
+
+  def test_pre_registered_clients_require_an_exact_host_selected_issuer
+    with_server do |server|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::MCP::OAuth.start(
+          url: server.url, client_name: "App",
+          redirect_uri: "https://app.example/callback", client_id: "static"
+        )
+      end
+      assert_match(/issuer/, error.message)
+
+      ["#{server.origin}/", server.origin.upcase].each do |issuer|
+        error = assert_raises(Mistri::MCP::Error) do
+          start_flow(server, client_id: "static", client_secret: "secret", issuer: issuer)
+        end
+        assert_match(/configured issuer/, error.message)
+      end
+      assert_empty server.registrations
+    end
+  end
+
+  def test_client_credentials_cannot_exist_without_a_client_id
+    common = { url: "https://mcp.example/mcp", client_name: "App",
+               redirect_uri: "https://app.example/callback" }
+
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::MCP::OAuth.start(**common, client_secret: "secret")
+    end
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::MCP::OAuth.start(**common, token_auth_method: "none")
+    end
+  end
+
+  def test_registration_arguments_have_strict_shapes_and_relationships
+    common = { url: "https://mcp.example/mcp", client_name: "App",
+               redirect_uri: "https://app.example/callback" }
+    cases = [
+      [{ client_id: " " }, "client_id: must be a non-empty string"],
+      [{ client_id: "id", client_secret: "", issuer: "https://auth.example" },
+       "client_secret: must be a non-empty string"],
+      [{ issuer: "" }, "issuer: must be a non-empty string"],
+      [{ token_auth_method: "private_key_jwt" },
+       'unsupported token endpoint authentication method "private_key_jwt"'],
+      [{ client_id: "id", client_secret: "secret", token_auth_method: "none",
+         issuer: "https://auth.example" },
+       "token_auth_method: none cannot be paired with client_secret:"]
+    ]
+
+    cases.each do |options, message|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::MCP::OAuth.start(**common, **options)
+      end
+
+      assert_equal message, error.message
+    end
+  end
+
+  def test_multiple_authorization_servers_require_host_selection
+    with_server(authorization_servers: lambda { |server|
+      ["https://unused.example", server.origin]
+    }) do |server|
+      assert_raises(Mistri::ConfigurationError) { start_flow(server) }
+
+      flow = start_flow(server, issuer: server.origin)
+
+      assert_equal server.origin, flow["issuer"]
+    end
+  end
+
+  def test_authorization_servers_must_be_a_nonempty_array_of_strings
+    [[], "https://auth.example", [nil], [""]].each do |advertised|
+      with_server(authorization_servers: ->(_server) { advertised }) do |server|
+        error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+        assert_equal "protected resource metadata names no authorization servers",
+                     error.message
+      end
+    end
+  end
+
+  def test_duplicate_authorization_servers_are_one_choice
+    with_server(authorization_servers: lambda { |server|
+      [server.origin, server.origin]
+    }) do |server|
+      assert_equal server.origin, start_flow(server)["issuer"]
+    end
+  end
+
+  def test_redirect_uri_is_validated_without_changing_its_exact_value
+    with_server do |server|
+      redirect_uri = "https://app.example.com:443/"
+      flow = Mistri::MCP::OAuth.start(
+        url: server.url, client_name: "Sendoso", redirect_uri: redirect_uri,
+        allow_non_public: Mistri::Test::ALLOW_LOOPBACK
+      )
+      query = URI.decode_www_form(URI(flow["authorize_url"]).query).to_h
+
+      assert_equal redirect_uri, flow["redirect_uri"]
+      assert_equal redirect_uri, server.registrations.first["redirect_uris"].first
+      assert_equal redirect_uri, query["redirect_uri"]
+    end
+  end
+
+  def test_authorize_url_replaces_server_supplied_oauth_parameters
+    with_server(endpoints: { "authorization_endpoint" => lambda { |server|
+      "#{server.origin}/authorize?tenant=one&client_id=evil&scope=admin" \
+        "&redirect_uri=https://evil.example"
+    } }) do |server|
+      flow = start_flow(server)
+      pairs = URI.decode_www_form(URI(flow["authorize_url"]).query)
+
+      tenants = pairs.filter_map { |key, value| value if key == "tenant" }
+      client_ids = pairs.filter_map do |key, value|
+        value if key == "client_id"
+      end
+
+      assert_equal ["one"], tenants
+      assert_equal [flow["client_id"]], client_ids
+      expected = "https://app.example.com/mcp/callback"
+      redirects = pairs.filter_map { |key, value| value if key == "redirect_uri" }
+
+      assert_equal [expected], redirects
+      refute(pairs.any? { |key, _value| key == "scope" })
     end
   end
 
@@ -84,6 +253,7 @@ class TestMcpOauth < Minitest::Test
     with_server do |server|
       flow = start_flow(server)
       tokens = Mistri::MCP::OAuth.complete(code: "good-code",
+                                           allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
                                            **flow.transform_keys(&:to_sym))
 
       assert_equal "at-1", tokens["access_token"]
@@ -99,10 +269,26 @@ class TestMcpOauth < Minitest::Test
     end
   end
 
+  def test_complete_requires_the_persisted_issuer
+    with_server do |server|
+      flow = start_flow(server).transform_keys(&:to_sym)
+      flow.delete(:issuer)
+
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::MCP::OAuth.complete(code: "good-code",
+                                    allow_non_public: Mistri::Test::ALLOW_LOOPBACK, **flow)
+      end
+
+      assert_match(/persist flow\["issuer"\]/, error.message)
+      assert_empty server.token_requests
+    end
+  end
+
   def test_refresh_rotates_the_refresh_token
     with_server do |server|
       flow = start_flow(server)
       tokens = Mistri::MCP::OAuth.refresh(refresh_token: "rt-1",
+                                          allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
                                           **flow.transform_keys(&:to_sym))
 
       assert_equal "at-2", tokens["access_token"]
@@ -110,29 +296,81 @@ class TestMcpOauth < Minitest::Test
     end
   end
 
-  def test_scopes_default_from_the_resource_and_offline_access_rides_support
+  def test_token_operations_rediscover_the_endpoint_from_the_bound_issuer
+    metadata_calls = 0
+    endpoint = lambda do |server|
+      metadata_calls += 1
+      metadata_calls == 1 ? "#{server.origin}/old-token" : "#{server.origin}/token"
+    end
+    with_server(endpoints: { "token_endpoint" => endpoint }) do |server|
+      flow = start_flow(server)
+
+      assert_equal "#{server.origin}/old-token", flow["token_endpoint"]
+
+      tokens = Mistri::MCP::OAuth.complete(
+        code: "good-code", allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+        **flow.transform_keys(&:to_sym)
+      )
+
+      assert_equal "at-1", tokens["access_token"]
+      assert_equal 2, metadata_calls
+    end
+  end
+
+  def test_issuer_mismatch_during_completion_sends_no_credentials
+    metadata_calls = 0
+    issuer = lambda do |server|
+      metadata_calls += 1
+      metadata_calls == 1 ? server.origin : "https://other.example"
+    end
+    with_server(issuer: issuer) do |server|
+      flow = start_flow(server)
+
+      error = assert_raises(Mistri::MCP::Error) do
+        Mistri::MCP::OAuth.complete(
+          code: "good-code", allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+          **flow.transform_keys(&:to_sym)
+        )
+      end
+
+      assert_match(/issuer does not match/, error.message)
+      assert_empty server.token_requests
+    end
+  end
+
+  def test_scopes_default_from_the_resource_without_adding_privileges
     with_server(resource_scopes: ["tools:read"],
                 as_scopes: %w[tools:read offline_access]) do |server|
       flow = start_flow(server)
       query = URI.decode_www_form(URI(flow["authorize_url"]).query).to_h
 
-      assert_equal "tools:read offline_access", query["scope"]
+      assert_equal "tools:read", query["scope"]
     end
   end
 
-  def test_unsupported_offline_access_is_stripped_from_an_explicit_scope
+  def test_an_explicit_scope_is_host_policy
     with_server do |server|
       flow = start_flow(server, scope: "tools offline_access")
       query = URI.decode_www_form(URI(flow["authorize_url"]).query).to_h
 
-      assert_equal "tools", query["scope"]
+      assert_equal "tools offline_access", query["scope"]
+    end
+  end
+
+  def test_malformed_resource_scopes_fail_closed
+    with_server(resource_scopes: ["tools:read", nil]) do |server|
+      error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+      assert_equal "protected resource scopes_supported is malformed", error.message
     end
   end
 
   def test_client_secret_basic_authenticates_the_token_request
     with_server(basic_token_auth: true) do |server|
       flow = start_flow(server)
-      Mistri::MCP::OAuth.complete(code: "good-code", **flow.transform_keys(&:to_sym))
+      Mistri::MCP::OAuth.complete(code: "good-code",
+                                  allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+                                  **flow.transform_keys(&:to_sym))
 
       exchange = server.token_requests.first
 
@@ -146,21 +384,614 @@ class TestMcpOauth < Minitest::Test
   def test_authorization_server_endpoints_must_be_https
     metadata = { "authorization_endpoint" => "http://evil.example/authorize",
                  "token_endpoint" => "https://as.example/token" }
-    error = assert_raises(Mistri::MCP::Error) do
+    error = assert_raises(Mistri::MCP::UnsafeURLError) do
       Mistri::MCP::OAuth.validate_endpoints(metadata)
     end
 
-    assert_match(/not HTTPS/, error.message)
+    assert_match(/HTTPS/, error.message)
   end
 
   def test_a_bad_code_surfaces_the_servers_reason
     with_server do |server|
       flow = start_flow(server)
       error = assert_raises(Mistri::MCP::Error) do
-        Mistri::MCP::OAuth.complete(code: "wrong", **flow.transform_keys(&:to_sym))
+        Mistri::MCP::OAuth.complete(code: "wrong",
+                                    allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+                                    **flow.transform_keys(&:to_sym))
       end
 
       assert_match(/invalid_grant/, error.message)
+    end
+  end
+
+  def test_token_errors_never_reflect_attacker_controlled_descriptions
+    reflected = "client_secret=shh&refresh_token=rt-1"
+    with_server(token_error_description: reflected) do |server|
+      flow = start_flow(server)
+      error = assert_raises(Mistri::MCP::Error) do
+        Mistri::MCP::OAuth.complete(
+          code: "wrong", allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+          **flow.transform_keys(&:to_sym)
+        )
+      end
+
+      assert_match(/invalid_grant/, error.message)
+      refute_includes error.message, reflected
+    end
+  end
+
+  def test_token_errors_only_surface_standard_error_codes
+    reflected = "shh"
+    with_server(token_error: reflected) do |server|
+      flow = start_flow(server)
+      error = assert_raises(Mistri::MCP::Error) do
+        Mistri::MCP::OAuth.complete(
+          code: "wrong", allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+          **flow.transform_keys(&:to_sym)
+        )
+      end
+
+      assert_equal "token request failed (400)", error.message
+      refute_includes error.message, reflected
+    end
+  end
+
+  def test_token_type_is_required_and_must_be_bearer
+    [nil, "", 7, "shh"].each do |token_type|
+      response = { "access_token" => "at" }
+      response["token_type"] = token_type unless token_type.nil?
+      with_server(token_response: response) do |server|
+        flow = start_flow(server)
+        error = assert_raises(Mistri::MCP::Error) do
+          Mistri::MCP::OAuth.complete(
+            code: "good-code", allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+            **flow.transform_keys(&:to_sym)
+          )
+        end
+
+        assert_equal "token endpoint returned unsupported token_type", error.message
+        refute_includes(error.message, token_type) if token_type.is_a?(String) && !token_type.empty?
+      end
+    end
+
+    with_server(token_response: { "access_token" => "at", "token_type" => "bearer" }) do |server|
+      flow = start_flow(server)
+      tokens = Mistri::MCP::OAuth.complete(
+        code: "good-code", allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+        **flow.transform_keys(&:to_sym)
+      )
+
+      assert_equal "at", tokens["access_token"]
+    end
+  end
+
+  def test_token_response_requires_a_string_access_token
+    [nil, "", { "nested" => "token" }].each do |access_token|
+      response = { "access_token" => access_token, "token_type" => "Bearer" }
+      with_server(token_response: response) do |server|
+        flow = start_flow(server)
+        error = assert_raises(Mistri::MCP::Error) do
+          Mistri::MCP::OAuth.complete(
+            code: "good-code", allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+            **flow.transform_keys(&:to_sym)
+          )
+        end
+
+        assert_match(/access_token/, error.message)
+      end
+    end
+  end
+
+  def test_oauth_responses_are_bounded_and_never_request_compression
+    limit = Mistri::MCP::OAuth.const_get(:MAX_RESPONSE_BYTES, false)
+    oversized = "x" * (limit + 1)
+    with_server(token_response: oversized) do |server|
+      flow = start_flow(server)
+      error = assert_raises(Mistri::MCP::Error) do
+        Mistri::MCP::OAuth.complete(
+          code: "good-code", allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+          **flow.transform_keys(&:to_sym)
+        )
+      end
+
+      assert_match(/exceeded/, error.message)
+      assert(server.requests.all? do |request|
+        request[:headers]["accept-encoding"] == "identity"
+      end)
+    end
+  end
+
+  def test_discovery_tries_path_then_root
+    with_server(challenge_header: false, path_metadata: false, root_metadata: true) do |server|
+      flow = start_flow(server)
+      paths = server.requests.filter_map do |request|
+        verb, path, = request[:line].split
+        path if verb == "GET" && path.include?("oauth-protected-resource")
+      end
+
+      assert_equal "app-123", flow["client_id"]
+      assert_equal ["/.well-known/oauth-protected-resource/mcp",
+                    "/.well-known/oauth-protected-resource"], paths
+    end
+  end
+
+  def test_the_challenge_scope_precedes_broader_resource_metadata
+    with_server(challenge_scope: "tools:write", resource_scopes: ["tools:all"]) do |server|
+      flow = start_flow(server)
+      query = URI.decode_www_form(URI(flow["authorize_url"]).query).to_h
+
+      assert_equal "tools:write", query["scope"]
+    end
+  end
+
+  def test_an_explicit_scope_may_add_to_the_challenged_scope
+    with_server(challenge_scope: "tools:read tools:write") do |server|
+      flow = start_flow(server, scope: "tools:admin tools:write tools:read")
+      query = URI.decode_www_form(URI(flow["authorize_url"]).query).to_h
+
+      assert_equal "tools:admin tools:write tools:read", query["scope"]
+    end
+  end
+
+  def test_an_explicit_scope_cannot_omit_a_challenged_scope
+    with_server(challenge_scope: "tools:read tools:write") do |server|
+      error = assert_raises(Mistri::ConfigurationError) do
+        start_flow(server, scope: "tools:read")
+      end
+
+      assert_equal "scope: must include every scope required by the MCP challenge",
+                   error.message
+      assert_empty server.registrations
+    end
+  end
+
+  def test_protected_resource_metadata_is_bound_to_the_server
+    with_server(resource: "https://other.example/mcp") do |server|
+      error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+      assert_match(/does not match/, error.message)
+    end
+  end
+
+  def test_root_metadata_identifies_the_origin_without_widening_the_token_audience
+    with_server(challenge_header: false, path_metadata: false, root_metadata: true,
+                query: "tenant=one") do |server|
+      flow = start_flow(server)
+      query = URI.decode_www_form(URI(flow["authorize_url"]).query).to_h
+      Mistri::MCP::OAuth.complete(
+        code: "good-code", allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+        **flow.transform_keys(&:to_sym)
+      )
+
+      assert_equal server.url, flow["resource"]
+      assert_equal server.url, query["resource"]
+      assert_equal server.url, server.token_requests.first["resource"]
+    end
+  end
+
+  def test_path_metadata_rejects_ancestor_and_queryless_resources
+    with_server(resource: lambda(&:origin)) do |server|
+      error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+      assert_match(/does not match/, error.message)
+    end
+    with_server(query: "tenant=one", resource: ->(server) { "#{server.origin}/mcp" }) do |server|
+      error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+      assert_match(/does not match/, error.message)
+    end
+  end
+
+  def test_authorization_server_metadata_is_bound_to_its_issuer
+    with_server(issuer: "https://other.example") do |server|
+      error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+      assert_match(/issuer does not match/, error.message)
+    end
+  end
+
+  def test_pkce_support_must_be_advertised_as_s256
+    [nil, ["plain"], "S256"].each do |methods|
+      with_server(pkce: methods) do |server|
+        error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+        assert_match(/S256 PKCE/, error.message)
+      end
+    end
+  end
+
+  def test_redirect_uri_must_be_https_or_loopback
+    error = assert_raises(Mistri::MCP::UnsafeURLError) do
+      Mistri::MCP::OAuth.start(url: "https://mcp.example/mcp", client_name: "App",
+                               redirect_uri: "http://app.example/callback")
+    end
+
+    assert_match(/redirect_uri/, error.message)
+  end
+
+  def test_every_discovered_endpoint_obeys_the_same_network_policy
+    with_server do |server|
+      base = { "authorization_endpoint" => "#{server.origin}/authorize",
+               "token_endpoint" => "#{server.origin}/token" }
+      %w[authorization_endpoint token_endpoint registration_endpoint].each do |key|
+        metadata = base.merge(key => "https://169.254.169.254/secret")
+
+        assert_raises(Mistri::MCP::UnsafeURLError, key) do
+          Mistri::MCP::OAuth.validate_endpoints(
+            metadata, allow_non_public: Mistri::Test::ALLOW_LOOPBACK
+          )
+        end
+      end
+    end
+  end
+
+  def test_oauth_requests_ignore_ambient_proxies
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.respond_json(socket, { "ok" => true })
+    end
+    proxy = Mistri::Test::StubServer.new do |socket, _request|
+      proxy.respond_json(socket, { "proxied" => true })
+    end
+    keys = %w[HTTP_PROXY http_proxy NO_PROXY no_proxy]
+    previous = keys.to_h { |key| [key, ENV.fetch(key, nil)] }
+    ENV.update("HTTP_PROXY" => proxy.origin, "http_proxy" => proxy.origin,
+               "NO_PROXY" => "", "no_proxy" => "")
+    egress = Mistri::MCP.const_get(:Egress, false)
+    port = URI(server.origin).port
+    lookup = ->(*, **) { [Addrinfo.tcp("127.0.0.1", port)] }
+    targets = egress.targets("http://oauth.example:#{port}/metadata",
+                             allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+                             lookup: lookup)
+
+    response = Mistri::MCP::OAuth.http(targets, Net::HTTP::Get.new(targets.first.uri))
+
+    assert_equal "200", response.code
+    assert_equal 1, server.requests.length
+    assert_empty proxy.requests
+  ensure
+    previous&.each { |key, value| value ? ENV[key] = value : ENV.delete(key) }
+    server&.stop
+    proxy&.stop
+  end
+
+  def test_oauth_tries_an_approved_alternate_before_sending_the_request
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.respond_json(socket, { "ok" => true })
+    end
+    egress = Mistri::MCP.const_get(:Egress, false)
+    port = URI(server.origin).port
+    lookup = lambda do |*, **|
+      [Addrinfo.tcp("::1", port), Addrinfo.tcp("127.0.0.1", port)]
+    end
+    targets = egress.targets("http://oauth.example:#{port}/metadata",
+                             allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+                             lookup: lookup)
+    request = Net::HTTP::Get.new(targets.first.uri)
+
+    response = Mistri::MCP::OAuth.http(targets, request)
+
+    assert_equal "200", response.code
+    assert_equal 1, server.requests.length
+  ensure
+    server&.stop
+  end
+
+  def test_metadata_discovery_falls_back_after_a_connection_failure
+    server = Mistri::Test::StubServer.new do |socket, request|
+      path = request[:line].split[1]
+      if path == "/.well-known/oauth-authorization-server"
+        :close
+      else
+        server.respond_json(socket, { "issuer" => server.origin,
+                                      "token_endpoint" => "#{server.origin}/token" })
+      end
+    end
+
+    metadata = Mistri::MCP::OAuth.server_metadata(
+      server.origin, allow_non_public: Mistri::Test::ALLOW_LOOPBACK
+    )
+
+    assert_equal "#{server.origin}/token", metadata["token_endpoint"]
+    assert_equal 2, server.requests.length
+  ensure
+    server&.stop
+  end
+
+  def test_first_exact_issuer_metadata_document_is_authoritative
+    server = Mistri::Test::StubServer.new do |socket, request|
+      verb, path, = request[:line].split
+      if path == "/.well-known/oauth-authorization-server"
+        server.respond_json(socket, { "issuer" => server.origin })
+      elsif path == "/.well-known/openid-configuration"
+        server.respond_json(socket, { "issuer" => server.origin,
+                                      "token_endpoint" => "#{server.origin}/token" })
+      elsif verb == "POST" && path == "/token"
+        server.respond_json(socket, { "access_token" => "unexpected",
+                                      "token_type" => "Bearer" })
+      end
+    end
+
+    error = assert_raises(Mistri::MCP::Error) do
+      Mistri::MCP::OAuth.complete(
+        code: "code", code_verifier: "verifier", client_id: "client",
+        resource: "#{server.origin}/mcp", redirect_uri: "https://app.example/callback",
+        issuer: server.origin, token_auth_method: "none",
+        allow_non_public: Mistri::Test::ALLOW_LOOPBACK
+      )
+    end
+
+    assert_equal "authorization server metadata has no token_endpoint", error.message
+    assert_equal 1, server.requests.length
+  ensure
+    server&.stop
+  end
+
+  def test_required_metadata_fetch_rejects_connection_failure_and_invalid_json
+    server = Mistri::Test::StubServer.new do |socket, request|
+      if request[:line].include?("/dropped")
+        :close
+      else
+        server.respond_json(socket, "not-json")
+      end
+    end
+
+    error = assert_raises(Mistri::MCP::Error) do
+      Mistri::MCP::OAuth.get_json(
+        "#{server.origin}/dropped", allow_non_public: Mistri::Test::ALLOW_LOOPBACK
+      )
+    end
+    assert_equal "OAuth connection failed", error.message
+
+    error = assert_raises(Mistri::MCP::Error) do
+      Mistri::MCP::OAuth.get_json(
+        "#{server.origin}/invalid", allow_non_public: Mistri::Test::ALLOW_LOOPBACK
+      )
+    end
+    assert_match(/returned invalid JSON/, error.message)
+  ensure
+    server&.stop
+  end
+
+  def test_registration_http_errors_are_fixed_and_bounded
+    server = Mistri::Test::StubServer.new do |socket, request|
+      if request[:line].include?("/rejected")
+        server.respond_json(socket, { "error" => "secret detail" }, status: 400)
+      else
+        server.respond_json(socket, "not-json")
+      end
+    end
+
+    cases = [["rejected", /answered 400/], ["invalid", /returned invalid JSON/]]
+    cases.each do |path, message|
+      error = assert_raises(Mistri::MCP::Error) do
+        Mistri::MCP::OAuth.post_json(
+          "#{server.origin}/#{path}", { "client_name" => "App" },
+          allow_non_public: Mistri::Test::ALLOW_LOOPBACK
+        )
+      end
+
+      assert_match message, error.message
+      refute_includes error.message, "secret detail"
+    end
+  ensure
+    server&.stop
+  end
+
+  def test_invalid_json_from_the_token_endpoint_has_a_fixed_error
+    server = Mistri::Test::StubServer.new do |socket, request|
+      verb, path, = request[:line].split
+      if verb == "GET"
+        server.respond_json(socket, { "issuer" => server.origin,
+                                      "token_endpoint" => "#{server.origin}/token" })
+      elsif path == "/token"
+        server.respond_json(socket, "not-json")
+      end
+    end
+
+    error = assert_raises(Mistri::MCP::Error) do
+      Mistri::MCP::OAuth.complete(
+        code: "good-code", code_verifier: "verifier", client_id: "client",
+        resource: "#{server.origin}/mcp", redirect_uri: "https://app.example/callback",
+        issuer: server.origin, token_auth_method: "none",
+        allow_non_public: Mistri::Test::ALLOW_LOOPBACK
+      )
+    end
+
+    assert_equal "token endpoint returned invalid JSON", error.message
+    refute_includes error.message, "not-json"
+  ensure
+    server&.stop
+  end
+
+  def test_a_dropped_oauth_metadata_response_is_not_retried
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      if server.requests.one?
+        :close
+      else
+        server.respond_json(socket, { "ok" => true })
+      end
+    end
+    egress = Mistri::MCP.const_get(:Egress, false)
+    port = URI(server.origin).port
+    lookup = ->(*, **) { [Addrinfo.tcp("127.0.0.1", port)] }
+    targets = egress.targets("http://oauth.example:#{port}/metadata",
+                             allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+                             lookup: lookup)
+    request = Net::HTTP::Get.new(targets.first.uri)
+
+    error = assert_raises(Mistri::MCP::Error) do
+      Mistri::MCP::OAuth.http(targets, request)
+    end
+
+    assert_match(/connection failed/i, error.message)
+    assert_equal 1, server.accepts
+    assert_equal 1, server.requests.length
+  ensure
+    server&.stop
+  end
+
+  def test_protocol_exceptions_never_reflect_remote_text
+    reflected = "client_secret=shh"
+    server = TCPServer.new("127.0.0.1", 0)
+    thread = Thread.new do
+      socket = server.accept
+      socket.each_line { |line| break if line == "\r\n" }
+      socket.write("#{reflected}\r\n\r\n")
+    ensure
+      socket&.close
+    end
+    uri = URI("http://oauth.example:#{server.local_address.ip_port}/token")
+    target = Struct.new(:uri, :address).new(uri, "127.0.0.1")
+
+    error = assert_raises(Mistri::MCP::Error) do
+      Mistri::MCP::OAuth.http([target], Net::HTTP::Get.new(target.uri))
+    end
+
+    assert_equal "OAuth connection failed", error.message
+    refute_includes error.message, reflected
+  ensure
+    server&.close
+    if thread
+      thread.join(1)
+      thread.kill if thread.alive?
+    end
+  end
+
+  def test_private_challenge_and_authorization_server_urls_are_rejected
+    with_server(challenge_metadata: "https://169.254.169.254/metadata") do |server|
+      assert_raises(Mistri::MCP::UnsafeURLError) { start_flow(server) }
+    end
+    with_server(authorization_server: "https://10.0.0.1") do |server|
+      assert_raises(Mistri::MCP::UnsafeURLError) { start_flow(server) }
+    end
+  end
+
+  def test_persisted_token_endpoint_cannot_redirect_credentials
+    with_server do |server|
+      flow = start_flow(server)
+      persisted = flow.transform_keys(&:to_sym)
+                      .merge(token_endpoint: "https://169.254.169.254/token")
+      tokens = Mistri::MCP::OAuth.complete(
+        code: "good-code", allow_non_public: Mistri::Test::ALLOW_LOOPBACK, **persisted
+      )
+
+      assert_equal "at-1", tokens["access_token"]
+      assert_equal 1, server.token_requests.length
+    end
+  end
+
+  def test_metadata_redirects_are_not_followed
+    with_server(metadata_redirect: "https://169.254.169.254/metadata") do |server|
+      error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+      assert_match(/no protected resource metadata/, error.message)
+      assert_equal 2, server.requests.length
+    end
+  end
+
+  def test_a_preregistered_secret_defaults_to_basic_auth
+    with_server do |server|
+      flow = start_flow(server, client_id: "static:id", client_secret: "s/e cret")
+      Mistri::MCP::OAuth.complete(code: "good-code",
+                                  allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+                                  **flow.transform_keys(&:to_sym))
+      exchange = server.token_requests.first
+
+      assert_nil exchange["client_secret"]
+      encoded = "static%3Aid:s%2Fe+cret"
+
+      assert_equal "Basic #{[encoded].pack("m0")}", exchange["_authorization"]
+    end
+  end
+
+  def test_a_preregistered_client_can_explicitly_use_secret_post
+    with_server do |server|
+      flow = start_flow(server, client_id: "static", client_secret: "secret",
+                                token_auth_method: "client_secret_post")
+      Mistri::MCP::OAuth.complete(code: "good-code",
+                                  allow_non_public: Mistri::Test::ALLOW_LOOPBACK,
+                                  **flow.transform_keys(&:to_sym))
+      exchange = server.token_requests.first
+
+      assert_equal "secret", exchange["client_secret"]
+      assert_nil exchange["_authorization"]
+    end
+  end
+
+  def test_legacy_nil_token_auth_method_keeps_secret_post
+    with_server do |server|
+      flow = start_flow(server)
+      persisted = flow.transform_keys(&:to_sym)
+      persisted.delete(:token_auth_method)
+      Mistri::MCP::OAuth.complete(
+        code: "good-code", allow_non_public: Mistri::Test::ALLOW_LOOPBACK, **persisted
+      )
+
+      exchange = server.token_requests.first
+
+      assert_equal "shh", exchange["client_secret"]
+      assert_nil exchange["_authorization"]
+    end
+  end
+
+  def test_registration_rejects_secret_authentication_without_a_secret
+    options = { registration_secret: nil, registration_auth_method: "client_secret_basic" }
+    with_server(**options) do |server|
+      error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+      assert_match(/without a client_secret/, error.message)
+    end
+  end
+
+  def test_registration_rejects_a_secret_for_an_unauthenticated_client
+    with_server(registration_auth_method: "none", registration_secret: "unexpected") do |server|
+      error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+      assert_equal "registration returned a client_secret for an unauthenticated client",
+                   error.message
+    end
+  end
+
+  def test_authorization_server_token_auth_methods_must_be_an_array_of_strings
+    ["client_secret_basic", [nil]].each do |supported|
+      with_server(token_auth_methods: supported) do |server|
+        error = assert_raises(Mistri::MCP::Error) { start_flow(server) }
+
+        assert_equal "authorization server token auth methods are malformed", error.message
+      end
+    end
+  end
+
+  def test_a_preregistered_secret_auth_method_without_a_secret_fails_before_network
+    with_server do |server|
+      error = assert_raises(Mistri::ConfigurationError) do
+        start_flow(server, client_id: "static", token_auth_method: "client_secret_basic")
+      end
+
+      assert_equal "client_secret_basic requires a client_secret", error.message
+      assert_empty server.requests
+    end
+  end
+
+  def test_token_auth_methods_fail_closed_and_none_rejects_a_secret
+    with_server do |server|
+      flow = start_flow(server)
+      params = flow.transform_keys(&:to_sym).merge(token_auth_method: "none",
+                                                   client_secret: "do-not-send",
+                                                   allow_non_public: Mistri::Test::ALLOW_LOOPBACK)
+      error = assert_raises(Mistri::MCP::Error) do
+        Mistri::MCP::OAuth.complete(code: "good-code", **params)
+      end
+      assert_match(/cannot use a client_secret/, error.message)
+      assert_empty server.token_requests
+
+      unknown = flow.transform_keys(&:to_sym).merge(token_auth_method: "private_key_jwt",
+                                                    allow_non_public: Mistri::Test::ALLOW_LOOPBACK)
+      error = assert_raises(Mistri::MCP::Error) do
+        Mistri::MCP::OAuth.refresh(refresh_token: "rt-1", **unknown)
+      end
+      assert_match(/unsupported token endpoint authentication/, error.message)
+      assert_empty server.token_requests
     end
   end
 end

--- a/test/test_transport.rb
+++ b/test/test_transport.rb
@@ -3,6 +3,7 @@
 require "json"
 require_relative "test_helper"
 require_relative "support/stub_server"
+require_relative "support/tls_stub_server"
 
 class TestTransport < Minitest::Test
   def test_streams_records_and_reuses_one_connection_across_turns
@@ -127,6 +128,177 @@ class TestTransport < Minitest::Test
     assert_equal 0, server.accepts
   ensure
     teardown_all(transport, server)
+  end
+
+  def test_a_resolved_address_is_pinned_without_changing_host_identity
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.respond_json(socket, { "ok" => true })
+    end
+    port = URI(server.origin).port
+    transport = Mistri::Transport.new(origin: "http://unresolvable.invalid:#{port}",
+                                      address_resolver: -> { ["127.0.0.1"] })
+
+    assert_equal({ "ok" => true }, transport.post("/v1/x", body: {}))
+    assert_equal "unresolvable.invalid:#{port}", server.requests.first[:headers]["host"]
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_approved_addresses_fail_over_before_the_request_is_sent
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.respond_json(socket, { "ok" => true })
+    end
+    resolutions = 0
+    resolver = lambda do
+      resolutions += 1
+      ["::1", "127.0.0.1"]
+    end
+    transport = Mistri::Transport.new(origin: server.origin, address_resolver: resolver,
+                                      open_timeout: 1)
+
+    assert_equal({ "ok" => true }, transport.post("/v1/x", body: {}))
+
+    assert_equal 1, resolutions
+    assert_equal 1, server.requests.length
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_an_empty_resolved_address_set_fails_before_connecting
+    transport = Mistri::Transport.new(origin: "http://mcp.example",
+                                      address_resolver: -> { [] })
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      transport.post("/v1/x", body: {})
+    end
+
+    assert_equal "address_resolver returned no addresses", error.message
+  ensure
+    transport&.close
+  end
+
+  def test_an_exhausted_resolved_connection_deadline_never_dials
+    server = Mistri::Test::StubServer.new do |_socket, _request|
+      flunk "reached the server"
+    end
+    transport = Mistri::Transport.new(origin: server.origin,
+                                      address_resolver: -> { ["127.0.0.1"] },
+                                      open_timeout: 0)
+
+    error = assert_raises(Mistri::ProviderError) do
+      transport.post("/v1/x", body: {})
+    end
+
+    assert_includes error.message, "all approved addresses timed out"
+    assert_equal 0, server.accepts
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_a_resolved_connection_can_disable_the_open_timeout
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.respond_json(socket, { "ok" => true })
+    end
+    transport = Mistri::Transport.new(origin: server.origin,
+                                      address_resolver: -> { ["127.0.0.1"] },
+                                      open_timeout: nil)
+
+    assert_equal({ "ok" => true }, transport.post("/v1/x", body: {}))
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_a_healthy_resolved_keep_alive_does_not_resolve_again
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.respond_json(socket, { "ok" => true })
+    end
+    port = URI(server.origin).port
+    resolutions = 0
+    resolver = lambda do
+      resolutions += 1
+      ["127.0.0.1"]
+    end
+    transport = Mistri::Transport.new(origin: "http://mcp.example:#{port}",
+                                      address_resolver: resolver)
+
+    2.times do
+      assert_equal({ "ok" => true }, transport.post("/v1/x", body: {}))
+    end
+
+    assert_equal 1, resolutions
+    assert_equal 1, server.accepts
+    assert_equal 2, server.requests.length
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_a_generic_transport_keeps_net_http_environment_proxy_behavior
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.respond_json(socket, { "ok" => true })
+    end
+    transport = Mistri::Transport.new(origin: server.origin)
+
+    assert_equal({ "ok" => true }, transport.post("/v1/x", body: {}))
+    connection = transport.send(:connection)
+
+    assert_instance_of Net::HTTP, connection
+    assert_predicate connection, :proxy_from_env?
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_a_resolved_transport_ignores_ambient_proxies
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.respond_json(socket, { "ok" => true })
+    end
+    proxy = Mistri::Test::StubServer.new do |socket, _request|
+      proxy.respond_json(socket, { "proxied" => true })
+    end
+    keys = %w[HTTP_PROXY http_proxy NO_PROXY no_proxy]
+    previous = keys.to_h { |key| [key, ENV.fetch(key, nil)] }
+    ENV.update("HTTP_PROXY" => proxy.origin, "http_proxy" => proxy.origin,
+               "NO_PROXY" => "", "no_proxy" => "")
+    port = URI(server.origin).port
+    transport = Mistri::Transport.new(origin: "http://mcp.example:#{port}",
+                                      address_resolver: -> { ["127.0.0.1"] })
+
+    assert_equal({ "ok" => true }, transport.post("/v1/x", body: {}))
+    assert_empty proxy.requests
+  ensure
+    previous&.each { |key, value| value ? ENV[key] = value : ENV.delete(key) }
+    teardown_all(transport, server)
+    proxy&.stop
+  end
+
+  def test_pinning_preserves_sni_and_certificate_hostname_verification
+    server = Mistri::Test::TlsStubServer.new(hostname: "mcp.test")
+    OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE.add_cert(server.ca_certificate)
+    transport = Mistri::Transport.new(origin: server.origin,
+                                      address_resolver: -> { ["127.0.0.1"] })
+
+    assert_equal({ "ok" => true }, transport.post("/mcp", body: {}))
+    assert_equal "mcp.test", server.server_name
+    assert_equal "mcp.test:#{URI(server.origin).port}",
+                 server.requests.first[:headers]["host"]
+  ensure
+    transport&.close
+    server&.stop
+  end
+
+  def test_pinning_rejects_a_certificate_for_a_different_hostname
+    server = Mistri::Test::TlsStubServer.new(hostname: "mcp.test",
+                                             certificate_hostname: "other.test")
+    OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE.add_cert(server.ca_certificate)
+    transport = Mistri::Transport.new(origin: server.origin,
+                                      address_resolver: -> { ["127.0.0.1"] })
+
+    assert_raises(OpenSSL::SSL::SSLError) do
+      transport.post("/mcp", body: {})
+    end
+    assert_empty server.requests
+  ensure
+    transport&.close
+    server&.stop
   end
 
   private


### PR DESCRIPTION
## Why

Remote MCP URLs and OAuth metadata are application-supplied network input. The client previously guarded only bearer tokens over plain HTTP, while DNS rebinding, proxy inheritance, endpoint substitution, and ambiguous OAuth discovery remained outside a single enforceable boundary.

## What changed

- Default remote MCP and server-side OAuth egress to public HTTPS, validate the complete DNS answer set, pin approved addresses without changing Host/SNI/certificate identity, and revalidate on each connection cycle.
- Add a narrow `allow_non_public:` host policy for internal HTTPS and explicit loopback development. MCP and OAuth requests remain direct and do not follow redirects.
- Bind protected-resource metadata to the exact candidate, require host selection for multiple issuers, persist the selected issuer, and rediscover token endpoints from it before code exchange and refresh.
- Follow the MCP 2025-11-25 discovery order, honor challenge scopes, require S256 PKCE, validate DCR and preregistered token authentication, and prevent remote token/protocol text from reflecting into errors.
- Reject malformed or transport-owned custom headers and bound tool discovery with repeated-cursor detection plus configurable page/tool ceilings.
- Update the Rails generator, README, CHANGELOG, and security guidance for the issuer migration and shared egress policy.

## Upgrade notes

Generated models from older releases are not rewritten. Existing applications must add an `issuer` column, restart pending OAuth flows, and reconnect established rows unless they independently recorded the exact issuer originally used. An issuer must not be inferred from a token endpoint. The low-level flow still returns `token_endpoint` for compatibility, but completion and refresh ignore persisted endpoint values.

## Verification

- Ruby 3.2, 3.3, and 3.4: 578 runs, 2,192 assertions, 0 failures.
- RuboCop: 166 files, no offenses.
- Coverage: 97.34% line, 84.40% branch.
- Live end-to-end MCP bridge through DeepWiki on Claude Haiku 4.5, GPT-5.6 Terra, and Gemini 2.5 Flash: 3 runs, 24 assertions.
- Built-gem install/require smoke passed, including the egress code and generator templates.

Client construction remains DNS-free and a healthy reused socket adds no resolver work. Each new connection cycle performs one validated lookup; candidate failover happens only before request transmission. OAuth discovery is outside the provider streaming hot path.

Implementation follows the [MCP 2025-11-25 authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization), [MCP security guidance](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices), [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728.html), [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414.html), and the current [IANA IPv4](https://www.iana.org/assignments/iana-ipv4-special-registry/) and [IPv6](https://www.iana.org/assignments/iana-ipv6-special-registry/) registries. The current [official Ruby MCP SDK](https://github.com/modelcontextprotocol/ruby-sdk) was used as a comparison baseline, not as the design authority.