### PR TITLE
Bound inbound response records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Provider and MCP JSON bodies, individual SSE lines, and stdio JSON records
+  now default to an 8 MiB ceiling, configurable with `max_record_bytes:`.
+  Successful bodies are counted incrementally, declared oversized bodies fail
+  before reading, streaming remains unlimited across individually safe records,
+  and error responses retain at most a 500-byte valid UTF-8 preview. Requests
+  use identity encoding so compressed expansion cannot bypass the boundary.
+  Overflow closes the connection or child process; an oversized MCP
+  `tools/call` response remains explicitly ambiguous and is never replayed.
+  Stdio timeouts now cover the complete record instead of only its first byte;
+  any in-flight stdio wire failure after `tools/call` is ambiguous, reaps the
+  child, and requires a clean handshake before the next operation. Explicitly
+  closing and reusing an MCP client also clears its session, negotiated
+  protocol version, and server information before the fresh handshake.
+  The hot path adds one byte-count addition and comparison per JSON socket
+  fragment or SSE line fragment, with no per-token work.
 - Remote MCP and server-side OAuth requests now default to public HTTPS and
   direct connections. Every DNS answer is checked against the IANA
   special-purpose registries, including embedded NAT64 destinations; one unsafe

--- a/README.md
+++ b/README.md
@@ -437,12 +437,24 @@ let a host set explicit limits. `prefix:` namespaces local names
 (`linear__create_issue`) because duplicate tool names raise at `Agent.new`:
 collisions fail loud instead of one server's tool silently shadowing another's.
 
+Inbound JSON bodies, individual SSE lines, and stdio JSON records default to an
+8 MiB `max_record_bytes:` ceiling. It limits one atomic record, not the total
+length of a stream. Oversized responses close the transport; for `tools/call`,
+the error explicitly says the operation may have completed and must not be
+retried automatically. For a trusted server, configure a larger explicit limit.
+Other paths surface `ResponseTooLargeError`; its `kind` and `limit` also ride a
+provider error turn as machine-readable data.
+Large tool output is better stored by the server or host and returned as an MCP
+`resource_link`; Mistri renders its URI for the model and never fetches the
+target itself.
+
 Local stdio servers spawn as child processes, credentials in their
 environment. That is also the whole "give the agent a browser" story:
 
 ```ruby
 browser = Mistri::MCP::Client.new(
   command: ["npx", "-y", "@playwright/mcp@latest", "--browser", "chrome", "--headless"],
+  max_record_bytes: 16 * 1024 * 1024, # explicit trust for larger screenshots
 )
 agent = Mistri.agent("claude-opus-4-8",
                      tools: Mistri::MCP.tools(browser, allow: %w[browser_navigate browser_snapshot]))
@@ -581,6 +593,8 @@ agent.run("What trend does this chart show?", images: [photo])
 
 Mistri.agent("gpt-5.6", provider_options: { reasoning: { effort: "high" } })
 Mistri.agent("claude-opus-4-8", provider_options: { cache: false })
+Mistri.agent("gemini-3.1-pro-preview",
+             provider_options: { max_record_bytes: 16 * 1024 * 1024 })
 ```
 
 ## Testing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,3 +33,8 @@ Notes worth knowing when assessing reports:
   OAuth response bodies are read incrementally with a 256 KiB limit and
   compression disabled; server-controlled descriptions are not copied into
   token errors.
+- Provider and MCP JSON bodies, individual SSE lines, and stdio records default
+  to an 8 MiB `max_record_bytes:` ceiling. The total size of an SSE stream is
+  not capped when each record remains within that boundary. Error responses
+  retain at most a 500-byte valid UTF-8 preview. HTTP status, header, chunk-size,
+  and trailer lines are parsed by Net::HTTP before this body boundary applies.

--- a/lib/mistri/errors.rb
+++ b/lib/mistri/errors.rb
@@ -57,6 +57,18 @@ module Mistri
     def self.default_message = "provider server error"
   end
 
+  # An inbound body or protocol record crossed its configured byte boundary.
+  class ResponseTooLargeError < Error
+    attr_reader :kind, :limit
+
+    def initialize(kind:, limit:)
+      @kind = kind
+      @limit = limit
+      label = kind.to_s.tr("_", " ")
+      super("#{label} exceeded max_record_bytes (#{limit} bytes)")
+    end
+  end
+
   # A non-replayable request has no confirmed response, so execution is unknown.
   class AmbiguousDeliveryError < ProviderError
     def self.default_message
@@ -115,6 +127,9 @@ module Mistri
       when RateLimitError
         { "type" => "RateLimitError", "status" => reason.status,
           "retry_after" => reason.retry_after }.compact
+      when ResponseTooLargeError
+        { "type" => "ResponseTooLargeError", "kind" => reason.kind.to_s,
+          "limit" => reason.limit }
       when ProviderError
         { "type" => reason.class.name.split("::").last, "status" => reason.status }.compact
       when Exception then { "type" => reason.class.name }

--- a/lib/mistri/mcp.rb
+++ b/lib/mistri/mcp.rb
@@ -28,6 +28,9 @@ module Mistri
       end
     end
 
+    # The stdio peer failed while a protocol message was in flight.
+    class WireError < Error; end
+
     # The server expired this client's session (a 404 with a session
     # attached); the spec says start a fresh one, and Client does.
     class SessionExpired < Error; end
@@ -99,4 +102,4 @@ require_relative "mcp/wires"
 require_relative "mcp/client"
 require_relative "mcp/oauth"
 
-Mistri::MCP.private_constant :Egress
+Mistri::MCP.private_constant :Egress, :WireError

--- a/lib/mistri/mcp/client.rb
+++ b/lib/mistri/mcp/client.rb
@@ -20,6 +20,8 @@ module Mistri
     # re-initializes, per spec.
     # Remote URLs default to public HTTPS. allow_non_public: is consulted only
     # for otherwise blocked addresses and plain HTTP remains loopback-only.
+    # max_record_bytes bounds one JSON body, SSE line, or stdio record without
+    # imposing a lifetime limit on an SSE stream.
     #
     # One client serializes its calls; parallel tool calls against one
     # server queue rather than interleave.
@@ -30,20 +32,24 @@ module Mistri
 
       def initialize(url: nil, command: nil, env: {}, token: nil, headers: {},
                      client_name: "mistri", open_timeout: 15, read_timeout: 120,
-                     allow_non_public: nil, max_tool_pages: 100, max_tools: 10_000)
+                     allow_non_public: nil, max_tool_pages: 100, max_tools: 10_000,
+                     max_record_bytes: DEFAULT_MAX_RECORD_BYTES)
         if [url, command].compact.length != 1
           raise ConfigurationError, "pass exactly one of url: or command:"
         end
 
         validate_limit(:max_tool_pages, max_tool_pages)
         validate_limit(:max_tools, max_tools)
+        validate_limit(:max_record_bytes, max_record_bytes)
 
         @wire = if url
                   Wires::Http.new(url: url, token: token, headers: headers,
                                   open_timeout: open_timeout, read_timeout: read_timeout,
-                                  allow_non_public: allow_non_public)
+                                  allow_non_public: allow_non_public,
+                                  max_record_bytes: max_record_bytes)
                 else
-                  Wires::Stdio.new(command: command, env: env, read_timeout: read_timeout)
+                  Wires::Stdio.new(command: command, env: env, read_timeout: read_timeout,
+                                   max_record_bytes: max_record_bytes)
                 end
         @client_name = client_name
         @mutex = Mutex.new
@@ -72,8 +78,7 @@ module Mistri
       end
 
       def close
-        @wire.close
-        @connected = false
+        @mutex.synchronize { reset_wire }
         nil
       end
 
@@ -96,6 +101,9 @@ module Mistri
         @server_info = result["serverInfo"]
         @wire.notify({ jsonrpc: "2.0", method: "notifications/initialized" })
         @connected = true
+      rescue Mistri::Error
+        reset_wire
+        raise
       end
 
       def request(method, params, reconnected: false, refreshed: false)
@@ -137,6 +145,20 @@ module Mistri
         end
 
         result
+      rescue ResponseTooLargeError, WireError => e
+        reset_wire
+        raise if replayable
+        return result if responded
+
+        message = "the request was sent but its tool outcome could not be confirmed: " \
+                  "#{e.message}; the operation may have completed; do not retry automatically; " \
+                  "verify external state first"
+        raise AmbiguousDeliveryError, message
+      rescue AmbiguousDeliveryError
+        reset_wire
+        return result if responded
+
+        raise
       rescue ProviderError => e
         raise SessionExpired if e.status == 404 && @wire.session?
 
@@ -172,6 +194,13 @@ module Mistri
         return if value.is_a?(Integer) && value.positive?
 
         raise ConfigurationError, "#{name}: must be a positive integer"
+      end
+
+      def reset_wire
+        @wire.close
+        @wire.reset_session
+        @connected = false
+        @server_info = nil
       end
 
       def rpc_error(error)

--- a/lib/mistri/mcp/wires.rb
+++ b/lib/mistri/mcp/wires.rb
@@ -21,13 +21,15 @@ module Mistri
                               mcp-protocol-version].freeze
         private_constant :HEADER_NAME, :INVALID_HEADER_VALUE, :RESERVED_HEADERS
 
-        def initialize(url:, token:, headers:, open_timeout:, read_timeout:, allow_non_public:)
+        def initialize(url:, token:, headers:, open_timeout:, read_timeout:, allow_non_public:,
+                       max_record_bytes: DEFAULT_MAX_RECORD_BYTES)
           uri, resolver = Egress.resolver(url, allow_non_public:, label: "MCP URL",
                                                timeout: open_timeout)
           @path = uri.path.empty? ? "/" : uri.path
           @path = "#{@path}?#{uri.query}" if uri.query
           @transport = Transport.new(origin: Egress.origin(uri), address_resolver: resolver,
-                                     open_timeout: open_timeout, read_timeout: read_timeout)
+                                     open_timeout: open_timeout, read_timeout: read_timeout,
+                                     max_record_bytes: max_record_bytes)
           @token = token
           @headers = normalized_headers(headers)
           @session_id = nil
@@ -53,7 +55,10 @@ module Mistri
 
         def refreshable? = @token.respond_to?(:call)
 
-        def reset_session = @session_id = nil
+        def reset_session
+          @session_id = nil
+          @protocol_version = nil
+        end
 
         def close = @transport.close
 
@@ -100,10 +105,20 @@ module Mistri
       # credentials in its environment, as the spec prescribes for local
       # servers. Its stderr stays attached for honest local debugging.
       class Stdio
-        def initialize(command:, env: {}, read_timeout: 120)
+        READ_SIZE = 16 * 1024
+        BLANK_RECORD = /\A[[:space:]]*\z/
+        private_constant :READ_SIZE, :BLANK_RECORD
+
+        def initialize(command:, env: {}, read_timeout: 120,
+                       max_record_bytes: DEFAULT_MAX_RECORD_BYTES)
+          unless max_record_bytes.is_a?(Integer) && max_record_bytes.positive?
+            raise ConfigurationError, "max_record_bytes: must be a positive integer"
+          end
+
           @command = Array(command).map(&:to_s)
           @env = env.transform_keys(&:to_s).transform_values(&:to_s)
           @read_timeout = read_timeout
+          @max_record_bytes = max_record_bytes
           @pid = nil
         end
 
@@ -133,11 +148,13 @@ module Mistri
         def protocol_version=(_version); end
 
         def close
-          return unless @pid
-
-          [@stdin, @stdout].each { |io| io.close unless io.closed? }
-          terminate
-          @pid = nil
+          if @pid
+            [@stdin, @stdout].each { |io| io.close unless io.closed? }
+            terminate
+            @pid = nil
+          end
+          @read_buffer&.clear
+          nil
         end
 
         private
@@ -146,6 +163,8 @@ module Mistri
           child_in, @stdin = IO.pipe
           @stdout, child_out = IO.pipe
           @pid = Process.spawn(@env, *@command, in: child_in, out: child_out)
+          @read_buffer = +"".b
+          @newline_search_offset = 0
           child_in.close
           child_out.close
         end
@@ -154,24 +173,69 @@ module Mistri
           @stdin.write("#{JSON.generate(payload)}\n")
           @stdin.flush
         rescue Errno::EPIPE
-          raise Error, "the MCP server closed its input"
+          raise WireError, "the MCP server closed its input"
         end
 
         # The spec requires stdout to carry only protocol messages, so a
         # line that is not one is corruption worth failing loudly on.
         def read_record
+          deadline = if @read_timeout
+                       Process.clock_gettime(Process::CLOCK_MONOTONIC) + @read_timeout
+                     end
           loop do
-            ready = @stdout.wait_readable(@read_timeout)
-            raise Error, "timed out waiting for the MCP server" unless ready
+            line = complete_record
+            return JSON.parse(line) if line
 
-            line = @stdout.gets
-            raise Error, "the MCP server exited" if line.nil?
-            next if line.strip.empty?
+            oversized_record! if @read_buffer.bytesize > @max_record_bytes
+            chunk = read_chunk(deadline)
+            return JSON.parse(eof_record) unless chunk
 
-            return JSON.parse(line)
+            @read_buffer << chunk
           end
         rescue JSON::ParserError
-          raise Error, "the MCP server wrote non-protocol output on stdout"
+          raise WireError, "the MCP server wrote non-protocol output on stdout"
+        end
+
+        def complete_record
+          while (newline = @read_buffer.index("\n", @newline_search_offset))
+            oversized_record! if newline > @max_record_bytes
+            line = @read_buffer.slice!(0, newline + 1)
+            @newline_search_offset = 0
+            return line unless BLANK_RECORD.match?(line)
+          end
+          @newline_search_offset = @read_buffer.bytesize
+          nil
+        end
+
+        def read_chunk(deadline)
+          loop do
+            remaining = deadline && (deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC))
+            if remaining && !remaining.positive?
+              raise WireError, "timed out waiting for the MCP server"
+            end
+
+            ready = @stdout.wait_readable(remaining)
+            raise WireError, "timed out waiting for the MCP server" unless ready
+
+            room = @max_record_bytes - @read_buffer.bytesize + 1
+            chunk = @stdout.read_nonblock([READ_SIZE, room].min, exception: false)
+            return chunk unless chunk == :wait_readable
+          end
+        end
+
+        def eof_record
+          raise WireError, "the MCP server exited" if @read_buffer.empty?
+
+          line = @read_buffer.slice!(0, @read_buffer.bytesize)
+          raise WireError, "the MCP server exited" if BLANK_RECORD.match?(line)
+
+          line
+        end
+
+        def oversized_record!
+          error = ResponseTooLargeError.new(kind: :stdio_record, limit: @max_record_bytes)
+          close
+          raise error
         end
 
         def terminate

--- a/lib/mistri/sse.rb
+++ b/lib/mistri/sse.rb
@@ -3,6 +3,9 @@
 require "json"
 
 module Mistri
+  DEFAULT_MAX_RECORD_BYTES = 8 * 1024 * 1024
+  private_constant :DEFAULT_MAX_RECORD_BYTES
+
   # An incremental Server-Sent Events decoder. Feed it raw socket fragments in
   # any chunking; it buffers partial lines across fragments and yields each
   # complete "data:" record as a parsed Hash.
@@ -11,37 +14,63 @@ module Mistri
   # send: one single-line JSON object per "data:" record. "event:", "id:",
   # comment, and blank lines are ignored (the event name is duplicated inside
   # the data payload), OpenAI's "[DONE]" sentinel is dropped, and a record that
-  # fails to parse is skipped rather than killing a live stream.
+  # fails to parse is skipped rather than killing a live stream. Only the
+  # partial line is bounded; the complete stream is not.
   class SSE
-    def initialize
+    def initialize(max_record_bytes: DEFAULT_MAX_RECORD_BYTES)
+      unless max_record_bytes.is_a?(Integer) && max_record_bytes.positive?
+        raise ConfigurationError, "max_record_bytes: must be a positive integer"
+      end
+
+      @max_record_bytes = max_record_bytes
       @buffer = +""
     end
 
     def feed(fragment, &)
-      @buffer << fragment
-      while (newline = @buffer.index("\n"))
-        line = @buffer.slice!(0, newline + 1)
-        decode(line.chomp, &)
+      scan = fragment.encoding == Encoding::BINARY ? fragment : fragment.b
+      offset = 0
+      while (newline = scan.index("\n", offset))
+        append(fragment, offset, newline - offset)
+        line = @buffer
+        @buffer = +""
+        line.chomp!
+        decode(line, &)
+        offset = newline + 1
       end
+      append(fragment, offset, scan.bytesize - offset)
       nil
     end
 
     # Flush a trailing record that arrived without a final newline.
     def finish(&)
-      decode(@buffer.chomp, &) unless @buffer.empty?
-      @buffer.clear
+      unless @buffer.empty?
+        line = @buffer
+        @buffer = +""
+        line.chomp!
+        decode(line, &)
+      end
       nil
     end
 
     private
 
+    def append(fragment, offset, length)
+      return if length.zero?
+
+      if @buffer.bytesize + length > @max_record_bytes
+        raise ResponseTooLargeError.new(kind: :sse_line, limit: @max_record_bytes)
+      end
+
+      @buffer << fragment.byteslice(offset, length)
+    end
+
     def decode(line)
-      return unless line.start_with?("data:")
+      return unless line.delete_prefix!("data:")
 
-      data = line.delete_prefix("data:").strip
-      return if data.empty? || data == "[DONE]"
+      line.strip!
+      return if line.empty? || line == "[DONE]"
 
-      decoded = JSON.parse(data)
+      decoded = JSON.parse(line)
       yield decoded if decoded.is_a?(Hash)
     rescue JSON::ParserError
       nil

--- a/lib/mistri/transport.rb
+++ b/lib/mistri/transport.rb
@@ -18,8 +18,12 @@ module Mistri
   # An address_resolver supplies a fresh validated set for each connection
   # cycle; candidates are tried before the request is sent while the original
   # hostname still owns Host, SNI, and TLS validation.
+  # JSON bodies and individual SSE lines share one configurable byte ceiling;
+  # a stream may contain any number of individually safe lines.
   class Transport
     KEEP_ALIVE_SECONDS = 30
+    ERROR_PREVIEW_BYTES = 500
+    BLANK_BODY = /\A[[:space:]]*\z/
     CONNECT_ERRORS = [IOError, SocketError, SystemCallError, Timeout::Error,
                       Net::HTTPBadResponse, OpenSSL::SSL::SSLError].freeze
 
@@ -56,16 +60,21 @@ module Mistri
         @open_timeout = original_timeout if original_timeout
       end
     end
-    private_constant :ResolvedHTTP, :CONNECT_ERRORS
+    private_constant :ResolvedHTTP, :CONNECT_ERRORS, :BLANK_BODY
 
     def initialize(origin:, open_timeout: 15, read_timeout: 300, write_timeout: 60,
-                   address_resolver: nil)
+                   address_resolver: nil, max_record_bytes: DEFAULT_MAX_RECORD_BYTES)
+      unless max_record_bytes.is_a?(Integer) && max_record_bytes.positive?
+        raise ConfigurationError, "max_record_bytes: must be a positive integer"
+      end
+
       @origin = origin.to_s.chomp("/")
       @uri = URI(@origin)
       @open_timeout = open_timeout
       @read_timeout = read_timeout
       @write_timeout = write_timeout
       @address_resolver = address_resolver
+      @max_record_bytes = max_record_bytes
       @mutex = Mutex.new
       @connection = nil
     end
@@ -73,11 +82,19 @@ module Mistri
     # POST and decode a JSON response body. Retries once on a dead idle
     # socket, so it suits idempotent endpoints.
     def post(path, body:, headers: {})
-      response = @mutex.synchronize do
-        with_retry { connection.request(build_request(path, body, headers)) }
+      @mutex.synchronize do
+        with_retry do
+          parsed = nil
+          connection.request(build_request(path, body, headers)) do |response|
+            raise_for_status(response)
+            parsed = JSON.parse(read_json_body(response))
+          end
+          parsed
+        end
+      rescue ResponseTooLargeError, ProviderError, JSON::ParserError
+        teardown
+        raise
       end
-      raise_for_status(response)
-      JSON.parse(response.body)
     end
 
     # POST and stream the SSE response, yielding each decoded data record.
@@ -93,32 +110,7 @@ module Mistri
     # returns the response headers, downcased. A replayable request retries
     # once when a dead idle socket fails before any response starts.
     def post_either(path, body:, headers: {}, replayable: true, &block)
-      @mutex.synchronize do
-        retried = false
-        begin
-          started = false
-          response_headers = nil
-          connection.request(build_request(path, body, headers, streaming: true)) do |response|
-            started = true
-            raise_for_status(response)
-            response_headers = response.to_hash.transform_values(&:first)
-            read_either(response, &block)
-          end
-          response_headers
-        rescue IOError, SocketError, SystemCallError, Timeout::Error, JSON::ParserError,
-               Net::HTTPBadResponse, OpenSSL::SSL::SSLError => e
-          teardown
-          unless replayable
-            raise AmbiguousDeliveryError, "#{AmbiguousDeliveryError.default_message}: #{e.message}"
-          end
-          if started || retried || e.is_a?(Timeout::Error)
-            raise ProviderError, "connection failed: #{e.message}"
-          end
-
-          retried = true
-          retry
-        end
-      end
+      @mutex.synchronize { post_either_locked(path, body, headers, replayable, &block) }
     end
 
     def close
@@ -127,14 +119,44 @@ module Mistri
 
     private
 
+    def post_either_locked(path, body, headers, replayable, &block)
+      retried = false
+      begin
+        started = false
+        response_headers = nil
+        connection.request(build_request(path, body, headers, streaming: true)) do |response|
+          started = true
+          raise_for_status(response)
+          response_headers = response.to_hash.transform_values(&:first)
+          read_either(response, &block)
+        end
+        response_headers
+      rescue ResponseTooLargeError, ProviderError
+        teardown
+        raise
+      rescue IOError, SocketError, SystemCallError, Timeout::Error, JSON::ParserError,
+             Net::HTTPBadResponse, OpenSSL::SSL::SSLError => e
+        teardown
+        unless replayable
+          raise AmbiguousDeliveryError, "#{AmbiguousDeliveryError.default_message}: #{e.message}"
+        end
+        if started || retried || e.is_a?(Timeout::Error)
+          raise ProviderError, "connection failed: #{e.message}"
+        end
+
+        retried = true
+        retry
+      end
+    end
+
     def read_either(response, &block)
       if response["content-type"].to_s.include?("text/event-stream")
-        sse = SSE.new
+        sse = SSE.new(max_record_bytes: @max_record_bytes)
         response.read_body { |chunk| sse.feed(chunk, &block) }
         sse.finish(&block)
       else
-        raw = response.read_body
-        block.call(JSON.parse(raw)) unless raw.to_s.strip.empty?
+        raw = read_json_body(response)
+        block.call(JSON.parse(raw)) unless BLANK_BODY.match?(raw)
       end
     end
 
@@ -161,6 +183,9 @@ module Mistri
         # than let the next request read stale frames.
         teardown if aborted
         aborted ? :aborted : nil
+      rescue ResponseTooLargeError, ProviderError
+        teardown
+        raise
       rescue IOError, SocketError, SystemCallError, Timeout::Error => e
         teardown
         return :aborted if signal&.aborted?
@@ -176,7 +201,7 @@ module Mistri
     end
 
     def read_stream(response, signal, &block)
-      sse = SSE.new
+      sse = SSE.new(max_record_bytes: @max_record_bytes)
       aborted = false
       response.read_body do |fragment|
         if signal&.aborted?
@@ -192,15 +217,30 @@ module Mistri
     def build_request(path, body, headers, streaming: false)
       request = Net::HTTP::Post.new(URI("#{@origin}#{path}"))
       request["Content-Type"] = "application/json"
-      if streaming
-        request["Accept"] = "text/event-stream"
-        # Net::HTTP silently negotiates gzip, and its inflater buffers the
-        # whole stream, delivering "live" events in one burst at the end.
-        request["Accept-Encoding"] = "identity"
-      end
+      request["Accept"] = "text/event-stream" if streaming
       headers.each { |key, value| request[key] = value }
+      # Identity keeps the byte ceiling meaningful before an untrusted
+      # compressed expansion and preserves immediate SSE delivery.
+      request["Accept-Encoding"] = "identity"
       request.body = JSON.generate(body)
       request
+    end
+
+    def read_json_body(response)
+      declared = response["content-length"]
+      if declared&.match?(/\A\d+\z/) && declared.to_i > @max_record_bytes
+        raise ResponseTooLargeError.new(kind: :json_body, limit: @max_record_bytes)
+      end
+
+      body = +""
+      response.read_body do |fragment|
+        if body.bytesize + fragment.bytesize > @max_record_bytes
+          raise ResponseTooLargeError.new(kind: :json_body, limit: @max_record_bytes)
+        end
+
+        body << fragment
+      end
+      body
     end
 
     def with_retry
@@ -258,10 +298,21 @@ module Mistri
       status = response.code.to_i
       return if (200..299).cover?(status)
 
+      preview = +""
+      response.read_body do |fragment|
+        remaining = ERROR_PREVIEW_BYTES - preview.bytesize
+        preview << fragment.byteslice(0, remaining) if remaining.positive?
+        raise status_error(response, status, preview) if preview.bytesize >= ERROR_PREVIEW_BYTES
+      end
+      raise status_error(response, status, preview)
+    end
+
+    def status_error(response, status, preview)
       klass = error_class(status)
-      options = { status: status, body: response.read_body.to_s[0, 500] }
+      body = preview.dup.force_encoding(Encoding::UTF_8).scrub("?")
+      options = { status: status, body: body }
       options[:retry_after] = retry_after(response) if klass == RateLimitError
-      raise klass.new(**options)
+      klass.new(**options)
     end
 
     def error_class(status)

--- a/test/support/mcp_stub_server.rb
+++ b/test/support/mcp_stub_server.rb
@@ -16,7 +16,7 @@ module Mistri
       def initialize(tools: {}, sse: true, session: nil, page_size: nil,
                      require_token: nil, expire_after: nil, protocol: "2025-11-25",
                      drop_after: nil, malformed_after: nil, empty_after: nil,
-                     next_cursor: nil)
+                     next_cursor: nil, trailing_after: nil)
         @tools = tools
         @sse = sse
         @session = session
@@ -27,6 +27,8 @@ module Mistri
         @drop_after = drop_after
         @malformed_after = malformed_after
         @empty_after = empty_after
+        @trailing_after = trailing_after
+        @trailed = false
         @next_cursor = next_cursor
         @dropped = false
         @malformed = false
@@ -71,7 +73,8 @@ module Mistri
           return @stub.respond_json(socket, "", status: 202)
         end
 
-        respond(socket, message["id"], result, headers: session_headers(message))
+        respond(socket, message["id"], result, headers: session_headers(message),
+                                               method: message["method"])
         nil
       end
 
@@ -115,7 +118,7 @@ module Mistri
         result
       end
 
-      def respond(socket, id, result, headers: {})
+      def respond(socket, id, result, method:, headers: {})
         payload = { "jsonrpc" => "2.0", "id" => id, "result" => result }
         return @stub.respond_json(socket, payload, headers: headers) unless @sse
 
@@ -123,6 +126,10 @@ module Mistri
                 "Transfer-Encoding: chunked", *headers.map { |k, v| "#{k}: #{v}" }]
         socket.write("#{head.join("\r\n")}\r\n\r\n")
         @stub.chunk(socket, "data: #{JSON.generate(payload)}\n\n")
+        if method == @trailing_after && !@trailed
+          @trailed = true
+          @stub.chunk(socket, "data: #{"x" * 2000}")
+        end
         @stub.finish_sse(socket)
       end
 

--- a/test/test_errors.rb
+++ b/test/test_errors.rb
@@ -6,8 +6,9 @@ class TestErrors < Minitest::Test
   def test_every_error_rescues_as_mistri_error
     [Mistri::ConfigurationError, Mistri::ProviderError, Mistri::AuthenticationError,
      Mistri::RateLimitError, Mistri::OverloadedError, Mistri::ServerError,
-     Mistri::AmbiguousDeliveryError, Mistri::InvalidRequestError, Mistri::SchemaError,
-     Mistri::AbortError, Mistri::BudgetError].each do |klass|
+     Mistri::ResponseTooLargeError, Mistri::AmbiguousDeliveryError,
+     Mistri::InvalidRequestError, Mistri::SchemaError, Mistri::AbortError,
+     Mistri::BudgetError].each do |klass|
       assert_operator klass, :<, Mistri::Error
     end
   end
@@ -32,5 +33,13 @@ class TestErrors < Minitest::Test
 
     assert_match(/operation may have completed/, error.message)
     assert_match(/do not retry automatically/, error.message)
+  end
+
+  def test_response_too_large_error_carries_only_boundary_metadata
+    error = Mistri::ResponseTooLargeError.new(kind: :json_body, limit: 1024)
+
+    assert_equal :json_body, error.kind
+    assert_equal 1024, error.limit
+    assert_equal "json body exceeded max_record_bytes (1024 bytes)", error.message
   end
 end

--- a/test/test_mcp_client.rb
+++ b/test/test_mcp_client.rb
@@ -100,8 +100,8 @@ class TestMcpClient < Minitest::Test
     end
   end
 
-  def test_tool_discovery_limits_must_be_positive_integers
-    [[:max_tool_pages, 0], [:max_tools, 1.5]].each do |name, value|
+  def test_client_limits_must_be_positive_integers
+    [[:max_tool_pages, 0], [:max_tools, 1.5], [:max_record_bytes, nil]].each do |name, value|
       error = assert_raises(Mistri::ConfigurationError) do
         Mistri::MCP::Client.new(command: ["unused"], name => value)
       end
@@ -181,6 +181,25 @@ class TestMcpClient < Minitest::Test
 
       assert_equal "echo: two", result.dig("content", 0, "text")
       assert_equal 2, server.initializes, "the client started a fresh session"
+    end
+  end
+
+  def test_close_discards_the_http_session_before_reconnecting
+    with_server(session: "sess") do |server|
+      client = remote_client(server)
+      client.connect
+      client.close
+
+      assert_nil client.server_info
+
+      client.connect
+      initialize_requests = server.requests.select do |request|
+        JSON.parse(request[:body])["method"] == "initialize"
+      end
+
+      assert_equal 2, server.initializes
+      assert_nil initialize_requests.last[:headers]["mcp-session-id"]
+      assert_nil initialize_requests.last[:headers]["mcp-protocol-version"]
     end
   end
 

--- a/test/test_mcp_response_limits.rb
+++ b/test/test_mcp_response_limits.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require_relative "support/mcp_stub_server"
+
+# Response overflow keeps JSON-RPC confirmation and replay semantics honest.
+class TestMcpResponseLimits < Minitest::Test
+  ECHO = { "echo" => { description: "Echoes.", handler: lambda { |args|
+    "echo: #{args["text"]}"
+  } } }.freeze
+
+  def test_an_oversized_tool_response_is_ambiguous_over_json_and_sse
+    tools = { "large" => { description: "Large.", handler: ->(_) { "x" * 2000 } } }
+
+    [true, false].each do |sse|
+      with_server(tools: tools, sse: sse, session: "sess") do |server|
+        client = remote_client(server, max_record_bytes: 512)
+
+        error = assert_raises(Mistri::AmbiguousDeliveryError) do
+          client.call_tool("large", {})
+        end
+
+        assert_match(/may have completed/, error.message)
+        assert_match(/do not retry automatically/, error.message)
+        assert_instance_of Mistri::ResponseTooLargeError, error.cause
+        assert_equal(sse ? :sse_line : :json_body, error.cause.kind)
+        assert_equal 1, server.calls.length
+
+        client.connect
+        initialize_requests = requests_for(server, "initialize")
+
+        assert_equal 2, server.initializes, "the next operation performs a fresh handshake"
+        assert_nil initialize_requests.last[:headers]["mcp-session-id"]
+        assert_nil initialize_requests.last[:headers]["mcp-protocol-version"]
+      end
+    end
+  end
+
+  def test_an_oversized_replayable_response_fails_without_replay
+    tools = { "large" => { description: "x" * 2000, handler: ->(_) { "unused" } } }
+    with_server(tools: tools) do |server|
+      client = remote_client(server, max_record_bytes: 512)
+
+      error = assert_raises(Mistri::ResponseTooLargeError) { client.tools }
+
+      assert_equal :sse_line, error.kind
+      assert_equal 1, requests_for(server, "tools/list").length
+      assert_empty server.calls
+    end
+  end
+
+  def test_a_confirmed_tool_result_survives_an_oversized_trailing_sse_line
+    with_server(trailing_after: "tools/call") do |server|
+      client = remote_client(server, max_record_bytes: 512)
+
+      result = client.call_tool("echo", { "text" => "confirmed" })
+
+      assert_equal "echo: confirmed", result.dig("content", 0, "text")
+      assert_equal 1, server.calls.length
+
+      client.connect
+
+      assert_equal 2, server.initializes, "the malformed stream forced a clean handshake"
+    end
+  end
+
+  def test_an_initialize_with_trailing_overflow_is_restarted_cleanly
+    with_server(trailing_after: "initialize", session: "sess") do |server|
+      client = remote_client(server, max_record_bytes: 512)
+
+      assert_raises(Mistri::ResponseTooLargeError) { client.connect }
+      client.connect
+
+      methods = server.bodies.map { |body| body["method"] }
+
+      assert_equal %w[initialize initialize notifications/initialized], methods
+      assert_nil requests_for(server, "initialize").last[:headers]["mcp-session-id"]
+      assert_nil requests_for(server, "initialize").last[:headers]["mcp-protocol-version"]
+    end
+  end
+
+  private
+
+  def with_server(tools: ECHO, **)
+    server = Mistri::Test::McpStubServer.new(tools: tools, **)
+    yield server
+  ensure
+    server&.stop
+  end
+
+  def remote_client(server, **)
+    Mistri::MCP::Client.new(url: server.url,
+                            allow_non_public: Mistri::Test::ALLOW_LOOPBACK, **)
+  end
+
+  def requests_for(server, method)
+    server.requests.select { |request| JSON.parse(request[:body])["method"] == method }
+  end
+end

--- a/test/test_mcp_stdio.rb
+++ b/test/test_mcp_stdio.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "tmpdir"
 
 # The stdio wire: a real spawned child process speaking line-delimited
 # JSON-RPC, with credentials in its environment.
@@ -11,17 +12,44 @@ class TestMcpStdio < Minitest::Test
     loop do
       line = STDIN.gets or exit
       message = JSON.parse(line)
+      if ENV["STUB_TRACE"]
+        File.open(ENV["STUB_TRACE"], "a") do |file|
+          file.puts([Process.pid, message["method"], message.dig("params", "name")].compact.join(":"))
+        end
+      end
       next unless message["id"]
       tool = message.dig("params", "name")
       exit if tool == "die"
       puts "not json at all" if tool == "corrupt"
+      if message["method"] == "tools/call" && tool == "stall"
+        STDOUT.write("{")
+        STDOUT.flush
+        sleep 60
+      end
+      if message["method"] == "tools/call" && %w[sized unterminated].include?(tool)
+        File.open(ENV["STUB_MARKER"], "a") { |file| file.puts(Process.pid) } if ENV["STUB_MARKER"]
+        result = { "content" => [{ "type" => "text", "text" => "" }] }
+        response = { "jsonrpc" => "2.0", "id" => message["id"], "result" => result }
+        target = Integer(ENV.fetch("STUB_RESPONSE_BYTES"))
+        result["content"][0]["text"] = "x" * (target - JSON.generate(response).bytesize)
+        encoded = JSON.generate(response)
+        raise "bad fixture size" unless encoded.bytesize == target
+        if tool == "unterminated"
+          STDOUT.write(encoded)
+          STDOUT.flush
+          sleep 60
+        end
+        puts encoded
+        next
+      end
       result =
         case message["method"]
         when "initialize"
           { "protocolVersion" => "2025-11-25", "capabilities" => {},
             "serverInfo" => { "name" => "stdio-stub", "version" => "1" } }
         when "tools/list"
-          { "tools" => [{ "name" => "echo", "description" => "Echoes.",
+          description = ENV["STUB_LARGE_LIST"] ? "x" * 2000 : "Echoes."
+          { "tools" => [{ "name" => "echo", "description" => description,
                           "inputSchema" => { "type" => "object",
                                              "properties" => { "text" => { "type" => "string" } } } }] }
         when "tools/call"
@@ -33,8 +61,10 @@ class TestMcpStdio < Minitest::Test
     end
   SCRIPT
 
-  def client(env: {})
-    Mistri::MCP::Client.new(command: ["ruby", "-e", SERVER], env: env, read_timeout: 10)
+  def client(env: {}, read_timeout: 10, max_record_bytes: nil)
+    options = { command: ["ruby", "-e", SERVER], env: env, read_timeout: read_timeout }
+    options[:max_record_bytes] = max_record_bytes if max_record_bytes
+    Mistri::MCP::Client.new(**options)
   end
 
   def test_the_full_lifecycle_over_a_spawned_process
@@ -71,8 +101,9 @@ class TestMcpStdio < Minitest::Test
     stdio = client
     stdio.connect
 
-    error = assert_raises(Mistri::MCP::Error) { stdio.call_tool("die", {}) }
+    error = assert_raises(Mistri::AmbiguousDeliveryError) { stdio.call_tool("die", {}) }
 
+    assert_kind_of Mistri::MCP::Error, error.cause
     assert_match(/exited|closed/, error.message)
   ensure
     stdio.close
@@ -82,11 +113,114 @@ class TestMcpStdio < Minitest::Test
     stdio = client
     stdio.connect
 
-    error = assert_raises(Mistri::MCP::Error) { stdio.call_tool("corrupt", {}) }
+    error = assert_raises(Mistri::AmbiguousDeliveryError) do
+      stdio.call_tool("corrupt", {})
+    end
 
+    assert_kind_of Mistri::MCP::Error, error.cause
     assert_match(/non-protocol/, error.message)
   ensure
     stdio.close
+  end
+
+  def test_accepts_a_stdio_record_at_the_exact_byte_limit
+    stdio = client(env: { "STUB_RESPONSE_BYTES" => "512" }, max_record_bytes: 512)
+
+    result = stdio.call_tool("sized", {})
+
+    assert_equal "text", result.dig("content", 0, "type")
+  ensure
+    stdio.close
+  end
+
+  def test_an_oversized_stdio_tool_response_is_ambiguous_and_terminates_the_child
+    Dir.mktmpdir do |directory|
+      marker = File.join(directory, "calls")
+      stdio = client(env: { "STUB_RESPONSE_BYTES" => "513", "STUB_MARKER" => marker },
+                     max_record_bytes: 512)
+
+      error = assert_raises(Mistri::AmbiguousDeliveryError) do
+        stdio.call_tool("sized", {})
+      end
+
+      assert_instance_of Mistri::ResponseTooLargeError, error.cause
+      assert_equal :stdio_record, error.cause.kind
+      assert_equal 1, File.readlines(marker).length
+      pid = File.read(marker).to_i
+      assert_raises(Errno::ESRCH) { Process.kill(0, pid) }
+    ensure
+      stdio&.close
+    end
+  end
+
+  def test_an_unterminated_stdio_record_fails_as_soon_as_it_crosses_the_limit
+    stdio = client(env: { "STUB_RESPONSE_BYTES" => "513" }, max_record_bytes: 512,
+                   read_timeout: 10)
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    error = assert_raises(Mistri::AmbiguousDeliveryError) do
+      stdio.call_tool("unterminated", {})
+    end
+
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_instance_of Mistri::ResponseTooLargeError, error.cause
+    assert_operator elapsed, :<, 2
+  ensure
+    stdio.close
+  end
+
+  def test_an_oversized_stdio_tool_list_is_not_ambiguous_or_replayed
+    Dir.mktmpdir do |directory|
+      trace = File.join(directory, "trace")
+      stdio = client(env: { "STUB_LARGE_LIST" => "1", "STUB_TRACE" => trace },
+                     max_record_bytes: 512)
+
+      error = assert_raises(Mistri::ResponseTooLargeError) { stdio.tools }
+      first_trace = File.readlines(trace, chomp: true)
+      list_line = first_trace.find { |line| line.end_with?(":tools/list") }
+
+      assert_equal :stdio_record, error.kind
+      assert_equal(1, first_trace.count { |line| line.end_with?(":tools/list") })
+      assert_raises(Errno::ESRCH) { Process.kill(0, list_line.to_i) }
+
+      stdio.connect
+      pids = File.readlines(trace, chomp: true).map { |line| line.split(":", 2).first }.uniq
+
+      assert_equal 2, pids.length, "the next operation performed a fresh stdio handshake"
+    ensure
+      stdio&.close
+    end
+  end
+
+  def test_the_stdio_timeout_covers_the_whole_record
+    Dir.mktmpdir do |directory|
+      trace = File.join(directory, "trace")
+      stdio = client(env: { "STUB_TRACE" => trace }, read_timeout: 0.2)
+      stdio.connect
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      error = assert_raises(Mistri::AmbiguousDeliveryError) do
+        stdio.call_tool("stall", {})
+      end
+
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+      first_trace = File.readlines(trace, chomp: true)
+      tool_pid = first_trace.find { |line| line.end_with?(":tools/call:stall") }.to_i
+
+      assert_kind_of Mistri::MCP::Error, error.cause
+      assert_match(/timed out/, error.message)
+      assert_operator elapsed, :<, 2
+      assert_equal(1, first_trace.count { |line| line.end_with?(":tools/call:stall") })
+      assert_raises(Errno::ESRCH) { Process.kill(0, tool_pid) }
+
+      stdio.connect
+      pids = File.readlines(trace, chomp: true).map { |line| line.split(":", 2).first }.uniq
+
+      assert_equal 2, pids.length, "the next operation performed a fresh stdio handshake"
+    ensure
+      stdio&.close
+    end
   end
 
   def test_close_terminates_the_child

--- a/test/test_mcp_stdio.rb
+++ b/test/test_mcp_stdio.rb
@@ -17,10 +17,21 @@ class TestMcpStdio < Minitest::Test
           file.puts([Process.pid, message["method"], message.dig("params", "name")].compact.join(":"))
         end
       end
+      if ENV["STUB_EXIT_AFTER_INIT"] && message["method"] == "notifications/initialized"
+        File.write(ENV.fetch("STUB_EXIT_AFTER_INIT"), Process.pid.to_s)
+        exit
+      end
       next unless message["id"]
       tool = message.dig("params", "name")
       exit if tool == "die"
       puts "not json at all" if tool == "corrupt"
+      if message["method"] == "tools/call" && tool == "eof"
+        result = { "content" => [{ "type" => "text", "text" => "tail" }] }
+        response = { "jsonrpc" => "2.0", "id" => message["id"], "result" => result }
+        STDOUT.write(JSON.generate(response))
+        STDOUT.flush
+        exit
+      end
       if message["method"] == "tools/call" && tool == "stall"
         STDOUT.write("{")
         STDOUT.flush
@@ -121,6 +132,42 @@ class TestMcpStdio < Minitest::Test
     assert_match(/non-protocol/, error.message)
   ensure
     stdio.close
+  end
+
+  def test_a_valid_final_stdio_record_may_end_at_eof
+    stdio = client
+
+    result = stdio.call_tool("eof", {})
+
+    assert_equal "tail", result.dig("content", 0, "text")
+  ensure
+    stdio.close
+  end
+
+  def test_a_child_that_exits_before_the_tool_write_is_ambiguous
+    Dir.mktmpdir do |directory|
+      marker = File.join(directory, "exited")
+      stdio = client(env: { "STUB_EXIT_AFTER_INIT" => marker })
+      stdio.connect
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+      until File.exist?(marker) || Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+        sleep 0.01
+      end
+
+      assert_path_exists marker
+
+      pid = File.read(marker).to_i
+      Process.waitpid(pid)
+
+      error = assert_raises(Mistri::AmbiguousDeliveryError) do
+        stdio.call_tool("echo", {})
+      end
+
+      assert_kind_of Mistri::MCP::Error, error.cause
+      assert_match(/closed its input/, error.message)
+    ensure
+      stdio&.close
+    end
   end
 
   def test_accepts_a_stdio_record_at_the_exact_byte_limit
@@ -237,6 +284,12 @@ class TestMcpStdio < Minitest::Test
     assert_raises(Mistri::ConfigurationError) { Mistri::MCP::Client.new }
     assert_raises(Mistri::ConfigurationError) do
       Mistri::MCP::Client.new(url: "https://x.example/mcp", command: ["ruby"])
+    end
+  end
+
+  def test_the_stdio_wire_validates_its_direct_record_limit
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::MCP::Wires::Stdio.new(command: ["unused"], max_record_bytes: 0)
     end
   end
 end

--- a/test/test_retry_policy.rb
+++ b/test/test_retry_policy.rb
@@ -18,7 +18,8 @@ class TestRetryPolicy < Minitest::Test
     %w[ProviderError RateLimitError OverloadedError ServerError TruncatedStream].each do |type|
       assert policy.retryable?({ "type" => type })
     end
-    %w[SchemaError RuntimeError Error NoMethodError InvalidRequestError].each do |type|
+    %w[SchemaError RuntimeError Error NoMethodError InvalidRequestError
+       ResponseTooLargeError].each do |type|
       refute policy.retryable?({ "type" => type })
     end
     refute policy.retryable?(nil)
@@ -48,6 +49,10 @@ class TestRetryPolicy < Minitest::Test
                  Mistri::ErrorData.for(rate))
     assert_equal({ "type" => "ServerError", "status" => 500 },
                  Mistri::ErrorData.for(Mistri::ServerError.new("boom", status: 500)))
+    too_large = Mistri::ResponseTooLargeError.new(kind: :json_body, limit: 1024)
+
+    assert_equal({ "type" => "ResponseTooLargeError", "kind" => "json_body", "limit" => 1024 },
+                 Mistri::ErrorData.for(too_large))
     assert_equal({ "type" => "RuntimeError" }, Mistri::ErrorData.for(RuntimeError.new("x")))
     assert_equal({ "type" => "TruncatedStream" },
                  Mistri::ErrorData.for("stream ended without message_stop"))

--- a/test/test_sse.rb
+++ b/test/test_sse.rb
@@ -32,4 +32,60 @@ class TestSSE < Minitest::Test
 
     assert_equal [{ "tail" => true }], records
   end
+
+  def test_accepts_a_line_at_the_byte_limit_and_rejects_one_byte_more
+    line = "data: {\"ok\":true}"
+    records = []
+    sse = Mistri::SSE.new(max_record_bytes: line.bytesize)
+
+    sse.feed("#{line}\n") { |record| records << record }
+
+    assert_equal [{ "ok" => true }], records
+
+    error = assert_raises(Mistri::ResponseTooLargeError) do
+      Mistri::SSE.new(max_record_bytes: line.bytesize - 1).feed("#{line}\n") { flunk }
+    end
+    assert_equal :sse_line, error.kind
+    assert_equal line.bytesize - 1, error.limit
+  end
+
+  def test_counts_fragmented_multibyte_lines_in_bytes
+    sse = Mistri::SSE.new(max_record_bytes: 10)
+
+    sse.feed("data: ")
+    sse.feed("éé")
+
+    assert_raises(Mistri::ResponseTooLargeError) { sse.feed("x") }
+  end
+
+  def test_finds_multiple_lines_by_byte_offset_in_a_utf8_fragment
+    sse = Mistri::SSE.new(max_record_bytes: 64)
+    records = []
+
+    sse.feed("data: {\"text\":\"é\"}\ndata: {\"text\":\"漢\"}\n") do |record|
+      records << record
+    end
+
+    assert_equal [{ "text" => "é" }, { "text" => "漢" }], records
+  end
+
+  def test_does_not_apply_the_record_limit_to_the_whole_stream
+    line = "data: {\"ok\":true}"
+    records = []
+    sse = Mistri::SSE.new(max_record_bytes: line.bytesize)
+
+    100.times { sse.feed("#{line}\n\n") { |record| records << record } }
+
+    assert_equal 100, records.length
+  end
+
+  def test_rejects_invalid_record_limits
+    [nil, 0, -1, 1.5, "10"].each do |value|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::SSE.new(max_record_bytes: value)
+      end
+
+      assert_equal "max_record_bytes: must be a positive integer", error.message
+    end
+  end
 end

--- a/test/test_transport_limits.rb
+++ b/test/test_transport_limits.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+require "json"
+require "stringio"
+require "zlib"
+require_relative "test_helper"
+require_relative "support/stub_server"
+
+# Entity bodies and streaming records stay bounded without capping a stream.
+class TestTransportLimits < Minitest::Test
+  def test_json_bodies_are_bounded_and_identity_encoded
+    exact = JSON.generate("value" => "x" * 20)
+    oversized = JSON.generate("value" => "x" * 21)
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      payload = server.requests.length == 1 ? exact : oversized
+      server.respond_json(socket, payload)
+    end
+    transport = Mistri::Transport.new(origin: server.origin,
+                                      max_record_bytes: exact.bytesize)
+
+    assert_equal({ "value" => "x" * 20 }, transport.post("/v1/x", body: {}))
+    error = assert_raises(Mistri::ResponseTooLargeError) do
+      transport.post("/v1/x", body: {})
+    end
+
+    assert_equal :json_body, error.kind
+    assert_equal exact.bytesize, error.limit
+    assert_equal "identity", server.requests.first[:headers]["accept-encoding"]
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_rejects_an_oversized_declared_body_without_waiting_for_it
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      socket.write("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" \
+                   "Content-Length: 1000\r\n\r\n")
+      sleep 60
+    end
+    transport = Mistri::Transport.new(origin: server.origin, max_record_bytes: 64,
+                                      read_timeout: 30)
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    assert_raises(Mistri::ResponseTooLargeError) do
+      transport.post("/v1/x", body: {})
+    end
+
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_operator elapsed, :<, 2
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_bounds_a_chunked_body_and_reconnects_without_stale_bytes
+    oversized = JSON.generate("value" => "x" * 100)
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      if server.requests.length == 1
+        socket.write("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" \
+                     "Transfer-Encoding: chunked\r\n\r\n")
+        server.chunk(socket, oversized.byteslice(0, 40))
+        server.chunk(socket, oversized.byteslice(40..))
+        server.finish_sse(socket)
+      else
+        server.respond_json(socket, { "clean" => true })
+      end
+    end
+    transport = Mistri::Transport.new(origin: server.origin, max_record_bytes: 64)
+
+    assert_raises(Mistri::ResponseTooLargeError) do
+      transport.post("/v1/x", body: {})
+    end
+    assert_equal({ "clean" => true }, transport.post("/v1/x", body: {}))
+
+    assert_equal 2, server.accepts
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_identity_encoding_prevents_compressed_expansion
+    compressed = StringIO.new
+    Zlib::GzipWriter.wrap(compressed) do |gzip|
+      gzip.write(JSON.generate("value" => "x" * 1000))
+    end
+    payload = compressed.string
+
+    assert_operator payload.bytesize, :<, 64, "the wire body must fit below the limit"
+
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      if server.requests.length == 1
+        socket.write("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" \
+                     "Content-Encoding: gzip\r\nContent-Length: #{payload.bytesize}\r\n\r\n")
+        socket.write(payload)
+      else
+        server.respond_json(socket, { "clean" => true })
+      end
+    end
+    transport = Mistri::Transport.new(origin: server.origin, max_record_bytes: 64)
+
+    assert_raises(JSON::ParserError) { transport.post("/v1/x", body: {}) }
+    assert_equal({ "clean" => true }, transport.post("/v1/x", body: {}))
+    assert_equal 2, server.accepts
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_error_bodies_stop_at_a_small_valid_preview_without_losing_status
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      if server.requests.length == 1
+        body = ("a" * 499) + ("€" * 1000)
+        server.respond_json(socket, body,
+                            status: 429, headers: { "Retry-After" => "2" })
+      else
+        server.respond_json(socket, { "clean" => true })
+      end
+    end
+    transport = Mistri::Transport.new(origin: server.origin, max_record_bytes: 16)
+
+    error = assert_raises(Mistri::RateLimitError) do
+      transport.post("/v1/x", body: {})
+    end
+
+    assert_equal 500, error.body.bytesize
+    assert_predicate error.body, :valid_encoding?
+    assert_equal "?", error.body[-1]
+    assert_in_delta 2.0, error.retry_after
+    assert_equal({ "clean" => true }, transport.post("/v1/x", body: {}))
+    assert_equal 2, server.accepts
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_an_oversized_sse_line_keeps_prior_records_and_resets_the_connection
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.start_sse(socket)
+      if server.requests.length == 1
+        server.sse_data(socket, { "first" => true })
+        server.chunk(socket, "data: #{"x" * 100}")
+      else
+        server.sse_data(socket, { "clean" => true })
+        server.finish_sse(socket)
+      end
+    end
+    transport = Mistri::Transport.new(origin: server.origin, max_record_bytes: 32)
+    records = []
+
+    error = assert_raises(Mistri::ResponseTooLargeError) do
+      transport.stream_post("/v1/x", body: {}) { |record| records << record }
+    end
+    transport.stream_post("/v1/x", body: {}) { |record| records << record }
+
+    assert_equal :sse_line, error.kind
+    assert_equal [{ "first" => true }, { "clean" => true }], records
+    assert_equal 2, server.accepts
+  ensure
+    teardown_all(transport, server)
+  end
+
+  def test_rejects_invalid_record_limits_before_connecting
+    [nil, 0, -1, 1.5, "10"].each do |value|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::Transport.new(origin: "http://127.0.0.1", max_record_bytes: value)
+      end
+
+      assert_equal "max_record_bytes: must be a positive integer", error.message
+    end
+  end
+
+  def test_provider_overflow_is_machine_readable_and_never_retried
+    server = Mistri::Test::StubServer.new do |socket, _request|
+      server.start_sse(socket)
+      server.chunk(socket, "data: #{"x" * 100}")
+    end
+    provider = Mistri::Providers::OpenAI.new(
+      api_key: "test", model: "gpt-5.6", origin: server.origin, max_record_bytes: 32
+    )
+    retries = Mistri::RetryPolicy.new(attempts: 2, base: 0.0)
+    agent = Mistri::Agent.new(provider: provider, retries: retries)
+
+    result = agent.run("go")
+
+    assert_predicate result, :errored?
+    assert_equal({ "type" => "ResponseTooLargeError", "kind" => "sse_line", "limit" => 32 },
+                 result.message.error)
+    assert_equal 1, server.requests.length
+  ensure
+    provider&.close
+    server&.stop
+  end
+
+  private
+
+  def teardown_all(transport, server)
+    transport&.close
+    server&.stop
+  end
+end


### PR DESCRIPTION
## Summary

- Bound one ordinary JSON body, SSE line, or stdio JSON record with a configurable `max_record_bytes:` ceiling, defaulting to 8 MiB. The total length of a healthy SSE stream remains unlimited.
- Read successful JSON and error previews incrementally, request identity encoding, reject oversized declared bodies before reading, and reset any connection or child with unread bytes.
- Add `ResponseTooLargeError` with machine-readable `kind` and `limit`. A response overflow or stdio failure after `tools/call` remains explicitly ambiguous and is never replayed.
- Make stdio timeouts cover the complete record, not only its first byte, and make close/overflow recovery clear session, protocol, and server state before a fresh handshake.
- Document the boundary, large-result resource-link guidance, hot-path cost, and the Net::HTTP framing residual.

## Why

Several parser-owned allocations were unbounded: Net::HTTP buffered ordinary JSON, error paths read an entire body before truncating it, SSE retained a partial line indefinitely, and stdio used unbounded `gets`. A malformed or hostile peer could therefore exhaust memory, and stopping early without teardown could poison the next keep-alive request.

The official MCP Ruby SDK provides a useful 4 MiB stdio-frame baseline but leaves its HTTP/SSE client unbounded. The official Python SDK and FastMCP likewise stream overall connections while leaving JSON bodies and partial SSE/stdio records without one coherent client-side limit. This change applies the same contract across every Mistri response path while preserving MCP's ambiguous-execution semantics.

## Validation

- Hermetic suite on Ruby 3.2.9, 3.3.11, and 3.4.1: 605 tests, 2,332 assertions, zero failures
- Targeted changed paths on Ruby 4.0.2: green
- RuboCop: 168 files, zero offenses
- Coverage: 97.49% lines, 84.67% branches
- Live Anthropic, OpenAI, and Gemini suites; all 17 catalog models passed
- Full three-provider integration scenarios passed, including compaction, background workers, and the public DeepWiki MCP server
- Strict gem build plus isolated install/require smoke passed

The hot path adds a byte-count addition and comparison per JSON fragment or SSE line fragment, with no per-token work.