### PR TITLE
Add structured tool lifecycle outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   primitive checks and one immutable nil slot; partial Message construction
   adds one nil check and one immutable nil slot, with no parsing, buffering,
   I/O, or string work;
-  starts arrive on serialized worker-thread callbacks, while ordered results
-  still emit after the batch joins. `:tool_started` and handler-progress
+  tool batches add one sentinel write at commitment and one identity check per
+  result so a hard worker exit distinguishes started calls from untouched queue
+  entries; same-batch ordering adds one short-lived identity map and a linear
+  post-join pass, plus a second identity map only when `after_tool` is configured;
+  starts arrive on serialized worker-thread callbacks, while same-batch results
+  still emit in model-call order after the batch joins. `:tool_started` and handler-progress
   subscriber exceptions propagate and never become tool failures.
   Unknown, blocked, denied, queued, and pre-invocation interrupted calls add no
   start event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Tool execution now emits `:tool_started` when each resolved call commits to
+  invocation and carries a structured failure fact end to end. A handler may
+  return `ToolResult(error: true)`; unknown tools, policy blocks,
+  handler exceptions, timeouts, pre-invocation interruptions, failed result
+  hooks, healed dangling calls, and MCP `isError` results set it automatically.
+  The flag is sticky through `after_tool` rewrites, so changing error text
+  cannot relabel a failed operation as successful. `Event#tool_error` is always
+  true or false on `:tool_result`; new tool messages persist the same value, and legacy
+  messages without it remain unknown and replay with the historical unmarked
+  provider shape. Human approval denial remains a normal control outcome rather
+  than an execution error. Anthropic receives
+  `is_error: true`; Gemini receives the documented `error` function-response
+  key; OpenAI retains textual output because its function-call output has no
+  execution-error member. Error text is not classified by prefix, and an error
+  bit never authorizes a mechanical replay because a side effect may already
+  have happened; the model may still choose a new call, so hosts retain
+  idempotency and reconciliation policy. `ends_turn` remains the host's stronger
+  floor-transfer policy even when a result is errored; `handed_off?` does not
+  claim confirmed tool success. The new lifecycle signal adds one synchronous
+  sink event per committed call. Partial streaming Event construction adds two
+  primitive checks and one immutable nil slot; partial Message construction
+  adds one nil check and one immutable nil slot, with no parsing, buffering,
+  I/O, or string work;
+  starts arrive on serialized worker-thread callbacks, while ordered results
+  still emit after the batch joins. `:tool_started` and handler-progress
+  subscriber exceptions propagate and never become tool failures.
+  Unknown, blocked, denied, queued, and pre-invocation interrupted calls add no
+  start event.
 - A blockless nested object in the tool-schema DSL now declares a freeform JSON
   object instead of leaking `LocalJumpError` during application boot. A bare
   top-level `Schema.build` raises `ConfigurationError` with a useful message.

--- a/README.md
+++ b/README.md
@@ -112,16 +112,40 @@ without changing its meaning, so `Schema.strict` raises instead of silently
 narrowing it to an object that only accepts `{}`. Use declared properties, or an
 explicitly closed raw schema, for constrained task output.
 
-A tool can speak on two channels: `content` for the model, `ui` for your
-interface. The `ui` payload rides the `:tool_result` event and persists with
-the session, but never reaches a provider:
+A tool result carries model content, host-only UI, and a failure fact. The
+`ui` payload rides the `:tool_result` event and persists with the session, but
+never reaches a provider. Return `error: true` for an expected tool failure
+that the model should handle rather than treating as a successful answer:
 
 ```ruby
 Mistri::Tool.define("edit_page", "Applies a page edit.") do |args|
   page = apply(args)
   Mistri::ToolResult.new(content: "Saved.", ui: { "html" => page })
 end
+
+Mistri::Tool.define("lookup", "Looks up an account.") do |args|
+  account = Accounts.find_by(id: args["id"])
+  account || Mistri::ToolResult.new(content: "Account not found.", error: true)
+end
 ```
+
+Mistri also sets the flag for unknown tools, blocked calls, handler exceptions,
+timeouts, calls interrupted before invocation, crash-healed calls whose outcome
+is unknown, and failed `after_tool` hooks. `event.tool_error` and
+`event.message.tool_error?` expose it without inspecting result text. A new
+successful result records false; a reloaded legacy result without the field
+keeps `tool_error == nil`, because Mistri cannot infer its historical outcome.
+Human denial is an expected approval outcome and records false. Anthropic and
+Gemini receive their native failure representation; OpenAI receives the same
+explanatory output because its function-result shape has no error member.
+Legacy unknown results replay with the historical unmarked provider shape;
+Mistri never guesses their status from prose.
+
+The flag means the call did not produce a confirmed successful result. It does
+not mean retrying is safe: a handler can commit an external write before it
+raises or times out. Mistri never mechanically replays the same call because
+this flag is true, but the model may choose to issue another call. Hosts still
+own idempotency, approval, and reconciliation for side effects.
 
 Handlers and hooks can take the run's context as a second argument, and
 `context.app` carries whatever object you pass as `Mistri.agent(context:)`
@@ -140,8 +164,9 @@ end
 A tool can also be the last word of its turn. `ends_turn: true` makes the
 loop end the run once the tool executes, instead of prompting the model
 again: an `ask_user` tool hands the floor to a human structurally, no
-"remember to stop after asking" prompt required. The result says it
-happened (`result.handed_off?`), and the answer arrives as the next run's
+"remember to stop after asking" prompt required. `result.handed_off?` says the
+model's floor was handed away; the persisted tool result says separately
+whether execution confirmed success. The answer arrives as the next run's
 input:
 
 ```ruby
@@ -595,11 +620,25 @@ are loop-owned: `:done` and `:error` reach the subscriber only for the
 accepted attempt, so a recovered retry never flashes an error it then walks
 back.
 
+Tool execution emits `:tool_started` when each resolved call commits to
+execution, then `:tool_result` with an explicit `tool_error` boolean. Calls
+still queued behind `max_concurrency`, blocked by policy, waiting for approval,
+denied, unknown, or interrupted before invocation never claim to have started.
+Starts arrive from tool worker threads as execution begins; sinks must tolerate
+serialized callbacks from those threads. Results retain deterministic model-call
+order and emit after the parallel batch joins, as before. A subscriber exception
+from `:tool_started` or handler-emitted progress propagates to the run and never
+becomes a tool result.
+Event types are an extensible union; subscribers should handle the types they
+use and ignore the rest.
+
 ```ruby
 agent.run("Plan the itinerary.") do |event|
   case event.type
   when :text_delta then stream(event.delta)
   when :retry then banner("Retrying (#{event.attempt}/#{event.max_attempts}) in #{event.delay}s")
+  when :tool_started then tool_running(event.tool_call)
+  when :tool_result then tool_finished(event.tool_call, failed: event.tool_error)
   when :done, :error then clear_banner
   end
 end

--- a/README.md
+++ b/README.md
@@ -625,10 +625,10 @@ execution, then `:tool_result` with an explicit `tool_error` boolean. Calls
 still queued behind `max_concurrency`, blocked by policy, waiting for approval,
 denied, unknown, or interrupted before invocation never claim to have started.
 Starts arrive from tool worker threads as execution begins; sinks must tolerate
-serialized callbacks from those threads. Results retain deterministic model-call
-order and emit after the parallel batch joins, as before. A subscriber exception
-from `:tool_started` or handler-emitted progress propagates to the run and never
-becomes a tool result.
+serialized callbacks from those threads. Results settled in the same batch
+retain deterministic model-call order and emit after the parallel batch joins,
+as before. A subscriber exception from `:tool_started` or handler-emitted
+progress propagates to the run and never becomes a tool result.
 Event types are an extensible union; subscribers should handle the types they
 use and ignore the rest.
 

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -311,11 +311,13 @@ module Mistri
     def run_tools(assistant, signal, &emit)
       calls = assistant.tool_calls
       unless assistant.stop_reason == StopReason::TOOL_USE && !signal&.aborted?
-        calls.each { |call| answer(call, ToolExecutor::INTERRUPTED, &emit) }
+        calls.each do |call|
+          answer(call, ToolResult.new(content: ToolExecutor::INTERRUPTED, error: true), &emit)
+        end
         return [[], false]
       end
 
-      parked, free = screen(calls, signal, &emit).partition { |call| gated?(call) }
+      parked, free = partition_approval(screen(calls, signal, &emit), &emit)
       executed = execute(free, signal, &emit)
       parked.each do |call|
         @session.append("approval_request", "call" => call.to_h)
@@ -369,15 +371,26 @@ module Mistri
         end
         next false unless reason.is_a?(String)
 
-        answer(call, "Blocked: #{reason}", &emit)
+        answer(call, ToolResult.new(content: "Blocked: #{reason}", error: true), &emit)
         true
       end
     end
 
     def rewrite(call, result, context)
-      @after_tool.call(call, result, context) || result
+      rewritten = @after_tool.call(call, result, context) || result
+      return rewritten unless result.is_a?(ToolResult) && result.error?
+
+      if rewritten.is_a?(ToolResult)
+        rewritten.with(error: true)
+      else
+        ToolResult.new(content: rewritten, error: true)
+      end
     rescue StandardError => e
-      "Error in after_tool hook: #{e.class}: #{e.message}"
+      ToolResult.new(
+        content: "Error in after_tool hook: #{e.class}: #{e.message}. The tool already returned; " \
+                 "verify its effects before retrying.",
+        error: true
+      )
     end
 
     def hook_context(signal, emit)
@@ -387,17 +400,32 @@ module Mistri
     # The tool message carries both channels; the :tool_result event exposes
     # it whole so hosts read event.message.ui for their side of the result.
     def answer(call, result, duration: nil, &emit)
-      content, ui = result.is_a?(ToolResult) ? [result.content, result.ui] : [result, nil]
+      content, ui, tool_error = if result.is_a?(ToolResult)
+                                  [result.content, result.ui, result.error?]
+                                else
+                                  [result, nil, false]
+                                end
       message = @session.append_message(Message.tool(content: content, tool_call_id: call.id,
-                                                     tool_name: call.name, ui: ui))
+                                                     tool_name: call.name, ui: ui,
+                                                     tool_error: tool_error))
       text = content.is_a?(String) ? content : "[content]"
       emit&.call(Event.new(type: :tool_result, tool_call: call, content: text,
-                           message: message, duration: duration))
+                           message: message, duration: duration, tool_error: tool_error))
     end
 
     def gated?(call)
       tool = @tools_by_name[call.name]
       tool ? tool.needs_approval?(call.arguments) : false
+    end
+
+    def partition_approval(calls, &emit)
+      calls.each_with_object([[], []]) do |call, (parked, free)|
+        (gated?(call) ? parked : free) << call
+      rescue StandardError => e
+        content = "Error evaluating approval policy for tool #{call.name.inspect}: " \
+                  "#{e.class}: #{e.message}. The tool did not run."
+        answer(call, ToolResult.new(content:, error: true), &emit)
+      end
     end
 
     def ends_turn?(call)

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -317,62 +317,62 @@ module Mistri
         return [[], false]
       end
 
-      parked, free = partition_approval(screen(calls, signal, &emit), &emit)
+      screened, blocked = screen(calls, signal, &emit)
+      parked, free, rejected = partition_approval(screened)
       executed = execute(free, signal, &emit)
+      answer_results(calls, [*blocked, *rejected, *executed], executed:, signal:, &emit)
       parked.each do |call|
         @session.append("approval_request", "call" => call.to_h)
         emit&.call(Event.new(type: :approval_needed, tool_call: call))
       end
-      [parked, executed.any? { |call| ends_turn?(call) }]
+      [parked, executed.any? { |call, _result, _seconds| ends_turn?(call) }]
     end
 
     # Returns the calls that actually executed (denied ones only answer).
-    def settle(open, signal, &emit)
+    def settle(open, signal, &)
       approved, denied = open.partition { |approval| approval[:decision]["approved"] }
-      cleared = screen(approved.map { |approval| approval[:call] }, signal, &emit)
-      executed = execute(cleared, signal, &emit)
-      denied.each do |approval|
+      cleared, blocked = screen(approved.map { |approval| approval[:call] }, signal, &)
+      executed = execute(cleared, signal, &)
+      denials = denied.map do |approval|
         note = approval[:decision]["note"]
         text = "The user denied this tool call#{note ? ": #{note}" : "."}"
-        answer(approval[:call], text, &emit)
+        [approval[:call], text, nil]
       end
-      executed
+      answer_results(open.map { |approval| approval[:call] },
+                     [*blocked, *executed, *denials], executed:, signal:, &)
+      executed.map(&:first)
     end
 
-    # Runs the calls and answers each; returns the calls that executed
-    # (blocked and parked calls never reach here).
+    # Runs calls without persisting them; the caller commits and rewrites
+    # settled results in the model's original call order.
     def execute(calls, signal, &emit)
       return [] if calls.empty?
 
-      results = ToolExecutor.call(calls, @tools_by_name, signal: signal,
-                                                         max_concurrency: @max_concurrency,
-                                                         session: @session, emit: emit,
-                                                         app: @context)
-      context = hook_context(signal, emit)
-      results.each do |call, result, seconds|
-        result = rewrite(call, result, context) if @after_tool
-        answer(call, result, duration: seconds, &emit)
-      end
-      calls
+      ToolExecutor.call(calls, @tools_by_name, signal: signal,
+                                               max_concurrency: @max_concurrency,
+                                               session: @session, emit: emit,
+                                               app: @context)
     end
 
     # A blocked call answers in band, so the model reads the reason and
     # reacts; a hook that raises blocks conservatively rather than letting
     # an unpoliced call through.
     def screen(calls, signal, &emit)
-      return calls unless @before_tool
+      return [calls, []] unless @before_tool
 
       context = hook_context(signal, emit)
-      calls.reject do |call|
+      calls.each_with_object([[], []]) do |call, (cleared, blocked)|
         reason = begin
           @before_tool.call(call, context)
         rescue StandardError => e
           "the before_tool hook failed: #{e.class}: #{e.message}"
         end
-        next false unless reason.is_a?(String)
-
-        answer(call, ToolResult.new(content: "Blocked: #{reason}", error: true), &emit)
-        true
+        if reason.is_a?(String)
+          result = ToolResult.new(content: "Blocked: #{reason}", error: true)
+          blocked << [call, result, nil]
+        else
+          cleared << call
+        end
       end
     end
 
@@ -413,18 +413,37 @@ module Mistri
                            message: message, duration: duration, tool_error: tool_error))
     end
 
+    def answer_results(calls, results, executed:, signal:, &emit)
+      executed_results = if @after_tool
+                           {}.compare_by_identity.tap do |index|
+                             executed.each { |result| index[result] = true }
+                           end
+                         end
+      by_call = {}.compare_by_identity
+      results.each { |result| (by_call[result[0]] ||= []) << result }
+      context = hook_context(signal, emit) if @after_tool
+      calls.each do |call|
+        queued = by_call[call]
+        next unless queued && (entry = queued.shift)
+
+        _call, result, seconds = entry
+        result = rewrite(call, result, context) if executed_results&.key?(entry)
+        answer(call, result, duration: seconds, &emit)
+      end
+    end
+
     def gated?(call)
       tool = @tools_by_name[call.name]
       tool ? tool.needs_approval?(call.arguments) : false
     end
 
-    def partition_approval(calls, &emit)
-      calls.each_with_object([[], []]) do |call, (parked, free)|
+    def partition_approval(calls)
+      calls.each_with_object([[], [], []]) do |call, (parked, free, rejected)|
         (gated?(call) ? parked : free) << call
       rescue StandardError => e
         content = "Error evaluating approval policy for tool #{call.name.inspect}: " \
                   "#{e.class}: #{e.message}. The tool did not run."
-        answer(call, ToolResult.new(content:, error: true), &emit)
+        rejected << [call, ToolResult.new(content:, error: true), nil]
       end
     end
 

--- a/lib/mistri/event.rb
+++ b/lib/mistri/event.rb
@@ -11,15 +11,18 @@ module Mistri
   # message's content list.
   # origin names the sub-agent an event came from: nil for this agent's own
   # turns, and nesting joins names left to right ("researcher>writer").
-  # duration is the tool's execution time in seconds on :tool_result
-  # events; nil where nothing ran (denials, interruptions).
+  # duration is the measured tool execution time on :tool_result events; nil
+  # means no duration is available, not necessarily that no side effect ran.
+  # tool_error is explicit on :tool_result and does not change Event#error?,
+  # which means a terminal provider-turn failure.
   class Event < Data.define(:type, :content_index, :delta, :content, :tool_call,
                             :reason, :message, :error_message, :partial, :origin,
                             :duration, :attempt, :max_attempts, :delay,
-                            :agent, :session_id, :status)
+                            :agent, :session_id, :status, :tool_error)
     # The stream types come from a provider mid-turn; the loop adds
-    # :tool_result after it runs each tool, :approval_needed when a gated
-    # call parks for a human, :compacting/:compaction around a context
+    # :tool_started when a resolved tool commits to execution, :tool_result
+    # after it finishes, :approval_needed when a gated call parks for a human,
+    # :compacting/:compaction around a context
     # compaction, and :retry (with attempt, max_attempts, delay) before it
     # waits out a transient failure, so one subscription sees the whole
     # exchange. :done and :error are loop-owned and terminal: only the
@@ -33,7 +36,7 @@ module Mistri
       thinking_start thinking_delta thinking_end
       toolcall_start toolcall_delta toolcall_end
       done error
-      tool_result approval_needed
+      tool_started tool_result approval_needed
       compacting compaction
       retry
       subagent_report
@@ -42,8 +45,19 @@ module Mistri
     def initialize(type:, content_index: nil, delta: nil, content: nil, tool_call: nil,
                    reason: nil, message: nil, error_message: nil, partial: nil, origin: nil,
                    duration: nil, attempt: nil, max_attempts: nil, delay: nil,
-                   agent: nil, session_id: nil, status: nil)
+                   agent: nil, session_id: nil, status: nil, tool_error: nil)
       raise ArgumentError, "unknown event type #{type.inspect}" unless TYPES.include?(type)
+
+      if type == :tool_result
+        unless [true, false].include?(tool_error)
+          raise ArgumentError, "tool_result events require a boolean tool_error"
+        end
+      elsif !tool_error.nil?
+        raise ArgumentError, "tool_error is only valid on tool_result events"
+      end
+      if type == :tool_result && message && message.tool_error != tool_error
+        raise ArgumentError, "event tool_error must match its message"
+      end
 
       super
     end
@@ -52,13 +66,15 @@ module Mistri
 
     def error? = type == :error
 
+    def tool_error? = tool_error == true
+
     def terminal? = done? || error?
 
     # Partials are ephemeral streaming state and stay out of serialization.
     def to_h
       { type:, content_index:, delta:, content:, tool_call: tool_call&.to_h,
         reason:, message: message&.to_h, error_message:, origin:, duration:,
-        attempt:, max_attempts:, delay:, agent:, session_id:, status: }.compact
+        attempt:, max_attempts:, delay:, agent:, session_id:, status:, tool_error: }.compact
     end
   end
 end

--- a/lib/mistri/mcp.rb
+++ b/lib/mistri/mcp.rb
@@ -64,12 +64,20 @@ module Mistri
     end
 
     # An MCP result becomes model-readable content: text joins, images ride
-    # as image blocks, and isError answers in band so the model can react.
+    # as image blocks, and isError remains structured failure data end to end.
     def answer(result)
       blocks = Array(result["content"]).map { |block| convert(block) }
       if result["isError"]
-        text = blocks.grep(String).join("\n")
-        return "MCP tool error: #{text.empty? ? "unknown error" : text}"
+        text_blocks = blocks.grep(String)
+        if result["structuredContent"]
+          structured = JSON.generate(result["structuredContent"])
+          text_blocks << structured unless text_blocks.include?(structured)
+        end
+        text = text_blocks.join("\n")
+        content = "MCP tool error: #{text.empty? ? "unknown error" : text}"
+        non_text = blocks.grep_v(String)
+        content = [content, *non_text] unless non_text.empty?
+        return ToolResult.new(content:, error: true)
       end
       if blocks.empty? && result["structuredContent"]
         return JSON.generate(result["structuredContent"])

--- a/lib/mistri/message.rb
+++ b/lib/mistri/message.rb
@@ -10,26 +10,33 @@ module Mistri
   # them, which is what lets a later turn replay history across models, plus
   # usage and the stop reason.
   #
-  # ui is a tool result's host-only channel: it persists with the message and
-  # rides its :tool_result event, but no serializer ever sends it to a model.
-  # error is the machine-readable failure on an errored turn (ErrorData
-  # shape); error_message stays the human story.
+  # ui is a tool result's host-only channel. tool_error is true or false on
+  # newly produced tool results and nil on legacy records that predate the
+  # field. error is the machine-readable failure on an errored provider turn
+  # (ErrorData shape); error_message stays the human story.
   class Message < Data.define(:role, :content, :tool_call_id, :tool_name,
                               :model, :provider, :usage, :stop_reason, :error_message, :ui,
-                              :error)
+                              :error, :tool_error)
     ROLES = %i[system user assistant tool].freeze
 
     def initialize(role:, content: nil, tool_call_id: nil, tool_name: nil, model: nil,
                    provider: nil, usage: nil, stop_reason: nil, error_message: nil, ui: nil,
-                   error: nil)
+                   error: nil, tool_error: nil)
       role = role.to_sym
       raise ArgumentError, "unknown role #{role.inspect}" unless ROLES.include?(role)
       if stop_reason && !StopReason.valid?(stop_reason)
         raise ArgumentError, "unknown stop reason #{stop_reason.inspect}"
       end
 
+      unless tool_error.nil?
+        unless [true, false].include?(tool_error)
+          raise ArgumentError, "tool_error must be true, false, or nil"
+        end
+        raise ArgumentError, "tool_error is only valid on tool messages" if role != :tool
+      end
+
       super(role:, content: Content.wrap(content).freeze, tool_call_id:, tool_name:,
-            model:, provider:, usage:, stop_reason:, error_message:, ui:, error:)
+            model:, provider:, usage:, stop_reason:, error_message:, ui:, error:, tool_error:)
     end
 
     def self.system(content) = new(role: :system, content:)
@@ -50,8 +57,8 @@ module Mistri
       new(role: :assistant, content: [*Content.wrap(content), *tool_calls], **meta)
     end
 
-    def self.tool(content:, tool_call_id:, tool_name: nil, ui: nil)
-      new(role: :tool, content:, tool_call_id:, tool_name:, ui:)
+    def self.tool(content:, tool_call_id:, tool_name: nil, ui: nil, tool_error: false)
+      new(role: :tool, content:, tool_call_id:, tool_name:, ui:, tool_error:)
     end
 
     def self.from_h(hash)
@@ -62,13 +69,15 @@ module Mistri
           model: h["model"], provider: h["provider"]&.to_sym,
           usage: h["usage"] && Usage.from_h(h["usage"]),
           stop_reason: h["stop_reason"]&.to_sym, error_message: h["error_message"],
-          ui: h["ui"], error: h["error"])
+          ui: h["ui"], error: h["error"], tool_error: h["tool_error"])
     end
 
     def system? = role == :system
     def user? = role == :user
     def assistant? = role == :assistant
     def tool? = role == :tool
+    def tool_error? = tool_error == true
+    def tool_error_known? = !tool_error.nil?
 
     # Every Text block joined, or nil when the turn carried no text.
     def text
@@ -84,7 +93,8 @@ module Mistri
     # never with new(**to_h).
     def to_h
       { role:, content: content.map(&:to_h), tool_call_id:, tool_name:, model:,
-        provider:, usage: usage&.to_h, stop_reason:, error_message:, ui:, error: }.compact
+        provider:, usage: usage&.to_h, stop_reason:, error_message:, ui:, error:,
+        tool_error: }.compact
     end
   end
 end

--- a/lib/mistri/providers/anthropic/serializer.rb
+++ b/lib/mistri/providers/anthropic/serializer.rb
@@ -51,7 +51,9 @@ module Mistri
             # The API rejects an empty tool_result; a space stands in for a
             # tool that returned nothing.
             blocks = [{ type: "text", text: " " }] if blocks.empty?
-            { type: "tool_result", tool_use_id: msg.tool_call_id, content: blocks }
+            result = { type: "tool_result", tool_use_id: msg.tool_call_id, content: blocks }
+            result[:is_error] = true if msg.tool_error?
+            result
           end }
         end
 

--- a/lib/mistri/providers/gemini/serializer.rb
+++ b/lib/mistri/providers/gemini/serializer.rb
@@ -53,8 +53,9 @@ module Mistri
               raise SchemaError, "Gemini tool results need tool_name to pair with their call"
             end
 
+            key = msg.tool_error? ? "error" : "result"
             { functionResponse: { name: msg.tool_name,
-                                  response: { "result" => result_text(msg) } } }
+                                  response: { key => result_text(msg) } } }
           end }
         end
 

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -41,7 +41,8 @@ module Mistri
     def messages = replay.map(&:first)
 
     # What a run killed mid-tool answers in place of the result it never got.
-    INTERRUPTED_RESULT = "[interrupted: the run stopped before this tool returned]"
+    INTERRUPTED_RESULT = "[interrupted: the run stopped before this result was persisted; " \
+                         "the tool may have executed, so verify its effects before retrying]"
 
     # Replay messages paired with the entry index each came from, starting at
     # the latest compaction boundary. The synthetic summary message carries a
@@ -197,7 +198,7 @@ module Mistri
                    end
         [[message, index]] + dangling.map do |call|
           [Message.tool(content: INTERRUPTED_RESULT, tool_call_id: call.id,
-                        tool_name: call.name), nil]
+                        tool_name: call.name, tool_error: true), nil]
         end
       end
     end

--- a/lib/mistri/sub_agent.rb
+++ b/lib/mistri/sub_agent.rb
@@ -195,7 +195,7 @@ module Mistri
           child.deny(call.id, note: "sub-agents cannot pause for human approval")
           child.append_message(Message.tool(
                                  content: "Denied: sub-agents cannot pause for human approval.",
-                                 tool_call_id: call.id, tool_name: call.name
+                                 tool_call_id: call.id, tool_name: call.name, tool_error: true
                                ))
         end
       end
@@ -301,12 +301,14 @@ module Mistri
         when :awaiting_approval
           deny_pending(result, child)
           ToolResult.new(content: "The #{label} sub-agent stopped: it needed human " \
-                                  "approval, which sub-agents cannot wait for.", ui: link)
+                                  "approval, which sub-agents cannot wait for.", ui: link,
+                         error: true)
         when :aborted
-          ToolResult.new(content: "[the #{label} sub-agent was stopped]", ui: link)
+          ToolResult.new(content: "[the #{label} sub-agent was stopped]", ui: link, error: true)
         else
           reason = result.error_message || result.status
-          ToolResult.new(content: "The #{label} sub-agent failed: #{reason}", ui: link)
+          ToolResult.new(content: "The #{label} sub-agent failed: #{reason}", ui: link,
+                         error: true)
         end
       end
 

--- a/lib/mistri/tool.rb
+++ b/lib/mistri/tool.rb
@@ -41,9 +41,9 @@ module Mistri
       @handler = handler
     end
 
-    # A handler may return a ToolResult to speak on two channels; its ui
-    # payload is canonicalized through JSON here so the live event and a
-    # reloaded session read the identical shape.
+    # A handler may return a ToolResult to add host-only UI or declare a
+    # model-readable failure. Its ui payload is canonicalized through JSON
+    # here so the live event and a reloaded session read the identical shape.
     #
     # Handlers receive (arguments, context). A proc that declares one
     # parameter ignores the context invisibly; a lambda opts in by arity.

--- a/lib/mistri/tool_executor.rb
+++ b/lib/mistri/tool_executor.rb
@@ -8,11 +8,32 @@ module Mistri
   # concurrently up to max_concurrency; each runs inside the Rails executor
   # when Rails is present, so ActiveRecord connections return to the pool.
   #
-  # A tool that raises becomes an in-band error string the model can read. An
-  # abort never starts a not-yet-started call: it gets an interrupted result
-  # instead, so the turn always pairs and the session replays cleanly.
+  # A tool that fails becomes an in-band ToolResult with an explicit error
+  # fact. An abort never starts a not-yet-started call: it gets an interrupted
+  # result instead, so the turn always pairs and the session replays cleanly.
   module ToolExecutor
+    # Separates Mistri's deadline from a handler's own Timeout::Error.
+    class InvocationTimeout < StandardError
+    end
+    private_constant :InvocationTimeout
+
+    # Carries subscriber failures past the handler outcome boundary.
+    class SubscriberError < StandardError
+      attr_reader :original
+
+      def initialize(original)
+        @original = original
+        super(original.message)
+        set_backtrace(original.backtrace)
+      end
+    end
+    private_constant :SubscriberError
+
     INTERRUPTED = "[interrupted: this tool call never ran]"
+    OUTCOME_UNKNOWN = "[interrupted: this tool call's outcome is unavailable; the tool may have " \
+                      "executed, so verify its effects before retrying]"
+    VERIFY_BEFORE_RETRY = "The tool may have completed partially; verify its effects before " \
+                          "retrying."
 
     module_function
 
@@ -20,65 +41,113 @@ module Mistri
              app: nil)
       return [] if calls.empty?
 
-      context = ToolContext.new(session: session, signal: signal, emit: thread_safe(emit),
+      context = ToolContext.new(session: session, signal: signal, emit: thread_safe(emit, signal),
                                 app: app)
       results = Array.new(calls.length)
       queue = Queue.new
+      errors = Queue.new
       calls.each_with_index { |call, index| queue << [call, index] }
       workers = max_concurrency.clamp(1, calls.length)
-      Array.new(workers) { worker(queue, results, tools_by_name, context) }.each(&:join)
+      Array.new(workers) { worker(queue, results, tools_by_name, context, errors) }.each(&:join)
+      unless errors.empty?
+        error = errors.pop
+        raise(error.is_a?(SubscriberError) ? error.original : error)
+      end
+
       calls.zip(results).map do |call, entry|
-        value, seconds = entry || [INTERRUPTED, nil]
+        value, seconds = entry || [failure(OUTCOME_UNKNOWN), nil]
         [call, value, seconds]
       end
     end
 
-    def worker(queue, results, tools_by_name, context)
+    def worker(queue, results, tools_by_name, context, errors)
       Thread.new do
         loop do
+          break unless errors.empty?
+
           call, index = begin
             queue.pop(true)
           rescue ThreadError
             break
           end
           if context.signal&.aborted?
-            results[index] = [INTERRUPTED, nil]
+            results[index] = [failure(INTERRUPTED), nil]
             next
           end
 
-          started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          value = run_one(call, tools_by_name, context)
-          results[index] = [value, Process.clock_gettime(Process::CLOCK_MONOTONIC) - started]
+          results[index] = run_one(call, tools_by_name, context)
         end
+      rescue StandardError => e
+        errors << e
       end
     end
 
     def run_one(call, tools_by_name, context)
       tool = tools_by_name[call.name]
-      return "Error: unknown tool #{call.name.inspect}" unless tool
+      return [failure("Error: unknown tool #{call.name.inspect}"), nil] unless tool
 
-      with_rails_executor { invoke(tool, call, context) }
-    rescue StandardError => e
-      "Error running tool #{call.name.inspect}: #{e.class}: #{e.message}"
+      return [failure(INTERRUPTED), nil] unless commit(call, context)
+
+      invoke_one(tool, call, context)
     end
 
-    # A tool with a timeout answers in band when it stalls, so one hung
-    # handler cannot stall the whole run.
+    def invoke_one(tool, call, context)
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      value = with_rails_executor { invoke(tool, call, context) }
+      [value, elapsed(started)]
+    rescue SubscriberError
+      raise
+    rescue InvocationTimeout
+      content = "Error running tool #{call.name.inspect}: timed out after #{tool.timeout}s. " \
+                "#{VERIFY_BEFORE_RETRY}"
+      [failure(content), elapsed(started)]
+    rescue StandardError => e
+      [failure("Error running tool #{call.name.inspect}: #{e.class}: #{e.message}. " \
+               "#{VERIFY_BEFORE_RETRY}"),
+       elapsed(started)]
+    end
+
     def invoke(tool, call, context)
       return tool.call(call.arguments, context) unless tool.timeout
 
-      Timeout.timeout(tool.timeout) { tool.call(call.arguments, context) }
-    rescue Timeout::Error
-      "Error running tool #{call.name.inspect}: timed out after #{tool.timeout}s"
+      Timeout.timeout(tool.timeout, InvocationTimeout) { tool.call(call.arguments, context) }
+    end
+
+    def commit(call, context)
+      return false if context.signal&.aborted?
+      return true unless context.emit
+
+      context.emit.call(Event.new(type: :tool_started, tool_call: call))
+    end
+
+    def failure(content) = ToolResult.new(content:, error: true)
+
+    def elapsed(started)
+      started && (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started)
     end
 
     # Concurrent tools share the caller's sink; sinks are not required to be
     # thread-safe, so forwarded events serialize here.
-    def thread_safe(emit)
+    def thread_safe(emit, signal)
       return nil unless emit
 
       mutex = Mutex.new
-      ->(event) { mutex.synchronize { emit.call(event) } }
+      failed = false
+      lambda do |event|
+        mutex.synchronize do
+          next false if event.type == :tool_started && (failed || signal&.aborted?)
+
+          result = begin
+            emit.call(event)
+          rescue InvocationTimeout
+            raise
+          rescue StandardError => e
+            failed = true
+            raise SubscriberError, e
+          end
+          event.type == :tool_started ? true : result
+        end
+      end
     end
 
     def with_rails_executor(&)

--- a/lib/mistri/tool_executor.rb
+++ b/lib/mistri/tool_executor.rb
@@ -34,6 +34,8 @@ module Mistri
                       "executed, so verify its effects before retrying]"
     VERIFY_BEFORE_RETRY = "The tool may have completed partially; verify its effects before " \
                           "retrying."
+    COMMITTED = Object.new.freeze
+    private_constant :COMMITTED
 
     module_function
 
@@ -54,8 +56,10 @@ module Mistri
         raise(error.is_a?(SubscriberError) ? error.original : error)
       end
 
-      calls.zip(results).map do |call, entry|
-        value, seconds = entry || [failure(OUTCOME_UNKNOWN), nil]
+      calls.each_with_index.map do |call, index|
+        entry = results[index]
+        entry = [failure(OUTCOME_UNKNOWN), nil] if entry.equal?(COMMITTED)
+        value, seconds = entry || [failure(INTERRUPTED), nil]
         [call, value, seconds]
       end
     end
@@ -75,19 +79,20 @@ module Mistri
             next
           end
 
-          results[index] = run_one(call, tools_by_name, context)
+          results[index] = run_one(call, index, results, tools_by_name, context)
         end
       rescue StandardError => e
         errors << e
       end
     end
 
-    def run_one(call, tools_by_name, context)
+    def run_one(call, index, results, tools_by_name, context)
       tool = tools_by_name[call.name]
       return [failure("Error: unknown tool #{call.name.inspect}"), nil] unless tool
 
       return [failure(INTERRUPTED), nil] unless commit(call, context)
 
+      results[index] = COMMITTED
       invoke_one(tool, call, context)
     end
 

--- a/lib/mistri/tool_result.rb
+++ b/lib/mistri/tool_result.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 module Mistri
-  # A two-channel tool result: content goes to the model, ui goes only to the
-  # host. The ui payload rides the tool message and its :tool_result event,
-  # persists with the session for transcript re-renders, and never reaches a
-  # provider. Return one from a handler when the UI needs more than the model
-  # should read or pay for: full query rows behind a compact answer, the
-  # updated document behind "saved".
+  # A tool result with model content, host-only UI, and an explicit failure
+  # fact. Both channels and the error bit persist with the tool message; only
+  # content and provider-supported error signaling reach the model.
   #
   #   Tool.define("edit_page", "Edits the page.") do |args|
   #     page = apply(args)
@@ -15,9 +12,15 @@ module Mistri
   #
   # ui must be JSON-serializable; it is stored and delivered in canonical
   # JSON form (string keys), the same shape a reloaded session reads.
-  ToolResult = Data.define(:content, :ui) do
-    def initialize(content:, ui: nil)
+  ToolResult = Data.define(:content, :ui, :error) do
+    def initialize(content:, ui: nil, error: false)
+      unless [true, false].include?(error)
+        raise ArgumentError, "tool result error must be true or false"
+      end
+
       super
     end
+
+    def error? = error
   end
 end

--- a/test/integration/test_core_loop.rb
+++ b/test/integration/test_core_loop.rb
@@ -39,4 +39,27 @@ class TestCoreLoopIntegration < Minitest::Test
     refute Integration.saw?(result.text, revision),
            "the model mentioned a value it should never have seen"
   end
+
+  Integration.scenario(self, :tool_failure_round_trips_as_data) do |model|
+    code = Integration.codename
+    diagnose = Mistri::Tool.define("diagnose_service", "Runs one service diagnostic.") do
+      Mistri::ToolResult.new(
+        content: "The diagnostic failed permanently with code #{code}. Do not retry it.",
+        error: true
+      )
+    end
+    failures = []
+    agent = Mistri::Agent.new(
+      provider: Mistri.provider(model), tools: [diagnose],
+      system: "Call diagnose_service exactly once. Then report its failure code and stop."
+    )
+
+    result = agent.run("Diagnose the service.") do |event|
+      failures << event.tool_error if event.type == :tool_result
+    end
+
+    refute_empty failures, "the live tool was never called"
+    assert_predicate failures, :all?, "the live lifecycle lost its error fact"
+    assert Integration.saw?(result.text, code), "the failed result never replayed: #{result.text}"
+  end
 end

--- a/test/test_agent.rb
+++ b/test/test_agent.rb
@@ -45,9 +45,11 @@ class TestAgent < Minitest::Test
     agent = Mistri::Agent.new(provider:, tools: [boom])
 
     agent.run("go")
-    tool_result = agent.session.messages[2].text
+    tool_result = agent.session.messages[2]
 
-    assert_match(/Error running tool "boom".*kaboom/, tool_result)
+    assert_match(/Error running tool "boom".*kaboom/, tool_result.text)
+    assert_match(/verify.*before retrying/i, tool_result.text)
+    assert_predicate tool_result, :tool_error?
   end
 
   def test_an_errored_turn_with_tool_calls_pairs_without_executing
@@ -63,6 +65,7 @@ class TestAgent < Minitest::Test
 
     assert_predicate tool_result, :tool?
     assert_equal Mistri::ToolExecutor::INTERRUPTED, tool_result.text
+    assert_predicate tool_result, :tool_error?
   end
 
   def test_a_budget_stops_the_run_between_turns

--- a/test/test_agent_approval.rb
+++ b/test/test_agent_approval.rb
@@ -117,30 +117,72 @@ class TestAgentApproval < Minitest::Test
     broken = Mistri::Tool.define("broken", "B.", needs_approval: lambda { |_args|
       raise "policy unavailable"
     }) { flunk "ran despite an unavailable approval policy" }
-    safe = Mistri::Tool.define("safe", "S.") do
-      ran << :safe
+    safe_a = Mistri::Tool.define("safe_a", "A.") do
+      ran << :safe_a
+      "ok"
+    end
+    safe_b = Mistri::Tool.define("safe_b", "B.") do
+      ran << :safe_b
       "ok"
     end
     provider = Mistri::Providers::Fake.new(turns: [
-                                             { tool_calls: [{ name: "broken", arguments: {} },
-                                                            { name: "safe", arguments: {} }] },
+                                             { tool_calls: [{ name: "safe_a", arguments: {} },
+                                                            { name: "broken", arguments: {} },
+                                                            { name: "safe_b", arguments: {} }] },
                                              { text: "done" }
                                            ])
     events = []
-    agent = Mistri::Agent.new(provider:, tools: [broken, safe], max_concurrency: 1)
+    agent = Mistri::Agent.new(provider:, tools: [safe_a, broken, safe_b], max_concurrency: 1)
 
     result = agent.run("go") { |event| events << event }
 
     assert_predicate result, :completed?
-    assert_equal [:safe], ran
+    assert_equal %i[safe_a safe_b], ran
     answers = agent.session.messages.select(&:tool?)
-    failed = answers.find { |message| message.tool_name == "broken" }
 
-    assert_predicate failed, :tool_error?
-    assert_includes failed.text, "approval policy"
+    assert_equal %w[safe_a broken safe_b], answers.map(&:tool_name)
+    assert_equal [false, true, false], answers.map(&:tool_error)
+    assert_includes answers[1].text, "approval policy"
     starts = events.select { |event| event.type == :tool_started }.map(&:tool_call)
+    results = events.select { |event| event.type == :tool_result }.map(&:tool_call)
 
-    assert_equal ["safe"], starts.map(&:name)
+    assert_equal %w[safe_a safe_b], starts.map(&:name)
+    assert_equal %w[safe_a broken safe_b], results.map(&:name)
+    replay = provider.requests.last[:messages].select(&:tool?)
+
+    assert_equal %w[safe_a broken safe_b], replay.map(&:tool_name)
+  end
+
+  def test_mixed_approval_decisions_settle_in_original_call_order
+    ran = []
+    first = Mistri::Tool.define("first", "First.", needs_approval: true) do
+      flunk "denied call ran"
+    end
+    second = Mistri::Tool.define("second", "Second.", needs_approval: true) do
+      ran << :second
+      "done"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "first", arguments: {} },
+                                                            { name: "second", arguments: {} }] },
+                                             { text: "noted" }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [first, second])
+    pending = agent.run("go").pending
+    agent.session.deny(pending[0].id)
+    agent.session.approve(pending[1].id)
+    events = []
+
+    agent.resume { |event| events << event }
+
+    assert_equal [:second], ran
+    answers = agent.session.messages.select(&:tool?)
+
+    assert_equal %w[first second], answers.map(&:tool_name)
+    assert_equal [false, false], answers.map(&:tool_error)
+    results = events.select { |event| event.type == :tool_result }
+
+    assert_equal(%w[first second], results.map { |event| event.tool_call.name })
   end
 
   private

--- a/test/test_agent_approval.rb
+++ b/test/test_agent_approval.rb
@@ -17,6 +17,7 @@ class TestAgentApproval < Minitest::Test
     assert_equal "send_gift", result.pending.first.name
     assert_empty sent, "the gated tool must not execute before approval"
     assert(events.any? { |e| e.type == :approval_needed })
+    refute(events.any? { |e| e.type == :tool_started })
   end
 
   def test_approval_days_later_from_a_fresh_process_completes_the_run
@@ -51,10 +52,11 @@ class TestAgentApproval < Minitest::Test
 
     assert_predicate result, :completed?
     assert_empty sent
-    denial = agent.session.messages.select(&:tool?).last.text
+    denial = agent.session.messages.select(&:tool?).last
 
-    assert_match(/denied/i, denial)
-    assert_match(/too expensive/, denial)
+    assert_match(/denied/i, denial.text)
+    assert_match(/too expensive/, denial.text)
+    refute_predicate denial, :tool_error?, "human denial is an expected control outcome"
   end
 
   def test_resume_before_a_decision_returns_still_suspended
@@ -108,6 +110,37 @@ class TestAgentApproval < Minitest::Test
 
     assert_predicate result, :completed?
     assert_equal [5], sent
+  end
+
+  def test_a_raising_approval_policy_fails_closed_per_call
+    ran = []
+    broken = Mistri::Tool.define("broken", "B.", needs_approval: lambda { |_args|
+      raise "policy unavailable"
+    }) { flunk "ran despite an unavailable approval policy" }
+    safe = Mistri::Tool.define("safe", "S.") do
+      ran << :safe
+      "ok"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "broken", arguments: {} },
+                                                            { name: "safe", arguments: {} }] },
+                                             { text: "done" }
+                                           ])
+    events = []
+    agent = Mistri::Agent.new(provider:, tools: [broken, safe], max_concurrency: 1)
+
+    result = agent.run("go") { |event| events << event }
+
+    assert_predicate result, :completed?
+    assert_equal [:safe], ran
+    answers = agent.session.messages.select(&:tool?)
+    failed = answers.find { |message| message.tool_name == "broken" }
+
+    assert_predicate failed, :tool_error?
+    assert_includes failed.text, "approval policy"
+    starts = events.select { |event| event.type == :tool_started }.map(&:tool_call)
+
+    assert_equal ["safe"], starts.map(&:name)
   end
 
   private

--- a/test/test_agent_hooks.rb
+++ b/test/test_agent_hooks.rb
@@ -29,7 +29,8 @@ class TestAgentHooks < Minitest::Test
     provider = Mistri::Providers::Fake.new(turns: two_call_turns)
     agent = Mistri::Agent.new(provider:, tools: tools(log), before_tool: policy)
 
-    result = agent.run("clean up")
+    events = []
+    result = agent.run("clean up") { |event| events << event }
 
     assert_predicate result, :completed?
     assert_equal [:read], log, "the blocked tool never ran"
@@ -38,6 +39,12 @@ class TestAgentHooks < Minitest::Test
 
     assert_includes answers, "Blocked: org policy forbids purging"
     assert_includes answers, "data"
+    errors = agent.session.messages.select(&:tool?).map(&:tool_error).sort_by(&:to_s)
+    starts = events.select { |event| event.type == :tool_started }
+                   .map { |event| event.tool_call.name }
+
+    assert_equal [false, true], errors
+    assert_equal ["read"], starts
   end
 
   def test_before_tool_outranks_the_approval_gate
@@ -135,7 +142,34 @@ class TestAgentHooks < Minitest::Test
     agent = Mistri::Agent.new(provider:, tools: [tool], after_tool: boom)
     agent.run("go")
 
-    assert_includes agent.session.messages.select(&:tool?).last.text, "after_tool hook"
+    answer = agent.session.messages.select(&:tool?).last
+
+    assert_includes answer.text, "after_tool hook"
+    assert_includes answer.text, "already returned"
+    assert_predicate answer, :tool_error?
+  end
+
+  def test_after_tool_sees_typed_failures_and_cannot_clear_them
+    seen = nil
+    tool = Mistri::Tool.define("boom", "B.") { raise "secret detail" }
+    redact = lambda do |_call, result, _context|
+      seen = result
+      Mistri::ToolResult.new(content: "The operation failed.", error: false)
+    end
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "boom", arguments: {} }] },
+                                             { text: "done" }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [tool], after_tool: redact)
+
+    agent.run("go")
+
+    assert_instance_of Mistri::ToolResult, seen
+    assert_predicate seen, :error?
+    answer = agent.session.messages.select(&:tool?).last
+
+    assert_equal "The operation failed.", answer.text
+    assert_predicate answer, :tool_error?
   end
 
   def test_hooks_receive_the_callers_context

--- a/test/test_agent_hooks.rb
+++ b/test/test_agent_hooks.rb
@@ -35,16 +35,19 @@ class TestAgentHooks < Minitest::Test
     assert_predicate result, :completed?
     assert_equal [:read], log, "the blocked tool never ran"
 
-    answers = agent.session.messages.select(&:tool?).map(&:text)
+    answers = agent.session.messages.select(&:tool?)
 
-    assert_includes answers, "Blocked: org policy forbids purging"
-    assert_includes answers, "data"
-    errors = agent.session.messages.select(&:tool?).map(&:tool_error).sort_by(&:to_s)
+    assert_equal %w[read purge], answers.map(&:tool_name)
+    assert_equal ["data", "Blocked: org policy forbids purging"], answers.map(&:text)
+    errors = answers.map(&:tool_error)
     starts = events.select { |event| event.type == :tool_started }
                    .map { |event| event.tool_call.name }
+    results = events.select { |event| event.type == :tool_result }
+                    .map { |event| event.tool_call.name }
 
     assert_equal [false, true], errors
     assert_equal ["read"], starts
+    assert_equal %w[read purge], results
   end
 
   def test_before_tool_outranks_the_approval_gate
@@ -170,6 +173,34 @@ class TestAgentHooks < Minitest::Test
 
     assert_equal "The operation failed.", answer.text
     assert_predicate answer, :tool_error?
+  end
+
+  def test_after_tool_stays_interleaved_with_each_persisted_result
+    observed = []
+    audit = lambda do |call, result, context|
+      persisted = context.session.entries.count do |entry|
+        entry["type"] == "message" && entry.dig("message", "role") == "tool"
+      end
+      observed << [call.name, persisted]
+      context.emit.call(Mistri::Event.new(type: :compacting, content: call.name))
+      result
+    end
+    provider = Mistri::Providers::Fake.new(turns: two_call_turns)
+    events = []
+    agent = Mistri::Agent.new(provider:, tools: tools([]), after_tool: audit,
+                              max_concurrency: 1)
+
+    agent.run("go") { |event| events << event }
+
+    assert_equal [["read", 0], ["purge", 1]], observed
+    lifecycle = events.filter_map do |event|
+      case event.type
+      when :compacting then "hook:#{event.content}"
+      when :tool_result then "result:#{event.tool_call.name}"
+      end
+    end
+
+    assert_equal %w[hook:read result:read hook:purge result:purge], lifecycle
   end
 
   def test_hooks_receive_the_callers_context

--- a/test/test_agent_interrupt.rb
+++ b/test/test_agent_interrupt.rb
@@ -22,7 +22,7 @@ class TestAgentInterrupt < Minitest::Test
     end
     never = Mistri::Tool.define("never_runs", "Should not complete.") { flunk "ran despite abort" }
     session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
-    agent = Mistri::Agent.new(provider:, tools: [stop_here, never], session:)
+    agent = Mistri::Agent.new(provider:, tools: [stop_here, never], session:, max_concurrency: 1)
 
     agent.run("do two things", signal:)
 

--- a/test/test_anthropic_serializer.rb
+++ b/test/test_anthropic_serializer.rb
@@ -35,6 +35,17 @@ class TestAnthropicSerializer < Minitest::Test
     assert_equal({ type: "tool_use", id: "a", name: "x", input: {} }, wire[1][:content].first)
   end
 
+  def test_only_failed_tool_results_emit_is_error
+    history = [Mistri::Message.tool(content: "Error-looking success", tool_call_id: "a"),
+               Mistri::Message.tool(content: "plain failure", tool_call_id: "b",
+                                    tool_error: true)]
+
+    blocks = SERIALIZER.messages(history).first[:content]
+
+    refute blocks.first.key?(:is_error)
+    assert blocks.last[:is_error]
+  end
+
   def test_thinking_replays_with_signature_and_redacted_as_opaque_data
     thinking = Mistri::Content::Thinking.new(thinking: "why", signature: "sig")
     redacted = Mistri::Content::Thinking.new(thinking: "", signature: "opaque", redacted: true)

--- a/test/test_child_stop.rb
+++ b/test/test_child_stop.rb
@@ -81,6 +81,7 @@ class TestChildStop < Minitest::Test
     tool_message = session.messages.select(&:tool?).last
 
     assert_match(/was stopped/, tool_message.text)
+    assert_predicate tool_message, :tool_error?
     refute Mistri.locks.flag?(Mistri::Child.stop_key(child.session_id)),
            "the stop flag clears when the child ends"
   end

--- a/test/test_ends_turn.rb
+++ b/test/test_ends_turn.rb
@@ -67,6 +67,26 @@ class TestEndsTurn < Minitest::Test
                  "a blocked call never executed, so the model keeps the floor"
   end
 
+  def test_an_errored_ends_turn_call_still_hands_away_the_floor
+    tools = [
+      Mistri::Tool.define("declared", "D.", ends_turn: true) do
+        Mistri::ToolResult.new(content: "could not present", error: true)
+      end,
+      Mistri::Tool.define("raised", "R.", ends_turn: true) { raise "display failed" }
+    ]
+
+    tools.each do |tool|
+      provider = fake({ tool_calls: [{ name: tool.name, arguments: {} }] })
+      agent = Mistri::Agent.new(provider:, tools: [tool])
+
+      result = agent.run("go")
+
+      assert_predicate result, :handed_off?, "ends_turn is structural, not a success claim"
+      assert_predicate agent.session.messages.select(&:tool?).last, :tool_error?
+      assert_equal 1, provider.requests.length, "the model never mechanically retries the call"
+    end
+  end
+
   def test_ends_turn_outranks_a_pending_steer
     provider = fake({ tool_calls: [{ name: "ask_user",
                                      arguments: { "question" => "Which one?" } }] })

--- a/test/test_event.rb
+++ b/test/test_event.rb
@@ -33,4 +33,31 @@ class TestEvent < Minitest::Test
     refute_includes event.to_h.keys, :partial
     assert_equal "He", event.to_h[:delta]
   end
+
+  def test_tool_lifecycle_events_keep_terminal_errors_distinct
+    call = Mistri::ToolCall.new(id: "c1", name: "lookup", arguments: {})
+    started = Mistri::Event.new(type: :tool_started, tool_call: call)
+    failed = Mistri::Event.new(type: :tool_result, tool_call: call, tool_error: true)
+
+    refute_predicate started, :terminal?
+    refute_predicate failed, :error?
+    assert failed.to_h[:tool_error]
+  end
+
+  def test_tool_error_is_boolean_and_only_belongs_to_results
+    assert_raises(ArgumentError) do
+      Mistri::Event.new(type: :tool_result)
+    end
+    assert_raises(ArgumentError) do
+      Mistri::Event.new(type: :tool_result, tool_error: "yes")
+    end
+    assert_raises(ArgumentError) do
+      Mistri::Event.new(type: :tool_started, tool_error: false)
+    end
+    message = Mistri::Message.tool(content: "failed", tool_call_id: "c1", tool_error: true)
+
+    assert_raises(ArgumentError) do
+      Mistri::Event.new(type: :tool_result, message:, tool_error: false)
+    end
+  end
 end

--- a/test/test_gemini_serializer.rb
+++ b/test/test_gemini_serializer.rb
@@ -53,6 +53,15 @@ class TestGeminiSerializer < Minitest::Test
     assert_raises(Mistri::SchemaError) { SERIALIZER.contents([result]) }
   end
 
+  def test_failed_tool_results_use_the_documented_error_key
+    failed = Mistri::Message.tool(content: "unavailable", tool_call_id: "c1",
+                                  tool_name: "search", tool_error: true)
+
+    response = SERIALIZER.contents([failed]).first[:parts].first[:functionResponse][:response]
+
+    assert_equal({ "error" => "unavailable" }, response)
+  end
+
   def test_images_ride_as_inline_data
     image = Mistri::Content::Image.from_bytes("png!", mime_type: "image/png")
     contents = SERIALIZER.contents([Mistri::Message.user(["see", image])])

--- a/test/test_mcp_bridge.rb
+++ b/test/test_mcp_bridge.rb
@@ -37,10 +37,27 @@ class TestMcpBridge < Minitest::Test
 
     failed = { "isError" => true, "content" => [{ "type" => "text", "text" => "no access" }] }
 
-    assert_equal "MCP tool error: no access", Mistri::MCP.answer(failed)
+    error = Mistri::MCP.answer(failed)
+
+    assert_equal "MCP tool error: no access", error.content
+    assert_predicate error, :error?
 
     image = { "content" => [{ "type" => "image", "data" => ["png!"].pack("m0"),
                               "mimeType" => "image/png" }] }
+    failed_image = { "isError" => true, "content" => image["content"] }
+    image_error = Mistri::MCP.answer(failed_image)
+
+    assert_instance_of Mistri::Content::Image, image_error.content.last
+    assert_predicate image_error, :error?
+
+    structured_error = Mistri::MCP.answer(
+      "isError" => true, "content" => [],
+      "structuredContent" => { "code" => "RATE_LIMITED" }
+    )
+
+    assert_includes structured_error.content, '"code":"RATE_LIMITED"'
+    assert_predicate structured_error, :error?
+
     blocks = Mistri::MCP.answer(image)
 
     assert_instance_of Mistri::Content::Image, blocks.first
@@ -71,6 +88,30 @@ class TestMcpBridge < Minitest::Test
     server.stop
   end
 
+  def test_mcp_is_error_reaches_the_agent_event_and_session
+    tools = { "lookup" => { description: "Looks up facts.", handler: lambda do |_args|
+      { "isError" => true,
+        "content" => [{ "type" => "text", "text" => "index unavailable" }] }
+    end } }
+    server = Mistri::Test::McpStubServer.new(tools: tools)
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "lookup",
+                                                              arguments: {} }] },
+                                             { text: "I will use another source." }
+                                           ])
+    events = []
+    agent = Mistri::Agent.new(provider:, tools: Mistri::MCP.tools(remote_client(server)))
+
+    agent.run("look it up") { |event| events << event }
+
+    event = events.find { |item| item.type == :tool_result }
+
+    assert_predicate event, :tool_error?
+    assert_predicate agent.session.messages.find(&:tool?), :tool_error?
+  ensure
+    server&.stop
+  end
+
   def test_an_ambiguous_delivery_warns_the_model_not_to_retry
     tools = { "send" => { description: "Sends once.", handler: ->(_) { "sent" } } }
     server = Mistri::Test::McpStubServer.new(tools: tools, drop_after: "tools/call")
@@ -87,6 +128,7 @@ class TestMcpBridge < Minitest::Test
 
     assert_match(/AmbiguousDeliveryError/, result.text)
     assert_match(/do not retry automatically/, result.text)
+    assert_predicate result, :tool_error?
     assert_equal 1, server.calls.length
   ensure
     server&.stop

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -37,6 +37,19 @@ class TestMessage < Minitest::Test
 
     assert_predicate message, :tool?
     assert_equal "call_1", message.tool_call_id
+    assert_predicate message, :tool_error_known?
+    refute_predicate message, :tool_error?
+  end
+
+  def test_tool_error_survives_json_and_legacy_absence_stays_unknown
+    failed = Mistri::Message.tool(content: "failed", tool_call_id: "call_1", tool_error: true)
+    restored = Mistri::Message.from_h(JSON.parse(JSON.generate(failed.to_h)))
+    legacy = Mistri::Message.from_h(role: "tool", content: [], tool_call_id: "call_0")
+
+    assert_predicate restored, :tool_error?
+    assert restored.to_h[:tool_error]
+    refute_predicate legacy, :tool_error_known?
+    assert_nil legacy.tool_error
   end
 
   def test_text_is_nil_on_a_pure_tool_call_turn
@@ -48,5 +61,9 @@ class TestMessage < Minitest::Test
   def test_invalid_role_and_stop_reason_raise
     assert_raises(ArgumentError) { Mistri::Message.new(role: :robot) }
     assert_raises(ArgumentError) { Mistri::Message.assistant(content: "x", stop_reason: :tired) }
+    assert_raises(ArgumentError) do
+      Mistri::Message.tool(content: "x", tool_call_id: "c1", tool_error: "yes")
+    end
+    assert_raises(ArgumentError) { Mistri::Message.new(role: :user, tool_error: false) }
   end
 end

--- a/test/test_openai_serializer.rb
+++ b/test/test_openai_serializer.rb
@@ -41,6 +41,16 @@ class TestOpenAISerializer < Minitest::Test
                  items[4])
   end
 
+  def test_failed_tool_results_do_not_invent_an_unsupported_wire_field
+    failed = Mistri::Message.tool(content: "unavailable", tool_call_id: "call_1",
+                                  tool_error: true)
+
+    item = SERIALIZER.input_items([failed]).first
+
+    assert_equal({ type: "function_call_output", call_id: "call_1", output: "unavailable" },
+                 item)
+  end
+
   def test_a_reasoning_item_missing_encrypted_content_is_dropped
     bare = { "type" => "reasoning", "id" => "rs_1", "summary" => [] }
     thinking = Mistri::Content::Thinking.new(thinking: "", signature: JSON.generate(bare))

--- a/test/test_session_healing.rb
+++ b/test/test_session_healing.rb
@@ -31,6 +31,8 @@ class TestSessionHealing < Minitest::Test
     interrupted = answers.find { |message| message.tool_call_id == "b" }
 
     assert_equal INTERRUPTED, interrupted.text
+    assert_match(/may have executed.*verify/i, interrupted.text)
+    assert_predicate interrupted, :tool_error?
     assert_equal 1, session.entries.count { |e| e.dig("message", "role") == "tool" },
                  "the stored log gained nothing"
   end

--- a/test/test_sinks.rb
+++ b/test/test_sinks.rb
@@ -40,9 +40,11 @@ class TestSinks < Minitest::Test
 
     sink.call(Mistri::Event.new(type: :start))
     sink.call(delta("partial answer"))
-    sink.call(Mistri::Event.new(type: :tool_result, content: "ran"))
+    call = Mistri::ToolCall.new(id: "c1", name: "run", arguments: {})
+    sink.call(Mistri::Event.new(type: :tool_started, tool_call: call))
+    sink.call(Mistri::Event.new(type: :tool_result, content: "ran", tool_error: false))
 
-    assert_equal %i[start text_delta tool_result], seen.map(&:type),
+    assert_equal %i[start text_delta tool_started tool_result], seen.map(&:type),
                  "the buffered delta flushes before the next non-delta event"
   end
 
@@ -112,6 +114,16 @@ class TestSinks < Minitest::Test
     assert_includes frames.last, "event: done"
   end
 
+  def test_sse_carries_tool_failure_as_json_data
+    io = StringIO.new
+    sink = Mistri::Sinks::SSE.new(io)
+
+    sink.call(Mistri::Event.new(type: :tool_result, content: "failed", tool_error: true))
+
+    assert_includes io.string, "event: tool_result"
+    assert_includes io.string, '"tool_error":true'
+  end
+
   def test_action_cable_broadcasts_event_hashes_to_the_stream
     broadcasts = []
     server = Object.new
@@ -125,6 +137,18 @@ class TestSinks < Minitest::Test
     assert_equal "agent_9", stream
     assert_equal :text_delta, payload[:type]
     assert_equal "hi", payload[:delta]
+  end
+
+  def test_action_cable_broadcasts_known_success_without_dropping_false
+    broadcasts = []
+    server = Object.new
+    server.define_singleton_method(:broadcast) { |_stream, payload| broadcasts << payload }
+    sink = Mistri::Sinks::ActionCable.new("agent_9", server: server)
+
+    sink.call(Mistri::Event.new(type: :tool_result, content: "ok", tool_error: false))
+
+    assert broadcasts.first.key?(:tool_error)
+    refute broadcasts.first.fetch(:tool_error)
   end
 
   def test_sinks_compose_as_blocks

--- a/test/test_sub_agent.rb
+++ b/test/test_sub_agent.rb
@@ -137,6 +137,7 @@ class TestSubAgent < Minitest::Test
     answer = agent.session.messages.select(&:tool?).last
 
     assert_includes answer.text, "cannot wait"
+    assert_predicate answer, :tool_error?
 
     child = Mistri::Session.new(store:, id: answer.ui["session_id"])
 
@@ -144,6 +145,7 @@ class TestSubAgent < Minitest::Test
     denial = child.messages.select(&:tool?).last
 
     assert_includes denial.text, "cannot pause"
+    assert_predicate denial, :tool_error?
   end
 
   def test_gating_the_delegation_itself_suspends_the_parent
@@ -185,7 +187,10 @@ class TestSubAgent < Minitest::Test
     result = agent.run("go")
 
     assert_predicate result, :completed?
-    assert_includes agent.session.messages.select(&:tool?).last.text, "failed"
+    answer = agent.session.messages.select(&:tool?).last
+
+    assert_includes answer.text, "failed"
+    assert_predicate answer, :tool_error?
   end
 
   def test_child_models_come_only_from_the_host_allowlist

--- a/test/test_tool.rb
+++ b/test/test_tool.rb
@@ -136,7 +136,67 @@ class TestTool < Minitest::Test
     result = agent.run("go")
 
     assert_predicate result, :completed?
-    assert_match(/timed out after 0.1s/, agent.session.messages.select(&:tool?).last.text)
+    answer = agent.session.messages.select(&:tool?).last
+
+    assert_match(/timed out after 0.1s/, answer.text)
+    assert_predicate answer, :tool_error?
+  end
+
+  def test_a_handler_timeout_error_is_not_mislabeled_as_the_configured_timeout
+    tool = Mistri::Tool.define("upstream", "Calls upstream.", timeout: 1) do
+      raise Timeout::Error, "upstream timed out"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "upstream",
+                                                              arguments: {} }] },
+                                             { text: "done" }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [tool])
+
+    agent.run("go")
+
+    answer = agent.session.messages.select(&:tool?).last
+
+    assert_includes answer.text, "Timeout::Error: upstream timed out"
+    refute_includes answer.text, "timed out after 1s"
+    assert_predicate answer, :tool_error?
+  end
+
+  def test_abort_at_the_serialized_start_boundary_never_announces_the_next_call
+    signal = Mistri::AbortSignal.new
+    resolved = Queue.new
+    ran = []
+    definitions = %w[a b].to_h do |name|
+      tool = Mistri::Tool.define(name, "Runs.") do
+        ran << name
+        name
+      end
+      [name, tool]
+    end
+    lookup = Object.new
+    lookup.define_singleton_method(:[]) do |name|
+      resolved << name
+      definitions[name]
+    end
+    calls = %w[a b].map { |name| Mistri::ToolCall.new(id: name, name:, arguments: {}) }
+    started = []
+    emit = lambda do |event|
+      next unless event.type == :tool_started
+
+      2.times { resolved.pop } if started.empty?
+      started << event.tool_call.name
+      signal.abort!(:test) if started.length == 1
+    end
+
+    results = Mistri::ToolExecutor.call(calls, lookup, signal:, max_concurrency: 2, emit:)
+
+    assert_equal 1, started.length
+    assert_equal started, ran
+    interrupted = results.find { |call, _result, _duration| call.name != started.first }
+
+    assert_predicate interrupted[1], :error?
+    assert_equal Mistri::ToolExecutor::INTERRUPTED, interrupted[1].content
+    assert_nil interrupted[2]
   end
 
   def test_tool_results_carry_their_duration

--- a/test/test_tool_lifecycle.rb
+++ b/test/test_tool_lifecycle.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Tool lifecycle events distinguish execution commitment from typed outcomes.
+class TestToolLifecycle < Minitest::Test
+  def test_lifecycle_is_typed_without_sniffing_content
+    seen_before_each_handler = []
+    starts = []
+    first = Mistri::Tool.define("first", "First.") do
+      seen_before_each_handler << starts.dup
+      "Error is just the first word of this successful result"
+    end
+    second = Mistri::Tool.define("second", "Second.") do
+      seen_before_each_handler << starts.dup
+      Mistri::ToolResult.new(content: "ordinary text", error: true)
+    end
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "first", arguments: {} },
+                                                            { name: "second", arguments: {} }] },
+                                             { text: "done" }
+                                           ])
+    results = []
+
+    Mistri::Agent.new(provider:, tools: [first, second], max_concurrency: 1).run("go") do |event|
+      starts << event.tool_call.name if event.type == :tool_started
+      results << event if event.type == :tool_result
+    end
+
+    assert_equal [["first"], %w[first second]], seen_before_each_handler,
+                 "a queued call announces only when its own handler is next"
+    assert_equal [false, true], results.map(&:tool_error)
+    assert_equal([false, true], results.map { |event| event.message.tool_error })
+  end
+
+  def test_unknown_tools_fail_without_claiming_execution_started
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "missing", arguments: {} }] },
+                                             { text: "recovered" }
+                                           ])
+    events = []
+
+    Mistri::Agent.new(provider:).run("go") { |event| events << event }
+
+    refute(events.any? { |event| event.type == :tool_started })
+    result = events.find { |event| event.type == :tool_result }
+
+    assert result.tool_error
+    assert_nil result.duration
+  end
+
+  def test_a_start_subscriber_error_propagates_without_running_the_tool
+    ran = false
+    tool = Mistri::Tool.define("write", "Writes.") do
+      ran = true
+      "written"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "write", arguments: {} }] }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [tool])
+
+    error = assert_raises(RuntimeError) do
+      agent.run("go") { |event| raise "subscriber failed" if event.type == :tool_started }
+    end
+
+    assert_equal "subscriber failed", error.message
+    refute ran
+    tool_ids = agent.session.entries.filter_map { |entry| entry.dig("message", "tool_call_id") }
+
+    assert_empty tool_ids
+  end
+
+  def test_a_start_subscriber_error_latches_before_another_worker_can_commit
+    resolved = Queue.new
+    ran = []
+    definitions = %w[a b].to_h do |name|
+      tool = Mistri::Tool.define(name, "Runs.") do
+        ran << name
+        name
+      end
+      [name, tool]
+    end
+    lookup = Object.new
+    lookup.define_singleton_method(:[]) do |name|
+      resolved << name
+      definitions[name]
+    end
+    calls = %w[a b].map { |name| Mistri::ToolCall.new(id: name, name:, arguments: {}) }
+    started = []
+    emit = lambda do |event|
+      next unless event.type == :tool_started
+
+      2.times { resolved.pop } if started.empty?
+      started << event.tool_call.name
+      raise "subscriber failed"
+    end
+
+    error = assert_raises(RuntimeError) do
+      Mistri::ToolExecutor.call(calls, lookup, max_concurrency: 2, emit:)
+    end
+
+    assert_equal "subscriber failed", error.message
+    assert_equal 1, started.length
+    assert_empty ran, "no handler commits after the subscriber boundary fails"
+  end
+
+  def test_a_progress_subscriber_error_is_not_mislabeled_as_a_handler_failure
+    later_ran = false
+    progress = Mistri::Tool.define("progress", "Reports progress.") do |_args, context|
+      context.emit.call(Mistri::Event.new(type: :compacting))
+
+      flunk "continued after its progress subscriber failed"
+    end
+    later = Mistri::Tool.define("later", "Runs later.") do
+      later_ran = true
+      "done"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "progress", arguments: {} },
+                                                            { name: "later", arguments: {} }] }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [progress, later], max_concurrency: 1)
+
+    error = assert_raises(IOError) do
+      agent.run("go") { |event| raise IOError, "subscriber failed" if event.type == :compacting }
+    end
+
+    assert_equal "subscriber failed", error.message
+    refute later_ran
+    tool_ids = agent.session.entries.filter_map { |entry| entry.dig("message", "tool_call_id") }
+
+    assert_empty tool_ids, "subscriber failures never persist as tool outcomes"
+  end
+
+  def test_a_configured_timeout_inside_progress_delivery_remains_a_tool_timeout
+    tool = Mistri::Tool.define("progress", "Reports progress.", timeout: 0.05) do |_args, context|
+      context.emit.call(Mistri::Event.new(type: :compacting))
+      "done"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "progress",
+                                                              arguments: {} }] },
+                                             { text: "recovered" }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [tool])
+
+    agent.run("go") { |event| sleep 0.2 if event.type == :compacting }
+
+    answer = agent.session.messages.select(&:tool?).last
+
+    assert_includes answer.text, "timed out after 0.05s"
+    assert_predicate answer, :tool_error?
+  end
+
+  def test_a_worker_that_dies_after_start_returns_an_unknown_outcome
+    tool = Mistri::Tool.define("exit", "Exits its worker.") { Thread.exit }
+    call = Mistri::ToolCall.new(id: "c1", name: "exit", arguments: {})
+    events = []
+
+    emit = lambda do |event|
+      events << event
+    end
+    result = Mistri::ToolExecutor.call([call], { "exit" => tool }, emit:).first
+
+    assert_equal [:tool_started], events.map(&:type)
+    assert_predicate result[1], :error?
+    assert_equal Mistri::ToolExecutor::OUTCOME_UNKNOWN, result[1].content
+    assert_match(/verify.*before retrying/i, result[1].content)
+    assert_nil result[2]
+  end
+
+  def test_parallel_results_keep_model_order_after_the_batch_joins
+    release = Queue.new
+    slow_started = Queue.new
+    fast_done = Queue.new
+    events = Queue.new
+    slow = Mistri::Tool.define("slow", "Slow.") do
+      slow_started << true
+      release.pop
+      "slow result"
+    end
+    fast = Mistri::Tool.define("fast", "Fast.") do
+      fast_done << true
+      "fast result"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "slow", arguments: {} },
+                                                            { name: "fast", arguments: {} }] },
+                                             { text: "done" }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [slow, fast], max_concurrency: 2)
+    run = Thread.new { agent.run("go") { |event| events << event } }
+
+    slow_started.pop
+    fast_done.pop
+    before_release = []
+    before_release << events.pop until events.empty?
+
+    refute(before_release.any? { |event| event.type == :tool_result },
+           "a fast sibling result waits for the deterministic batch barrier")
+    release << true
+    run.value
+    arrived = before_release
+    arrived << events.pop until events.empty?
+    result_names = arrived.select { |event| event.type == :tool_result }
+                          .map { |event| event.tool_call.name }
+
+    assert_equal %w[slow fast], result_names
+  ensure
+    release << true if release && release.empty?
+    run&.join
+  end
+end

--- a/test/test_tool_lifecycle.rb
+++ b/test/test_tool_lifecycle.rb
@@ -153,21 +153,41 @@ class TestToolLifecycle < Minitest::Test
     assert_predicate answer, :tool_error?
   end
 
-  def test_a_worker_that_dies_after_start_returns_an_unknown_outcome
+  def test_a_worker_that_dies_distinguishes_its_outcome_from_queued_calls
+    later_ran = false
     tool = Mistri::Tool.define("exit", "Exits its worker.") { Thread.exit }
-    call = Mistri::ToolCall.new(id: "c1", name: "exit", arguments: {})
+    later = Mistri::Tool.define("later", "Runs later.") do
+      later_ran = true
+      "done"
+    end
+    calls = [Mistri::ToolCall.new(id: "c1", name: "exit", arguments: {}),
+             Mistri::ToolCall.new(id: "c2", name: "later", arguments: {})]
     events = []
 
-    emit = lambda do |event|
-      events << event
-    end
-    result = Mistri::ToolExecutor.call([call], { "exit" => tool }, emit:).first
+    results = Mistri::ToolExecutor.call(calls, { "exit" => tool, "later" => later },
+                                        max_concurrency: 1, emit: ->(event) { events << event })
 
     assert_equal [:tool_started], events.map(&:type)
-    assert_predicate result[1], :error?
-    assert_equal Mistri::ToolExecutor::OUTCOME_UNKNOWN, result[1].content
-    assert_match(/verify.*before retrying/i, result[1].content)
-    assert_nil result[2]
+    assert_predicate results[0][1], :error?
+    assert_equal Mistri::ToolExecutor::OUTCOME_UNKNOWN, results[0][1].content
+    assert_match(/verify.*before retrying/i, results[0][1].content)
+    assert_equal Mistri::ToolExecutor::INTERRUPTED, results[1][1].content
+    assert_nil results[0][2]
+    assert_nil results[1][2]
+    refute later_ran
+  end
+
+  def test_worker_outcomes_do_not_depend_on_a_lifecycle_subscriber
+    tool = Mistri::Tool.define("exit", "Exits its worker.") { Thread.exit }
+    later = Mistri::Tool.define("later", "Runs later.") { flunk "queued call ran" }
+    calls = [Mistri::ToolCall.new(id: "c1", name: "exit", arguments: {}),
+             Mistri::ToolCall.new(id: "c2", name: "later", arguments: {})]
+
+    results = Mistri::ToolExecutor.call(calls, { "exit" => tool, "later" => later },
+                                        max_concurrency: 1)
+
+    assert_equal Mistri::ToolExecutor::OUTCOME_UNKNOWN, results[0][1].content
+    assert_equal Mistri::ToolExecutor::INTERRUPTED, results[1][1].content
   end
 
   def test_parallel_results_keep_model_order_after_the_batch_joins
@@ -210,5 +230,25 @@ class TestToolLifecycle < Minitest::Test
   ensure
     release << true if release && release.empty?
     run&.join
+  end
+
+  def test_result_ordering_does_not_trust_provider_call_ids
+    first = Mistri::Tool.define("first", "First.") { "first result" }
+    second = Mistri::Tool.define("second", "Second.") { "second result" }
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ id: "same", name: "first",
+                                                              arguments: {} },
+                                                            { id: "same", name: "second",
+                                                              arguments: {} }] },
+                                             { text: "done" }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [first, second], max_concurrency: 1)
+
+    agent.run("go")
+
+    answers = agent.session.messages.select(&:tool?)
+
+    assert_equal %w[first second], answers.map(&:tool_name)
+    assert_equal ["first result", "second result"], answers.map(&:text)
   end
 end

--- a/test/test_tool_result_ui.rb
+++ b/test/test_tool_result_ui.rb
@@ -7,6 +7,10 @@ require_relative "test_helper"
 class TestToolResultUi < Minitest::Test
   MARKER = "UI_ONLY_PAYLOAD_9Z"
 
+  def test_error_must_be_boolean
+    assert_raises(ArgumentError) { Mistri::ToolResult.new(content: "x", error: nil) }
+  end
+
   def test_content_reaches_the_model_and_ui_reaches_the_host
     store = Mistri::Stores::Memory.new
     provider = Mistri::Providers::Fake.new(turns: [
@@ -62,6 +66,23 @@ class TestToolResultUi < Minitest::Test
     end
   end
 
+  def test_legacy_unknown_tool_status_keeps_the_historical_provider_wire_shape
+    legacy = Mistri::Message.from_h(
+      "role" => "tool", "content" => [{ "type" => "text", "text" => "old result" }],
+      "tool_call_id" => "c1", "tool_name" => "lookup"
+    )
+
+    anthropic = Mistri::Providers::Anthropic::Serializer.messages([legacy])
+    gemini = Mistri::Providers::Gemini::Serializer.contents([legacy])
+    openai = Mistri::Providers::OpenAI::Serializer.input_items([legacy])
+
+    refute_predicate legacy, :tool_error_known?
+    refute anthropic.first[:content].first.key?(:is_error)
+    assert_equal({ "result" => "old result" },
+                 gemini.first[:parts].first[:functionResponse][:response])
+    assert_equal "old result", openai.first[:output]
+  end
+
   def test_plain_returns_still_carry_no_ui
     provider = Mistri::Providers::Fake.new(turns: [
                                              { tool_calls: [{ name: "plain", arguments: {} }] },
@@ -87,5 +108,29 @@ class TestToolResultUi < Minitest::Test
 
     assert_equal '{"total":42}', result.content, "data content still serializes as JSON"
     assert_equal({ "rows" => [[1], [2]] }, result.ui)
+  end
+
+  def test_handler_declared_failure_keeps_ui_and_error_through_the_session
+    store = Mistri::Stores::Memory.new
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "lookup",
+                                                              arguments: {} }] },
+                                             { text: "done" }
+                                           ])
+    tool = Mistri::Tool.define("lookup", "Looks up.") do
+      Mistri::ToolResult.new(content: "Unavailable.", ui: { retryable: false }, error: true)
+    end
+    session = Mistri::Session.new(store:)
+    events = []
+
+    Mistri::Agent.new(provider:, tools: [tool], session:).run("go") { |event| events << event }
+
+    event = events.find { |item| item.type == :tool_result }
+    reloaded = Mistri::Session.new(store:, id: session.id).messages.find(&:tool?)
+
+    assert event.tool_error
+    assert_predicate event.message, :tool_error?
+    assert_predicate reloaded, :tool_error?
+    assert_equal({ "retryable" => false }, reloaded.ui)
   end
 end


### PR DESCRIPTION
## Summary

- emit `:tool_started` at the serialized execution-commit boundary
- carry an explicit tool failure fact through `ToolResult`, events, persisted messages, session healing, hooks, sub-agents, and MCP
- distinguish committed-but-unanswered calls from untouched queue entries after hard worker loss
- settle executed, blocked, rejected, and denied outcomes in same-batch model-call order without trusting provider call IDs
- project failures into Anthropic `is_error` and Gemini function-response `error` while retaining OpenAI's supported textual output shape
- preserve legacy session truth: historical results remain unknown rather than being inferred from prose

## Contract

A failed result never authorizes an automatic replay because a tool may have committed a side effect before failing. Subscriber failures remain host failures, approval denial remains a normal control outcome, and errored `ends_turn` tools still retain the host's structural floor-transfer policy.

The lifecycle signal adds one synchronous sink callback per committed call. Streaming construction adds only primitive checks and an immutable nil slot; it adds no parsing, buffering, I/O, or string work. Tool-result ordering is bounded linear post-batch work and stays off the token/SSE path.

Provider behavior follows the official [Anthropic tool-result contract](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls), [Gemini FunctionResponse contract](https://ai.google.dev/api/generate-content), [OpenAI Responses contract](https://platform.openai.com/docs/api-reference/responses), and [MCP tool-result contract](https://modelcontextprotocol.io/specification/2025-11-25/server/tools).

## Validation

- Ruby 3.2.9, 3.3.11, and 3.4.1: 660 tests, 2,590 assertions, all green
- 100 repeated edge-case seeds plus 60 independent lifecycle/concurrency seeds
- RuboCop: 172 files, no offenses
- coverage: 97.86% line, 85.75% branch
- live Anthropic, OpenAI, and Gemini tool-failure scenario
- independent API, concurrency, provider-wire, review-fix, and final adversarial reviews

Closes #6