### PR TITLE
Define freeform object schema semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- A blockless nested object in the tool-schema DSL now declares a freeform JSON
+  object instead of leaking `LocalJumpError` during application boot. A bare
+  top-level `Schema.build` raises `ConfigurationError` with a useful message.
+  Constrained-output preparation now refuses this freeform shape, and directly
+  encountered explicitly open objects, with a schema path instead of silently
+  closing them and changing their meaning. Existing block-built and raw tool
+  schemas keep their wire shape. Tool-schema work remains definition-time;
+  constrained-output request building adds one openness check to its existing
+  property/item traversal, with no streaming or token-path work.
 - Provider and MCP JSON bodies, individual SSE lines, and stdio JSON records
   now default to an 8 MiB ceiling, configurable with `max_record_bytes:`.
   Successful bodies are counted incrementally, declared oversized bodies fail

--- a/README.md
+++ b/README.md
@@ -91,6 +91,27 @@ weather = Mistri::Tool.define("get_weather", "Current weather for a city.", sche
 end
 ```
 
+A nested object without a block is deliberately freeform. This is useful for
+provider-neutral configuration payloads whose keys Mistri should not prescribe:
+
+```ruby
+chart = Mistri::Tool.define("render_chart", "Renders a chart.", schema: lambda {
+  object :config, "Chart-library configuration", required: true
+}) do |args|
+  Charts.render(args.fetch("config"))
+end
+```
+
+This gives providers an open JSON object schema, where `{}` remains valid. Tool
+arguments remain untrusted input: use the description for generation guidance
+and validate domain semantics in the handler. An empty object block currently
+emits the same open schema.
+
+This freeform DSL shape cannot be represented by strict constrained output
+without changing its meaning, so `Schema.strict` raises instead of silently
+narrowing it to an object that only accepts `{}`. Use declared properties, or an
+explicitly closed raw schema, for constrained task output.
+
 A tool can speak on two channels: `content` for the model, `ui` for your
 interface. The `ui` payload rides the `:tool_result` event and persists with
 the session, but never reaches a provider:

--- a/lib/mistri/schema.rb
+++ b/lib/mistri/schema.rb
@@ -16,9 +16,11 @@ module Mistri
   class Schema
     # instance_exec, not instance_eval: it binds self to the builder without
     # passing an argument, so a zero-arity lambda works as naturally as a proc.
-    def self.build(&)
+    def self.build(&block)
+      raise ConfigurationError, "schema needs a block" unless block
+
       builder = new
-      builder.instance_exec(&)
+      builder.instance_exec(&block)
       builder.to_h
     end
 
@@ -46,8 +48,8 @@ module Mistri
       nil
     end
 
-    def object(name, description = nil, required: false, &)
-      prop = self.class.build(&)
+    def object(name, description = nil, required: false, &block)
+      prop = block ? self.class.build(&block) : self.class.new.to_h
       prop[:description] = description if description
       @properties[name.to_s] = prop
       @required << name.to_s if required
@@ -82,27 +84,35 @@ module Mistri
         errors
       end
 
-      # Prepares a schema for constrained decoding: every object gains
-      # additionalProperties: false (Anthropic and OpenAI both demand it),
-      # and all_required marks every property required (OpenAI strict mode's
-      # rule). String keys throughout, ready for the wire.
+      # Prepares a schema for constrained decoding without turning a freeform
+      # object into one that accepts only {}. Direct objects with declared
+      # properties close for provider strict modes; explicit openness fails.
       def strict(schema, all_required: false)
+        strict_at(schema, all_required: all_required, path: "$")
+      end
+
+      def strict_at(schema, all_required:, path:)
         spec = schema.transform_keys(&:to_s)
         out = spec.dup
         if spec["type"] == "object" || spec.key?("properties")
-          props = (spec["properties"] || {}).to_h do |key, member|
-            [key.to_s, strict(member, all_required: all_required)]
+          raw_props = spec["properties"] || {}
+          reject_open_object!(spec, raw_props, path)
+          props = raw_props.to_h do |key, member|
+            member_path = "#{path}.#{key}"
+            [key.to_s, strict_at(member, all_required: all_required, path: member_path)]
           end
           out["properties"] = props
           out["additionalProperties"] = false
           out["required"] = all_required ? props.keys : Array(spec["required"]).map(&:to_s)
         end
         if spec["items"].is_a?(Hash)
-          out["items"] =
-            strict(spec["items"], all_required: all_required)
+          out["items"] = strict_at(
+            spec["items"], all_required: all_required, path: "#{path}[]"
+          )
         end
         out
       end
+      private :strict_at
 
       TYPES = {
         "object" => ->(v) { v.is_a?(Hash) }, "array" => ->(v) { v.is_a?(Array) },
@@ -112,6 +122,17 @@ module Mistri
       }.freeze
 
       private
+
+      def reject_open_object!(spec, properties, path)
+        if spec.key?("additionalProperties") && spec["additionalProperties"] != false
+          raise ConfigurationError,
+                "#{path} is open and cannot be represented by a strict schema"
+        end
+        return unless properties.empty? && spec["additionalProperties"] != false
+
+        raise ConfigurationError,
+              "#{path} is freeform and cannot be represented by a strict schema"
+      end
 
       def type_violation(value, spec, path)
         names = Array(spec["type"]).map(&:to_s)

--- a/test/test_anthropic_live.rb
+++ b/test/test_anthropic_live.rb
@@ -50,4 +50,29 @@ class TestAnthropicLive < Minitest::Test
   ensure
     provider&.close
   end
+
+  def test_a_nested_freeform_object_reaches_a_tool_call
+    provider = Mistri::Providers::Anthropic.new(
+      api_key: ENV.fetch("ANTHROPIC_API_KEY"), model: "claude-haiku-4-5-20251001"
+    )
+    tool = Mistri::Tool.define("render_chart", "Renders the requested chart.", schema: lambda {
+      object :config, "Chart config; include a series array.", required: true
+    }) { |_args| "rendered" }
+
+    message = provider.stream(
+      messages: [Mistri::Message.user(
+        'Call render_chart with config {"series":[{"type":"bar","data":[1,2]}]}.'
+      )],
+      tools: [tool.spec], tool_choice: { type: "tool", name: "render_chart" }
+    ) { |_event| nil }
+
+    assert_equal :tool_use, message.stop_reason
+    config = message.tool_calls.first.arguments["config"]
+
+    assert_kind_of Hash, config
+    assert_equal "bar", config.dig("series", 0, "type")
+    assert_equal [1, 2], config.dig("series", 0, "data")
+  ensure
+    provider&.close
+  end
 end

--- a/test/test_anthropic_serializer.rb
+++ b/test/test_anthropic_serializer.rb
@@ -5,6 +5,16 @@ require_relative "test_helper"
 class TestAnthropicSerializer < Minitest::Test
   SERIALIZER = Mistri::Providers::Anthropic::Serializer
 
+  def test_a_freeform_object_schema_passes_through
+    tool = Mistri::Tool.define("render", "d", schema: lambda {
+      object :config, "Open configuration", required: true
+    }) { "ok" }
+
+    wire = SERIALIZER.tools([tool.spec])
+
+    assert_equal tool.input_schema, wire.first[:input_schema]
+  end
+
   def test_parallel_tool_results_merge_into_one_user_turn
     call_a = Mistri::ToolCall.new(id: "a", name: "x", arguments: {})
     call_b = Mistri::ToolCall.new(id: "b", name: "y", arguments: {})

--- a/test/test_gemini_live.rb
+++ b/test/test_gemini_live.rb
@@ -54,4 +54,27 @@ class TestGeminiLive < Minitest::Test
   ensure
     provider&.close
   end
+
+  def test_a_nested_freeform_object_reaches_a_tool_call
+    provider = Mistri::Providers::Gemini.new(api_key: ENV.fetch("GEMINI_API_KEY"))
+    tool = Mistri::Tool.define("render_chart", "Renders the requested chart.", schema: lambda {
+      object :config, "Chart config; include a series array.", required: true
+    }) { |_args| "rendered" }
+
+    message = provider.stream(
+      messages: [Mistri::Message.user(
+        'Call render_chart with config {"series":[{"type":"bar","data":[1,2]}]}. No prose.'
+      )],
+      tools: [tool.spec]
+    ) { |_event| nil }
+
+    assert_equal :tool_use, message.stop_reason
+    config = message.tool_calls.first.arguments["config"]
+
+    assert_kind_of Hash, config
+    assert_equal "bar", config.dig("series", 0, "type")
+    assert_equal [1, 2], config.dig("series", 0, "data")
+  ensure
+    provider&.close
+  end
 end

--- a/test/test_gemini_serializer.rb
+++ b/test/test_gemini_serializer.rb
@@ -5,6 +5,16 @@ require_relative "test_helper"
 class TestGeminiSerializer < Minitest::Test
   SERIALIZER = Mistri::Providers::Gemini::Serializer
 
+  def test_a_freeform_object_schema_passes_through
+    tool = Mistri::Tool.define("render", "d", schema: lambda {
+      object :config, "Open configuration", required: true
+    }) { "ok" }
+
+    wire = SERIALIZER.tools([tool.spec])
+
+    assert_equal tool.input_schema, wire.first[:functionDeclarations].first[:parameters]
+  end
+
   def test_a_gemini_turn_replays_with_signatures_and_merged_tool_results
     call = Mistri::ToolCall.new(id: "c1", name: "search", arguments: { "q" => "ruby" },
                                 signature: "tsig")

--- a/test/test_openai_live.rb
+++ b/test/test_openai_live.rb
@@ -60,6 +60,28 @@ class TestOpenAILive < Minitest::Test
     provider&.close
   end
 
+  def test_a_nested_freeform_object_schema_is_accepted
+    provider = Mistri::Providers::OpenAI.new(api_key: ENV.fetch("OPENAI_API_KEY"),
+                                             model: "gpt-5.5")
+    tool = Mistri::Tool.define("render_chart", "Renders the requested chart.", schema: lambda {
+      object :config, "Chart config; include a series array.", required: true
+    }) { |_args| "rendered" }
+
+    message = provider.stream(
+      messages: [Mistri::Message.user(
+        'Call render_chart with config {"series":[{"type":"bar","data":[1,2]}]}. No prose.'
+      )],
+      tools: [tool.spec]
+    ) { |_event| nil }
+
+    assert_equal :tool_use, message.stop_reason
+    config = message.tool_calls.first.arguments["config"]
+
+    assert_kind_of Hash, config
+  ensure
+    provider&.close
+  end
+
   def test_gpt_5_6_cache_writes_are_accounted
     provider = Mistri::Providers::OpenAI.new(api_key: ENV.fetch("OPENAI_API_KEY"),
                                              model: "gpt-5.6-luna",

--- a/test/test_openai_serializer.rb
+++ b/test/test_openai_serializer.rb
@@ -6,6 +6,16 @@ require_relative "test_helper"
 class TestOpenAISerializer < Minitest::Test
   SERIALIZER = Mistri::Providers::OpenAI::Serializer
 
+  def test_a_freeform_object_schema_passes_through
+    tool = Mistri::Tool.define("render", "d", schema: lambda {
+      object :config, "Open configuration", required: true
+    }) { "ok" }
+
+    wire = SERIALIZER.tools([tool.spec])
+
+    assert_equal tool.input_schema, wire.first[:parameters]
+  end
+
   def test_an_assembled_turn_replays_with_its_pairing_intact
     reasoning_item = { "type" => "reasoning", "id" => "rs_1", "summary" => [],
                        "encrypted_content" => "opaque" }

--- a/test/test_schema_validate.rb
+++ b/test/test_schema_validate.rb
@@ -81,4 +81,36 @@ class TestSchemaValidate < Minitest::Test
     assert_equal %w[name tiers count note], strict["required"]
     assert_equal %w[price label], strict.dig("properties", "tiers", "items", "required")
   end
+
+  def test_strict_rejects_a_freeform_object_instead_of_closing_it
+    schema = {
+      type: "object",
+      properties: { "config" => { type: "object", properties: {} } }
+    }
+
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::Schema.strict(schema) }
+
+    assert_equal "$.config is freeform and cannot be represented by a strict schema", error.message
+  end
+
+  def test_strict_rejects_explicit_open_objects
+    schema = {
+      type: "object",
+      properties: { "metadata" => { type: "object", properties: { "name" => {
+        type: "string"
+      } }, additionalProperties: true } }
+    }
+
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::Schema.strict(schema) }
+
+    assert_equal "$.metadata is open and cannot be represented by a strict schema", error.message
+  end
+
+  def test_strict_preserves_an_explicitly_closed_empty_object
+    schema = { type: "object", properties: {}, additionalProperties: false }
+
+    assert_equal({ "type" => "object", "properties" => {},
+                   "additionalProperties" => false, "required" => [] },
+                 Mistri::Schema.strict(schema))
+  end
 end

--- a/test/test_tool.rb
+++ b/test/test_tool.rb
@@ -27,6 +27,59 @@ class TestTool < Minitest::Test
     assert_equal ["city"], schema[:required]
   end
 
+  def test_a_blockless_nested_object_is_freeform
+    tool = Mistri::Tool.define("render_chart", "Renders a chart.", schema: lambda {
+      object :config, "Provider-neutral chart configuration", required: true
+      string :title, "Chart title"
+    }) { |args| args["config"] }
+
+    schema = tool.spec[:input_schema]
+    config = schema[:properties]["config"]
+
+    assert_equal({ type: "object", properties: {},
+                   description: "Provider-neutral chart configuration" }, config)
+    assert_equal ["config"], schema[:required]
+    assert_equal "string", schema.dig(:properties, "title", :type)
+    assert_empty Mistri::Schema.violations(
+      { "config" => { "series" => [{ "type" => "bar", "data" => [1, 2] }] } },
+      schema
+    )
+    assert_equal ["$.config must be object, got string"],
+                 Mistri::Schema.violations({ "config" => "bar" }, schema)
+  end
+
+  def test_a_nested_object_block_keeps_its_declared_shape
+    tool = Mistri::Tool.define("locate", "Locates a place.", schema: lambda {
+      object :location, "Place to locate", required: true do
+        string :city, "City name", required: true
+        string :country, "Country code"
+      end
+    }) { |args| args["location"] }
+
+    assert_equal(
+      {
+        type: "object",
+        properties: {
+          "city" => { type: "string", description: "City name" },
+          "country" => { type: "string", description: "Country code" }
+        },
+        required: ["city"],
+        description: "Place to locate"
+      },
+      tool.spec[:input_schema][:properties]["location"]
+    )
+  end
+
+  def test_schema_build_requires_a_root_block
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::Schema.build }
+
+    assert_equal "schema needs a block", error.message
+  end
+
+  def test_schema_build_accepts_an_explicit_empty_block
+    assert_equal({ type: "object", properties: {} }, Mistri::Schema.build { nil })
+  end
+
   def test_results_serialize_by_type
     string_tool = Mistri::Tool.define("s", "d") { "text" }
     hash_tool = Mistri::Tool.define("h", "d") { { ok: true } }


### PR DESCRIPTION
## Summary

- make a blockless nested `object` declaration emit the existing portable freeform object schema
- make a bare top-level `Schema.build` fail with a contextual `ConfigurationError`
- refuse to strictify empty freeform or explicitly open objects when doing so would change their meaning
- document the boundary and cover the DSL-to-wire path plus real Anthropic, OpenAI, and Gemini calls

## Why

Issue #32 exposed two separate contract problems. The schema DSL leaked Ruby's internal `LocalJumpError` for a valid freeform tool-input shape, and constrained-output preparation could silently convert that open object into one that accepted only `{}`.

Under JSON Schema, an object with empty `properties` and no `additionalProperties: false` is open. This change preserves that meaning for tool inputs and fails locally when strict constrained output cannot represent it without loss.

A completely blockless `Schema.build` still has no declaration or intent, so it raises clearly instead of silently producing a schema.

## Compatibility

Existing block-built schemas and raw tool schemas keep their provider wire shape. The new DSL form is additive.

`Schema.strict` now rejects directly encountered empty freeform and explicitly open objects that it previously narrowed. That intentional fail-loud behavior makes this minor-release material.

The DSL change runs at definition time. Strict output preparation adds one openness check to its existing property/item traversal. There is no streaming or token-path work.

Tool arguments remain untrusted until the separate execution-validation phase; this PR does not claim or add local tool-argument enforcement.

## Verification

- Ruby 3.2: 631 tests, 2,419 assertions
- Ruby 3.3: 631 tests, 2,419 assertions
- Ruby 3.4 with coverage: 97.83% line, 85.14% branch
- RuboCop: 171 files, no offenses
- live Anthropic Haiku 4.5: undeclared nested chart keys survived
- live OpenAI GPT-5.5: freeform schema accepted and produced an object call
- live Gemini 2.5 Flash: undeclared nested chart keys survived
- three independent adversarial review passes completed with no remaining findings

Closes #32