### PR TITLE
Make gem releases tag-derived

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,32 @@ name: Release
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  verify:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - run: bundle exec ruby script/verify_release.rb
+      - run: bundle exec rake test
+      - run: bundle exec rubocop
+
   publish:
+    needs: verify
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -17,39 +36,42 @@ jobs:
       # The OIDC token is what rubygems.org trusts; no stored credential.
       id-token: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           ruby-version: "3.4"
           bundler-cache: true
-      # The tag does not set the published version; lib/mistri/version.rb
-      # does. A mismatched tag fails here, plainly, instead of surfacing as
-      # rubygems rejecting a republish of the old version.
-      - if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          ruby -r ./lib/mistri/version -e 'tag = ENV.fetch("GITHUB_REF_NAME");
-            abort "tag #{tag} but VERSION is #{Mistri::VERSION}" unless tag == "v#{Mistri::VERSION}"'
-      - run: bundle exec rake test
-      - uses: rubygems/release-gem@v1
+      - run: bundle exec ruby script/verify_release.rb
+      - uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0
+        with:
+          await-release: false
 
   # The release page exists only for versions that actually published, and
   # this job alone gets write access; the publish job stays read-only.
   github-release:
     needs: publish
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
-      # Notes are this version's changelog section; an unwritten section
-      # fails the job rather than shipping an empty page. Reruns are safe:
-      # an existing release is left alone.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      # The release page converges on the changelog even when this job is
+      # retried after RubyGems has accepted the immutable gem.
       - env:
           GH_TOKEN: ${{ github.token }}
         run: |
           version="${GITHUB_REF_NAME#v}"
-          awk -v ver="$version" '$0 ~ "^## \\[" ver "\\]" {flag=1; next} /^## \[/ {flag=0} flag' CHANGELOG.md > notes.md
+          awk -v heading="## [$version] - " 'index($0, heading) == 1 {flag=1; next} /^## \[/ {flag=0} flag' CHANGELOG.md > notes.md
           test -s notes.md
-          gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1 && exit 0
-          gh release create "$GITHUB_REF_NAME" --title "mistri $version" --notes-file notes.md
+          if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+            gh release edit "$GITHUB_REF_NAME" --title "mistri $version" --notes-file notes.md
+          else
+            gh release create "$GITHUB_REF_NAME" --title "mistri $version" --notes-file notes.md
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,10 @@ No ticket references, no Co-Authored-By, no emojis.
 
 ## Releases
 
-Semver from 0.x: patch for fixes, minor for features. Every release: CHANGELOG entry,
-tag `vX.Y.Z`, `gem build`, `gem push`. MFA becomes mandatory on the publishing account
-before 0.1.0; the Gemspec/RequireMFA cop turns on at the same time.
+Semver from 0.x: patch for fixes, minor for features. Prepare every release on main with
+a versioned CHANGELOG entry and matching `vX.Y.Z` tag. The tag-derived workflow verifies,
+builds, and publishes through RubyGems trusted publishing; never publish from a branch or
+manual dispatch. MFA is mandatory on the publishing account and in the gemspec metadata.
 
 ## Review
 

--- a/mistri.gemspec
+++ b/mistri.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["source_code_uri"] = "https://github.com/mcheemaa/mistri"
   spec.metadata["changelog_uri"] = "https://github.com/mcheemaa/mistri/blob/main/CHANGELOG.md"
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.metadata["documentation_uri"] = "https://mistri.sh/docs/getting-started/"
   spec.metadata["bug_tracker_uri"] = "https://github.com/mcheemaa/mistri/issues"

--- a/script/verify_release.rb
+++ b/script/verify_release.rb
@@ -105,6 +105,8 @@ module Mistri
   end
 end
 
+# The subprocess tests exercise this exit contract; SimpleCov cannot merge child coverage.
+# :nocov:
 if $PROGRAM_NAME == __FILE__
   verifier = Mistri::ReleaseVerifier.new(
     root: File.expand_path("..", __dir__),
@@ -124,3 +126,4 @@ if $PROGRAM_NAME == __FILE__
     exit 1
   end
 end
+# :nocov:

--- a/script/verify_release.rb
+++ b/script/verify_release.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "date"
+require "open3"
+require "rubygems"
+require_relative "../lib/mistri/version"
+
+module Mistri
+  # ReleaseVerifier verifies that a publishable checkout is the declared release on main.
+  class ReleaseVerifier
+    class Error < StandardError; end
+
+    STABLE_VERSION = /\A(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\z/
+
+    def initialize(root:, tag:, main_ref:, event_name:, ref_type:, version: VERSION)
+      @root = File.expand_path(root)
+      @tag = tag.to_s
+      @main_ref = main_ref.to_s
+      @event_name = event_name.to_s
+      @ref_type = ref_type.to_s
+      @version = version.to_s
+    end
+
+    def verify!
+      verify_trigger!
+      verify_identity!
+      notes = changelog_notes!
+      verify_commit!
+      notes
+    end
+
+    private
+
+    def verify_trigger!
+      return if @event_name == "push" && @ref_type == "tag"
+
+      raise Error, "release requires a tag push, got #{@event_name.inspect} on #{@ref_type.inspect}"
+    end
+
+    def verify_identity!
+      unless STABLE_VERSION.match?(@version)
+        raise Error, "version #{@version.inspect} is not a stable version"
+      end
+
+      expected_tag = "v#{@version}"
+      unless @tag == expected_tag
+        raise Error, "tag #{@tag.inspect} does not match #{expected_tag.inspect}"
+      end
+
+      spec = Gem::Specification.load(File.join(@root, "mistri.gemspec"))
+      raise Error, "mistri.gemspec could not be loaded" unless spec
+      unless spec.name == "mistri"
+        raise Error, "gemspec name is #{spec.name.inspect}, expected \"mistri\""
+      end
+      return if spec.version.to_s == @version
+
+      raise Error, "gemspec version is #{spec.version}, expected #{@version}"
+    end
+
+    def changelog_notes!
+      changelog = File.read(File.join(@root, "CHANGELOG.md"))
+      heading = /^## \[#{Regexp.escape(@version)}\] - (\d{4}-\d{2}-\d{2})$/
+      matches = changelog.to_enum(:scan, heading).map { Regexp.last_match.dup }
+      unless matches.one?
+        raise Error, "CHANGELOG.md must contain exactly one release heading for #{@version}"
+      end
+
+      Date.iso8601(matches.first[1])
+      next_heading = changelog.index(/^## \[/, matches.first.end(0)) || changelog.length
+      notes = changelog[matches.first.end(0)...next_heading].strip
+      meaningful = notes.gsub(/<!--.*?-->/m, "").strip
+      raise Error, "CHANGELOG.md release notes for #{@version} are empty" if meaningful.empty?
+
+      notes
+    rescue Date::Error
+      raise Error, "CHANGELOG.md release date for #{@version} is invalid"
+    end
+
+    def verify_commit!
+      dirty = git!("status", "--porcelain", "--untracked-files=all")
+      raise Error, "release checkout is dirty:\n#{dirty}" unless dirty.empty?
+
+      tag_commit = git!("rev-parse", "--verify", "#{@tag}^{commit}")
+      head_commit = git!("rev-parse", "--verify", "HEAD^{commit}")
+      main_commit = git!("rev-parse", "--verify", "#{@main_ref}^{commit}")
+
+      unless tag_commit == head_commit
+        raise Error, "tag #{@tag} points to #{tag_commit}, but the checkout is #{head_commit}"
+      end
+
+      _output, status = Open3.capture2e(
+        "git", "merge-base", "--is-ancestor", tag_commit, main_commit, chdir: @root
+      )
+      return if status.success?
+
+      raise Error, "tag #{@tag} is not reachable from #{@main_ref}"
+    end
+
+    def git!(*arguments)
+      output, status = Open3.capture2e("git", *arguments, chdir: @root)
+      raise Error, "git #{arguments.join(" ")} failed: #{output.strip}" unless status.success?
+
+      output.strip
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  verifier = Mistri::ReleaseVerifier.new(
+    root: File.expand_path("..", __dir__),
+    tag: ENV.fetch("GITHUB_REF_NAME", ""),
+    main_ref: ENV.fetch("RELEASE_MAIN_REF", "origin/main"),
+    event_name: ENV.fetch("GITHUB_EVENT_NAME", ""),
+    ref_type: ENV.fetch("GITHUB_REF_TYPE", "")
+  )
+
+  begin
+    verifier.verify!
+    tag = ENV.fetch("GITHUB_REF_NAME")
+    main_ref = ENV.fetch("RELEASE_MAIN_REF", "origin/main")
+    warn "Verified #{tag} from #{main_ref}"
+  rescue Mistri::ReleaseVerifier::Error, Errno::ENOENT => e
+    warn "Release verification failed: #{e.message}"
+    exit 1
+  end
+end

--- a/test/test_package.rb
+++ b/test/test_package.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "bundler"
+require "open3"
+require "pathname"
+require "rbconfig"
+require "rubygems/package"
+require "tmpdir"
+require_relative "test_helper"
+
+# The package smoke test exercises the artifact a user installs, outside Bundler and the checkout.
+class TestPackage < Minitest::Test
+  ROOT = File.expand_path("..", __dir__)
+  SHIPPED_DOCUMENTS = %w[CHANGELOG.md LICENSE NOTICE README.md].freeze
+
+  def test_strict_package_installs_and_loads_in_isolation
+    Dir.mktmpdir("mistri-package") do |temporary|
+      gem_path = File.join(temporary, "mistri-#{Mistri::VERSION}.gem")
+      clean_env = isolated_environment(temporary)
+
+      run!(clean_env, RbConfig.ruby, "-S", "gem", "build", "mistri.gemspec", "--strict",
+           "--output", gem_path, chdir: ROOT)
+      verify_specification(gem_path)
+
+      outside = File.join(temporary, "outside")
+      FileUtils.mkdir_p(outside)
+      run!(clean_env, RbConfig.ruby, "-S", "gem", "install", gem_path, "--local",
+           "--no-document", chdir: outside)
+      run!(clean_env, RbConfig.ruby, "-e", installed_smoke, chdir: outside)
+    end
+  end
+
+  private
+
+  def verify_specification(gem_path)
+    spec = Gem::Package.new(gem_path).spec
+
+    assert_equal "mistri", spec.name
+    assert_equal Mistri::VERSION, spec.version.to_s
+    assert_empty spec.runtime_dependencies
+    assert_equal ["lib"], spec.require_paths
+    assert_empty spec.executables
+    assert_equal "https://rubygems.org", spec.metadata["allowed_push_host"]
+    assert_equal "true", spec.metadata["rubygems_mfa_required"]
+    assert_equal expected_files, spec.files.sort
+  end
+
+  def expected_files
+    libraries = Dir.glob(File.join(ROOT, "lib", "**", "*"))
+                   .select { |path| File.file?(path) }
+                   .map { |path| Pathname(path).relative_path_from(Pathname(ROOT)).to_s }
+    (libraries + SHIPPED_DOCUMENTS).sort
+  end
+
+  def isolated_environment(temporary)
+    gem_home = File.join(temporary, "gems")
+    ENV.each_key.grep(/\ABUNDLE_/).to_h { |key| [key, nil] }.merge(
+      "GEM_HOME" => gem_home,
+      "GEM_PATH" => gem_home,
+      "GEMRC" => File::NULL,
+      "HOME" => File.join(temporary, "home"),
+      "RUBYGEMS_GEMDEPS" => nil,
+      "RUBYLIB" => nil,
+      "RUBYOPT" => nil
+    )
+  end
+
+  def installed_smoke
+    <<~'RUBY'
+      require "mistri"
+      require "mistri/locks/rails_cache"
+      require "mistri/stores/active_record"
+      require "mistri/workspace/active_record"
+
+      spec = Gem.loaded_specs.fetch("mistri")
+      loaded = $LOADED_FEATURES.find { |path| path.end_with?("/mistri.rb") }
+      abort "mistri loaded outside its installed gem" unless loaded &&
+        File.realpath(loaded).start_with?("#{File.realpath(spec.full_gem_path)}/")
+      abort "wrong installed version" unless Mistri::VERSION == spec.version.to_s
+    RUBY
+  end
+
+  def run!(environment, *command, chdir:)
+    output, status = Bundler.with_unbundled_env do
+      Open3.capture2e(environment, *command, chdir: chdir)
+    end
+
+    assert_predicate status, :success?, "#{command.join(" ")} failed:\n#{output}"
+  end
+end

--- a/test/test_release_verifier.rb
+++ b/test/test_release_verifier.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "tmpdir"
+require_relative "test_helper"
+require_relative "../script/verify_release"
+
+class TestReleaseVerifier < Minitest::Test
+  VERSION = "1.2.3"
+  TAG = "v#{VERSION}".freeze
+
+  def setup
+    @root = Dir.mktmpdir("mistri-release")
+    write_fixture
+    git!("init", "--quiet")
+    git!("config", "user.email", "test@example.com")
+    git!("config", "user.name", "Mistri Test")
+    git!("add", ".")
+    git!("commit", "--quiet", "--message", "Prepare release")
+    git!("branch", "--move", "main")
+    git!("tag", TAG)
+    git!("update-ref", "refs/remotes/origin/main", "HEAD")
+  end
+
+  def teardown
+    FileUtils.remove_entry(@root)
+  end
+
+  def test_accepts_the_exact_tagged_release_on_main
+    notes = verifier.verify!
+
+    assert_equal "- Ship the release.", notes
+  end
+
+  def test_rejects_a_manual_or_non_tag_trigger
+    error = assert_raises(Mistri::ReleaseVerifier::Error) do
+      verifier(event_name: "workflow_dispatch", ref_type: "branch").verify!
+    end
+
+    assert_match(/requires a tag push/, error.message)
+  end
+
+  def test_rejects_a_tag_or_gemspec_version_mismatch
+    error = assert_raises(Mistri::ReleaseVerifier::Error) do
+      verifier(tag: "v1.2.4").verify!
+    end
+    assert_match(/does not match/, error.message)
+
+    File.write(File.join(@root, "mistri.gemspec"), gemspec("1.2.4"))
+    error = assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
+    assert_match(/gemspec version/, error.message)
+  end
+
+  def test_rejects_missing_empty_or_duplicate_release_notes
+    changelog = File.join(@root, "CHANGELOG.md")
+    File.write(changelog, "# Changelog\n\n## [Unreleased]\n")
+    assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
+
+    File.write(changelog, "# Changelog\n\n## [#{VERSION}] - 2026-07-10\n\n<!-- later -->\n")
+    error = assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
+    assert_match(/notes.*empty/, error.message)
+
+    File.write(changelog, <<~CHANGELOG)
+      # Changelog
+
+      ## [#{VERSION}] - 2026-07-10
+
+      - First copy.
+
+      ## [#{VERSION}] - 2026-07-09
+
+      - Second copy.
+    CHANGELOG
+    error = assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
+    assert_match(/exactly one/, error.message)
+  end
+
+  def test_rejects_a_checkout_other_than_the_tag
+    File.write(File.join(@root, "README.md"), "later\n")
+    git!("add", "README.md")
+    git!("commit", "--quiet", "--message", "Move past release")
+    git!("update-ref", "refs/remotes/origin/main", "HEAD")
+
+    error = assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
+
+    assert_match(/checkout/, error.message)
+  end
+
+  def test_rejects_a_dirty_checkout
+    File.write(File.join(@root, "README.md"), "dirty\n")
+
+    error = assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
+
+    assert_match(/checkout is dirty/, error.message)
+  end
+
+  def test_rejects_a_tag_that_is_not_on_main
+    main_commit = git!("rev-parse", "HEAD")
+    git!("switch", "--quiet", "--orphan", "release-side")
+    write_fixture
+    git!("add", ".")
+    git!("commit", "--quiet", "--message", "Side release")
+    git!("tag", "--force", TAG)
+    git!("update-ref", "refs/remotes/origin/main", main_commit)
+
+    error = assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
+
+    assert_match(/not reachable/, error.message)
+  end
+
+  private
+
+  def verifier(tag: TAG, event_name: "push", ref_type: "tag")
+    Mistri::ReleaseVerifier.new(
+      root: @root,
+      tag: tag,
+      main_ref: "origin/main",
+      event_name: event_name,
+      ref_type: ref_type,
+      version: VERSION
+    )
+  end
+
+  def write_fixture
+    FileUtils.mkdir_p(File.join(@root, "lib"))
+    File.write(File.join(@root, "README.md"), "fixture\n")
+    File.write(File.join(@root, "mistri.gemspec"), gemspec(VERSION))
+    File.write(File.join(@root, "CHANGELOG.md"), <<~CHANGELOG)
+      # Changelog
+
+      ## [Unreleased]
+
+      ## [#{VERSION}] - 2026-07-10
+
+      - Ship the release.
+    CHANGELOG
+  end
+
+  def gemspec(version)
+    <<~RUBY
+      Gem::Specification.new do |spec|
+        spec.name = "mistri"
+        spec.version = "#{version}"
+        spec.authors = ["Test"]
+        spec.summary = "Test gem"
+        spec.files = []
+      end
+    RUBY
+  end
+
+  def git!(*arguments)
+    clean_env = ENV.each_key.grep(/\AGIT_CONFIG_/).to_h { |key| [key, nil] }.merge(
+      "GIT_CONFIG_GLOBAL" => File::NULL,
+      "GIT_CONFIG_NOSYSTEM" => "1",
+      "HOME" => @root,
+      "XDG_CONFIG_HOME" => @root
+    )
+    output, status = Open3.capture2e(
+      clean_env,
+      "git", "-c", "commit.gpgSign=false", "-c", "tag.gpgSign=false", *arguments,
+      chdir: @root
+    )
+    raise "git #{arguments.join(" ")} failed: #{output}" unless status.success?
+
+    output.strip
+  end
+end

--- a/test/test_release_verifier.rb
+++ b/test/test_release_verifier.rb
@@ -2,6 +2,7 @@
 
 require "fileutils"
 require "open3"
+require "rbconfig"
 require "tmpdir"
 require_relative "test_helper"
 require_relative "../script/verify_release"
@@ -9,6 +10,7 @@ require_relative "../script/verify_release"
 class TestReleaseVerifier < Minitest::Test
   VERSION = "1.2.3"
   TAG = "v#{VERSION}".freeze
+  SCRIPT = File.expand_path("../script/verify_release.rb", __dir__).freeze
 
   def setup
     @root = Dir.mktmpdir("mistri-release")
@@ -33,6 +35,27 @@ class TestReleaseVerifier < Minitest::Test
     assert_equal "- Ship the release.", notes
   end
 
+  def test_script_exits_successfully_for_a_tagged_release
+    stdout, stderr, status = run_script
+
+    assert_predicate status, :success?
+    assert_empty stdout
+    assert_equal "Verified #{TAG} from origin/main\n", stderr
+  end
+
+  def test_script_fails_closed_for_a_hostile_trigger
+    stdout, stderr, status = run_script(
+      "GITHUB_EVENT_NAME" => "workflow_dispatch",
+      "GITHUB_REF_NAME" => "main",
+      "GITHUB_REF_TYPE" => "branch"
+    )
+
+    refute_predicate status, :success?
+    assert_equal 1, status.exitstatus
+    assert_empty stdout
+    assert_match(/Release verification failed: release requires a tag push/, stderr)
+  end
+
   def test_rejects_a_manual_or_non_tag_trigger
     error = assert_raises(Mistri::ReleaseVerifier::Error) do
       verifier(event_name: "workflow_dispatch", ref_type: "branch").verify!
@@ -50,6 +73,25 @@ class TestReleaseVerifier < Minitest::Test
     File.write(File.join(@root, "mistri.gemspec"), gemspec("1.2.4"))
     error = assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
     assert_match(/gemspec version/, error.message)
+  end
+
+  def test_rejects_an_unstable_version
+    error = assert_raises(Mistri::ReleaseVerifier::Error) do
+      verifier(tag: "v01.2.3", version: "01.2.3").verify!
+    end
+
+    assert_match(/not a stable version/, error.message)
+  end
+
+  def test_rejects_an_unloadable_or_misnamed_gemspec
+    path = File.join(@root, "mistri.gemspec")
+    FileUtils.rm(path)
+    error = assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
+    assert_match(/could not be loaded/, error.message)
+
+    File.write(path, gemspec(VERSION, name: "another-gem"))
+    error = assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
+    assert_match(/gemspec name/, error.message)
   end
 
   def test_rejects_missing_empty_or_duplicate_release_notes
@@ -74,6 +116,16 @@ class TestReleaseVerifier < Minitest::Test
     CHANGELOG
     error = assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
     assert_match(/exactly one/, error.message)
+
+    File.write(changelog, <<~CHANGELOG)
+      # Changelog
+
+      ## [#{VERSION}] - 2026-02-30
+
+      - An impossible date.
+    CHANGELOG
+    error = assert_raises(Mistri::ReleaseVerifier::Error) { verifier.verify! }
+    assert_match(/release date.*invalid/, error.message)
   end
 
   def test_rejects_a_checkout_other_than_the_tag
@@ -109,23 +161,41 @@ class TestReleaseVerifier < Minitest::Test
     assert_match(/not reachable/, error.message)
   end
 
+  def test_reports_a_git_resolution_failure
+    error = assert_raises(Mistri::ReleaseVerifier::Error) do
+      verifier(main_ref: "origin/missing").verify!
+    end
+
+    assert_match(/git rev-parse.*failed/, error.message)
+  end
+
   private
 
-  def verifier(tag: TAG, event_name: "push", ref_type: "tag")
+  def verifier(tag: TAG, main_ref: "origin/main", event_name: "push", ref_type: "tag",
+               version: VERSION)
     Mistri::ReleaseVerifier.new(
       root: @root,
       tag: tag,
-      main_ref: "origin/main",
+      main_ref: main_ref,
       event_name: event_name,
       ref_type: ref_type,
-      version: VERSION
+      version: version
     )
   end
 
   def write_fixture
-    FileUtils.mkdir_p(File.join(@root, "lib"))
+    FileUtils.mkdir_p(File.join(@root, "lib", "mistri"))
+    FileUtils.mkdir_p(File.join(@root, "script"))
     File.write(File.join(@root, "README.md"), "fixture\n")
     File.write(File.join(@root, "mistri.gemspec"), gemspec(VERSION))
+    File.write(File.join(@root, "lib", "mistri", "version.rb"), <<~RUBY)
+      # frozen_string_literal: true
+
+      module Mistri
+        VERSION = "#{VERSION}"
+      end
+    RUBY
+    FileUtils.cp(SCRIPT, File.join(@root, "script", "verify_release.rb"))
     File.write(File.join(@root, "CHANGELOG.md"), <<~CHANGELOG)
       # Changelog
 
@@ -137,16 +207,34 @@ class TestReleaseVerifier < Minitest::Test
     CHANGELOG
   end
 
-  def gemspec(version)
+  def gemspec(version, name: "mistri")
     <<~RUBY
       Gem::Specification.new do |spec|
-        spec.name = "mistri"
+        spec.name = "#{name}"
         spec.version = "#{version}"
         spec.authors = ["Test"]
         spec.summary = "Test gem"
         spec.files = []
       end
     RUBY
+  end
+
+  def run_script(overrides = {})
+    environment = {
+      "GITHUB_EVENT_NAME" => "push",
+      "GITHUB_REF_NAME" => TAG,
+      "GITHUB_REF_TYPE" => "tag",
+      "GIT_CONFIG_GLOBAL" => File::NULL,
+      "GIT_CONFIG_NOSYSTEM" => "1",
+      "HOME" => @root,
+      "PATH" => ENV.fetch("PATH"),
+      "RELEASE_MAIN_REF" => "origin/main",
+      "XDG_CONFIG_HOME" => @root
+    }.merge(overrides)
+    Open3.capture3(
+      environment, RbConfig.ruby, File.join(@root, "script", "verify_release.rb"),
+      chdir: @root, unsetenv_others: true
+    )
   end
 
   def git!(*arguments)


### PR DESCRIPTION
## What changed

- Removes manual publishing and makes a tag push the only release trigger.
- Verifies the event, stable version, gemspec, changelog, clean checkout, exact tag commit, and main ancestry before any publishing authority is available, then repeats that check after the release environment gate.
- Pins every release-capable action to an audited commit, disables checkout credentials, scopes OIDC to the publish job, and removes the action's dynamic post-push wait.
- Permanently tests the shipped artifact: strict build, exact manifest, zero runtime dependencies, generator templates, isolated install outside Bundler, and require from the installed gem on every supported CI Ruby.
- Exercises the release script itself as a subprocess, including its successful and fail-closed exit contracts.
- Pins Bundler's push destination to RubyGems.org and makes an existing GitHub release converge on the tagged changelog.

## Why

The old workflow's manual path skipped its tag assertion while still invoking the publisher. This was not theoretical: [run 28736054258](https://github.com/mcheemaa/mistri/actions/runs/28736054258) published 0.2.0 from main commit `bd13ef7`, while `v0.2.0` pointed to `2aa784a`. The packaged files happened to match, but the artifact was not tag-derived.

The design follows [GitHub's tag-trigger semantics](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushbranchestagsbranches-ignoretags-ignore), [RubyGems trusted publishing](https://guides.rubygems.org/trusted-publishing/), and the [official release-gem action](https://github.com/rubygems/release-gem).

## Validation

- Ruby 3.2 and 3.4: 618 tests, 2,401 assertions, zero failures
- RuboCop: 171 files, zero offenses
- Coverage: 97.53% line, 84.89% branch
- Release verifier: 100% measured line and branch coverage outside the subprocess-only CLI shim
- Package smoke passed on all three stable Rubies
- Release verifier passed with hostile global Git signing configuration
- Package smoke passed with hostile Bundler and RubyGems configuration
- Two adversarial review rounds found no remaining code blocker

No tag was created and nothing was published.

Repository administration now enforces two active `v*` tag rulesets: only repository administrators may create release tags, while no actor can update, delete, or force-move them without changing the ruleset. The `release` environment accepts only `v*` tags, requires explicit owner approval, and does not permit administrator bypass.