### PR TITLE
Validate tool arguments before execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,131 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Model-originated tool calls now cross a local execution boundary rather than
+  relying on provider guidance alone. Completed calls deeply own immutable JSON,
+  canonicalize symbol keys without coercing values, retain malformed encoded
+  input as a durable `arguments_error`, and stop at 8 MiB, 64 levels, 10,000
+  nodes, or a 64 KiB numeric token. The same numeric bound applies to encoded
+  JSON and programmatic custom-provider arguments. The Agent requires an object
+  argument envelope before `before_tool`, approval predicates, `ends_turn`,
+  handlers, or remote MCP calls. Invalid calls receive a bounded typed result in
+  band, emit no execution-start event, expose no received field values in core
+  errors, and do not prevent valid siblings from running. Results settled in
+  the same phase return in model-call order.
+  Completed tool-call IDs, names, signatures, and provider correlation IDs must
+  be non-empty UTF-8 strings. Internal IDs are unique for the session, and
+  provider correlation IDs are unique within one assistant turn. A malformed
+  call envelope or a non-assistant provider result rejects the whole provider
+  attempt before persistence, policy, or execution. The normal provider retry
+  contract retries unchanged history; exhaustion persists a pairable error with
+  no tool calls. An abort during normalization, validation, policy, or approval
+  evaluation interrupts every uncommitted call and parks no approval. Custom
+  providers that emitted missing, blank, non-string, non-UTF-8, or duplicate
+  identifiers must correct their completed call contract. Each run or resume
+  validates every persisted message and audits call identity in one control-state
+  preflight before doing work, so malformed legacy history fails closed. The
+  preceding assistant entry remains the durable provider source; a normalized
+  approval stores the reviewed prepared call plus an explicit provenance
+  marker. Resume verifies pairing metadata and revalidates the exact approved
+  arguments without rerunning the normalizer. Requests must follow the exact
+  assistant call, decisions must follow one request and carry an exact boolean,
+  and duplicate or late control records fail closed. Legacy requests remain
+  valid only when they exactly mirror the source call.
+  Persisted tool results require one prior call with the exact name, settle in
+  assistant-call order within each direct or approval phase, and cannot cross
+  an unresolved approval; compaction may neither hide an open approval nor
+  split a completed call from its result.
+  `ToolCall#arguments_error?` is stable; its non-nil string remains an opaque
+  diagnostic rather than a public enum. Fake-provider default call IDs now use
+  a per-provider UUID namespace plus a monotonic sequence; explicitly scripted
+  `id:` values remain deterministic. New approval entries no longer duplicate
+  the source argument payload, and generated MySQL-family session tables use
+  LONGTEXT so a legal parallel tool turn is not constrained by MEDIUMTEXT's
+  16 MiB ceiling. Existing MySQL-family stores must migrate `payload` to
+  `size: :long`; generators cannot alter an installed table. `Stores::Memory`
+  owns durable appends while returning fresh mutable snapshots, matching stores
+  that decode each read.
+- Tool schemas compile once into the same deeply frozen canonical UTF-8 JSON
+  value used by provider serializers, so mutation and Ruby encoding cannot make
+  local validation disagree with the wire. Definition checks cover the complete
+  schema document. The zero-dependency runtime subset enforces JSON types and
+  unions, `enum`, `required`, `properties`, `prefixItems`, one-schema `items`,
+  boolean schemas, and boolean or schema-valued `additionalProperties`.
+  `argument_validator:` adds domain rules without weakening core;
+  `complete_argument_validator:` is separate explicit authority for every
+  non-empty `patternProperties` contract. Tool inputs use
+  JSON Schema 2020-12 and require an object root; legacy array-form `items` is
+  rejected in favor of `prefixItems`. A schema-less Tool is now a genuinely
+  closed no-argument contract; hosts that accepted model fields without
+  declaring them must add an explicit schema. Supplied object schemas preserve
+  JSON Schema's default-open semantics unless a raw schema explicitly sets
+  `additionalProperties: false`; handlers should extract named fields instead
+  of mass-assigning model input. MCP bridging requires the complete validator
+  for every unimplemented standard constraint or applicator, rejects external
+  references and explicit `inputSchema: null`, and still defaults an omitted
+  schema to a no-argument object. Common map schemas work in core. Task mode
+  rejects assertions and required vocabularies local validation cannot guarantee
+  before making a provider request, then shares one deeply frozen strict schema
+  between its prompt and compiled local validator.
+  Providers derive a native constraint only for schema shapes their documented
+  and live-verified subsets accept; incompatible shapes fall back to the prompt
+  and local correction loop instead of failing the request. Native constraints
+  are limited to catalogued matching-provider models and documented provider
+  complexity ceilings; unknown models keep the local path. Raw task output is
+  byte-bounded, then lexically
+  width/depth-bounded before JSON parsing so wide hostile JSON is rejected
+  before parser allocation. A Tool-owned `argument_normalizer:` remains the
+  explicit compatibility seam and runs once before validation; approved calls
+  persist that canonical value and revalidate against the current schema on
+  resume without renormalizing or reevaluating approval. `edit_file` declares
+  its existing alias and string-boolean tolerance through that seam and rejects
+  alias collisions. Provider replay substitutes `{}` only as the wire placeholder
+  for an already rejected call, paired with its error result. Direct `Tool#call`
+  remains a trusted host path and skips Agent validation. Task output now uses
+  the same JSON resource limits. This is minor-release behavior for hosts whose
+  policy or handlers previously received malformed values, whose custom
+  validators relied on implicit full-schema authority, or whose code mutated or
+  indexed a Tool's raw schema with symbol keys. `Schema.strict` results are now
+  deeply frozen, and `Tool.define` raises when both `input_schema:` and `schema:`
+  are supplied instead of silently choosing one. Definition compilation is paid
+  once; a completed call adds one bounded ownership pass and one compiled schema
+  traversal, plus ownership only when a normalizer replaces the value. Streaming
+  tool snapshots deep-freeze each newly refreshed bounded preview once; deltas
+  that reuse the cached preview are O(1), and pairing strings are copied.
+  Completed call envelope verification is one linear pass over that turn's
+  calls. Run and resume add one linear control-state read of the session log to
+  seed O(1) identity checks. Encoded Anthropic/OpenAI arguments and task text add
+  one linear lexical scan before JSON parsing; it is off the token-delta path. A
+  normalized approval adds only a small provenance marker. Structured
+  output request building adds one bounded schema ownership pass; task plans
+  compile their local validator once, with no added work on token streaming.
+  Arguments are now deeply frozen before hooks and handlers; hosts that mutated
+  model-supplied hashes or arrays must copy them first.
+- Provider replay now keeps opaque state with its provider of origin. Gemini
+  sends tool schemas through `parametersJsonSchema`, preserves each signed part
+  boundary, and returns Google's function-call ID exactly when one was supplied;
+  legacy calls without a wire ID get a collision-safe internal ID without
+  mutating the signed provider part. On pre-3 Gemini turns, an earlier gated
+  same-name/no-ID call is rejected in band if a later sibling would answer
+  first; Gemini 3 wire IDs retain out-of-order pairing. A MAX_TOKENS turn never
+  executes a returned call. OpenAI treats a missing completed `arguments` field
+  as malformed instead of executing `{}`. Anthropic and OpenAI no longer place
+  another provider's signatures on their wire. These replay checks add constant
+  metadata work per completed block. Terminal records now fence later known
+  content for all three providers. Anthropic enforces
+  sequential and open content-block indexes plus the delta kind expected by the
+  open block. OpenAI enforces one open output item, its kind, any present item or
+  output-index correlation, and terminal event/status agreement. Unknown future
+  event types remain ignorable. The checks add only constant primitive
+  comparisons per known delta, with no parsing, copying, or I/O.
+  Completed foreign tool exchanges project to neutral text when a session
+  moves to Gemini, preserving the result without manufacturing a Gemini
+  function call that lacks Google's thought signature.
+  Real providers now emit the same initial `:start` snapshot as the Fake, and
+  every opened text, thinking, or tool-call block emits its matching end before
+  a terminal failure. Interrupted tool calls remain explicitly incomplete and
+  are stripped before Agent persistence; interrupted Anthropic thinking never
+  replays a partial signature.
 - Tool execution now emits `:tool_started` when each resolved call commits to
   invocation and carries a structured failure fact end to end. A handler may
   return `ToolResult(error: true)`; unknown tools, policy blocks,
@@ -12,12 +137,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   hooks, healed dangling calls, and MCP `isError` results set it automatically.
   The flag is sticky through `after_tool` rewrites, so changing error text
   cannot relabel a failed operation as successful. `Event#tool_error` is always
-  true or false on `:tool_result`; new tool messages persist the same value, and legacy
-  messages without it remain unknown and replay with the historical unmarked
-  provider shape. Human approval denial remains a normal control outcome rather
-  than an execution error. Anthropic receives
-  `is_error: true`; Gemini receives the documented `error` function-response
-  key; OpenAI retains textual output because its function-call output has no
+  true or false on `:tool_result`; new tool messages persist the same value, and
+  legacy messages without it remain unknown and replay with the historical
+  unmarked provider shape. Human approval denial remains a normal control
+  outcome rather than an execution error. Anthropic receives `is_error: true`;
+  Gemini receives the documented `error` function-response key; OpenAI retains
+  textual output because its function-call output has no
   execution-error member. Error text is not classified by prefix, and an error
   bit never authorizes a mechanical replay because a side effect may already
   have happened; the model may still choose a new call, so hosts retain
@@ -27,14 +152,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   sink event per committed call. Partial streaming Event construction adds two
   primitive checks and one immutable nil slot; partial Message construction
   adds one nil check and one immutable nil slot, with no parsing, buffering,
-  I/O, or string work;
-  tool batches add one sentinel write at commitment and one identity check per
-  result so a hard worker exit distinguishes started calls from untouched queue
-  entries; same-batch ordering adds one short-lived identity map and a linear
-  post-join pass, plus a second identity map only when `after_tool` is configured;
+  I/O, or string work. Tool batches add one sentinel write at commitment and one
+  identity check per result so a hard worker exit distinguishes started calls
+  from untouched queue entries; same-batch ordering adds one short-lived
+  identity map and a linear post-join pass, plus a second identity map only when
+  `after_tool` is configured;
   starts arrive on serialized worker-thread callbacks, while same-batch results
-  still emit in model-call order after the batch joins. `:tool_started` and handler-progress
-  subscriber exceptions propagate and never become tool failures.
+  still emit in model-call order after the batch joins. `:tool_started` and
+  handler-progress subscriber exceptions propagate and never become tool
+  failures.
   Unknown, blocked, denied, queued, and pre-invocation interrupted calls add no
   start event.
 - A blockless nested object in the tool-schema DSL now declares a freeform JSON
@@ -59,8 +185,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   child, and requires a clean handshake before the next operation. Explicitly
   closing and reusing an MCP client also clears its session, negotiated
   protocol version, and server information before the fresh handshake.
-  The hot path adds one byte-count addition and comparison per JSON socket
-  fragment or SSE line fragment, with no per-token work.
+  Each completed SSE record also receives a bounded 20,001-token lexical
+  preflight, derived from the 10,000-node canonical limit, plus depth and 64 KiB
+  numeric-token ceilings before JSON parsing. A distinct
+  `ResponseTooComplexError` preserves the exact boundary and bounds Gemini
+  argument allocation inside its enclosing record. Either size or complexity
+  overflow resets an MCP wire and its negotiated session. An unconfirmed
+  `tools/call` outcome becomes ambiguous and is never replayed; a matching result
+  received before an invalid trailing SSE record remains authoritative, while
+  the next operation still performs a fresh handshake. Fragmented Anthropic and
+  OpenAI tool arguments also carry an aggregate 8 MiB cap across SSE records.
+  Their live partial preview stops reparsing after a bounded 64 KiB schedule
+  while raw delta events continue unchanged; OpenAI's completed item remains
+  authoritative. Fragmented Anthropic thinking
+  signatures stop immediately at the same aggregate ceiling rather than
+  growing quadratically or replaying a truncated opaque value.
+  The hot path adds one byte-count addition and comparison per JSON socket or SSE
+  line fragment, then one bounded linear lexical pass over each completed SSE
+  record before the provider's existing JSON parse.
 - Remote MCP and server-side OAuth requests now default to public HTTPS and
   direct connections. Every DNS answer is checked against the IANA
   special-purpose registries, including embedded NAT64 destinations; one unsafe
@@ -112,17 +254,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   PROHIBITED_CONTENT, SPII, the image verdicts) and blocked prompts
   (promptFeedback.blockReason, which previously read as a retryable
   truncated stream) fail fast as Mistri::InvalidRequestError with the
-  wire word in the message; its model fumbles and unknown stops
+  wire word in the message. MISSING_THOUGHT_SIGNATURE is a deterministic input
+  failure; its model fumbles and incomplete sentinels
   (MALFORMED_FUNCTION_CALL, UNEXPECTED_TOOL_CALL, TOO_MANY_TOOL_CALLS,
-  NO_IMAGE, and the catch-all OTHER pair, documented as unknown reasons
-  rather than rulings) error retryably. Anthropic's refusal
+  MALFORMED_RESPONSE, FINISH_REASON_UNSPECIFIED, NO_IMAGE, and the catch-all
+  OTHER pair, documented as unknown reasons rather than rulings) error retryably.
+  Anthropic's refusal
   stop reason fails fast carrying stop_details' category and explanation
   (the API's guidance is a different model, never a same-model retry),
   and model_context_window_exceeded maps to :length per its guidance.
-  OpenAI's incomplete_details content_filter fails fast instead of
-  reading as a completed answer. Partial content stays on the errored
-  message for hosts to show. Undocumented future stop reasons still
-  tolerate as clean stops, unchanged.
+  OpenAI's incomplete_details content_filter and structured-output refusal
+  parts or deltas fail fast instead of reading as a completed answer; unknown
+  incomplete reasons retry rather than becoming clean stops. Partial content
+  stays on the errored message for hosts to show. Genuinely undocumented future
+  Gemini stop reasons still tolerate as clean stops, unchanged. Anthropic and
+  OpenAI top-level stream errors now classify documented authentication,
+  request/policy, rate-limit, timeout, overload, and server failures by their
+  wire code rather than retrying deterministic 4xx errors.
+- Active session execution is not yet leased. Store appends from approvals,
+  steers, and reports remain concurrency-safe, but hosts must allow only one
+  `run` or `resume` at a time for a session. Even with one runner, a crash,
+  result-store failure, or subscriber exception after invocation but before
+  result persistence can leave an approved call open for at-least-once
+  re-execution. Simultaneous runners widen the same risk. Hosts must use
+  idempotency/reconciliation across that commit gap; durable atomic claiming is
+  the next synchronization feature, not simulated by a local mutex.
 - Sinks::Coalesced is origin-aware and thread-safe: a background worker's
   deltas no longer merge into the parent's (or another worker's) event at
   the same content index, and concurrent emitters serialize on an

--- a/README.md
+++ b/README.md
@@ -103,14 +103,94 @@ end
 ```
 
 This gives providers an open JSON object schema, where `{}` remains valid. Tool
-arguments remain untrusted input: use the description for generation guidance
-and validate domain semantics in the handler. An empty object block currently
-emits the same open schema.
+arguments remain untrusted input. Mistri owns each completed JSON value and the
+tool's provider-facing schema as immutable UTF-8, requires each completed
+argument value to be an object, and validates its portable schema subset before
+hooks, approval predicates, or handlers can see it. An invalid call receives an
+error result the model can correct; valid calls from the same turn still run.
+The core boundary never coerces model input; an explicit per-tool normalizer,
+described below, is the deliberate compatibility exception. Arguments are
+bounded at 8 MiB, 64 levels, 10,000 JSON nodes, and 64 KiB per numeric token;
+the numeric ceiling applies to both encoded JSON and programmatic
+custom-provider values. The byte ceiling includes the complete serialized JSON
+shape, not only string payloads. Encoded Anthropic/OpenAI arguments take a
+linear lexical width/depth pass before `JSON.parse`, so a wide or pathological
+numeric document stops before allocating its full tree. Each completed outer
+SSE record receives its own 20,001-token lexical preflight plus depth and 64 KiB
+numeric-token ceilings. This bounds Gemini arguments before their enclosing
+record is decoded; it is not a claim that an SSE envelope has already been
+reduced to 10,000 canonical argument nodes. For fragmented Anthropic and OpenAI
+calls, the byte ceiling applies across every delta; raw delta events still
+arrive, while partial snapshots retain a bounded, deeply frozen preview that
+refreshes on a capped schedule.
+
+Completed calls also need non-empty UTF-8 string names, IDs, and opaque pairing
+metadata, with IDs unique for the lifetime of the session. If a custom provider
+violates that envelope, Mistri rejects the whole attempt before persistence or
+policy and lets the configured provider retry request a clean turn; no sibling
+tool runs from the malformed attempt.
+
+`ToolCall#arguments_error?` is the public distinction between usable arguments
+and a durable malformed call. Its non-nil string is an opaque diagnostic, not a
+stable enum for application branching; use the predicate and the typed tool
+result instead.
+
+Every tool input schema must be a JSON Schema object with `type: "object"`.
+A tool defined without a schema is a closed no-argument tool; undeclared model
+fields are rejected before policy. Once a schema is supplied, object schemas
+keep JSON Schema's default-open semantics unless a raw schema explicitly sets
+`additionalProperties: false`. This includes DSL schemas with named properties,
+so handlers should extract declared fields rather than mass-assign the argument
+hash. Use a raw closed schema when extra keys must be rejected.
+Mistri uses JSON Schema 2020-12; an omitted `$schema` means that dialect, an
+explicit older dialect is rejected, and tuple arrays use `prefixItems` rather
+than the pre-2020-12 array form of `items`. The built-in validator enforces JSON
+types and type unions, `enum`, `required`, declared `properties`, `prefixItems`,
+one-schema array `items`, nested boolean schemas, and boolean or schema-valued
+`additionalProperties`. Other keywords remain provider-facing generation
+guidance unless the tool supplies a complete validator. This includes
+constraints such as `pattern`, `format`, and numeric or length bounds. An empty
+object block currently emits the same open schema.
 
 This freeform DSL shape cannot be represented by strict constrained output
 without changing its meaning, so `Schema.strict` raises instead of silently
 narrowing it to an object that only accepts `{}`. Use declared properties, or an
 explicitly closed raw schema, for constrained task output.
+
+Use `argument_validator:` for supplemental host or domain rules. It receives
+the same deeply frozen arguments and canonical schema that policy and execution
+use, and returns an array of model-readable violations. It cannot replace the
+arguments or weaken a core failure:
+
+```ruby
+invoice = Mistri::Tool.define(
+  "pay_invoice", "Pays an approved invoice.",
+  input_schema: invoice_schema,
+  argument_validator: lambda { |args, _schema|
+    args["invoice_id"].start_with?("inv_") ? [] : ["$.invoice_id must identify an invoice"]
+  }
+) do |args|
+  Invoices.pay!(args.fetch("invoice_id"))
+end
+```
+
+Use `complete_argument_validator:` when a host validator implements the full
+schema. It has the same `(args, schema)` contract, still runs only after core
+passes, and is deliberately distinct from a supplemental validator. Any
+non-empty `patternProperties` requires this explicit authority because core
+cannot enforce a pattern's value schema even when unmatched keys remain open.
+The two validator options are mutually exclusive.
+
+Validator errors are bounded before they reach a model; they should still
+describe expectations rather than include received field values or secrets.
+
+`argument_normalizer:` is the separate, explicit compatibility seam for a tool
+that intentionally accepts legacy aliases. It runs once before validation and
+must return a JSON object; the normalized value is what policy sees, what a
+human approves, and what the handler receives. It should be pure,
+deterministic, and idempotent. A direct `Tool#call` is a trusted host invocation:
+it applies that tool's normalizer for compatibility but does not run the Agent's
+model-input validation boundary.
 
 A tool result carries model content, host-only UI, and a failure fact. The
 `ui` payload rides the `:tool_result` event and persists with the session, but
@@ -118,12 +198,16 @@ never reaches a provider. Return `error: true` for an expected tool failure
 that the model should handle rather than treating as a successful answer:
 
 ```ruby
-Mistri::Tool.define("edit_page", "Applies a page edit.") do |args|
-  page = apply(args)
+Mistri::Tool.define("edit_page", "Applies a page edit.", schema: -> {
+  object :changes, "Page changes", required: true
+}) do |args|
+  page = apply(args.fetch("changes"))
   Mistri::ToolResult.new(content: "Saved.", ui: { "html" => page })
 end
 
-Mistri::Tool.define("lookup", "Looks up an account.") do |args|
+Mistri::Tool.define("lookup", "Looks up an account.", schema: -> {
+  string :id, "Account ID", required: true
+}) do |args|
   account = Accounts.find_by(id: args["id"])
   account || Mistri::ToolResult.new(content: "Account not found.", error: true)
 end
@@ -156,8 +240,10 @@ without closure gymnastics:
 agent = Mistri.agent("claude-opus-4-8", tools: tools,
                      context: { traveler: current_traveler })
 
-Mistri::Tool.define("book_hotel", "Books the chosen hotel.") do |args, context|
-  Bookings.create!(args, traveler: context.app[:traveler])
+Mistri::Tool.define("book_hotel", "Books the chosen hotel.", schema: -> {
+  string :hotel_id, "Hotel ID", required: true
+}) do |args, context|
+  Bookings.create!(args.fetch("hotel_id"), traveler: context.app[:traveler])
 end
 ```
 
@@ -186,8 +272,11 @@ The decision is a one-line session write from any process, any time later;
 
 ```ruby
 book_hotel = Mistri::Tool.define("book_hotel", "Books the chosen hotel.",
-                                 needs_approval: ->(args) { args["total_usd"].to_i > 500 }) do |args|
-  Bookings.create!(args)
+                                 schema: lambda {
+                                   number :total_usd, "Quoted total", required: true
+                                 },
+                                 needs_approval: ->(args) { args["total_usd"] > 500 }) do |args|
+  Bookings.create!(total_usd: args.fetch("total_usd"))
 end
 
 result = agent.run("Book the corner suite for the Lisbon trip")
@@ -202,6 +291,25 @@ Mistri.agent("claude-opus-4-8", tools: tools, session: reloaded).resume
 
 The harness renders nothing: it emits an `:approval_needed` event and your
 app draws the UI.
+
+The preceding assistant message remains the durable provider source. When a
+normalizer changes arguments, the approval stores the exact prepared call the
+human reviewed plus an explicit source marker. `resume` verifies pairing
+metadata and revalidates those approved arguments without rerunning a
+normalizer. Tool-call IDs are session-wide correlation keys; duplicate or
+malformed legacy histories fail before a handler or provider runs. Persisted
+results must follow one matching call with the same name and settle in call
+order within each direct or approval phase; a compaction boundary cannot hide
+an open approval or split a completed call from its result.
+
+Only one Agent may actively call `run` or `resume` for a session at a time.
+Concurrent appenders such as approval decisions, steers, and worker reports are
+supported. The current execution contract is still at-least-once across the
+gap between handler invocation and durable result persistence: a crash, store
+failure, or subscriber exception in that gap can leave an approved call open,
+and a later resume can execute it again. Simultaneous runners widen the same
+risk. Until durable atomic claims land, hosts must serialize active runners and
+make side effects idempotent or reconcilable.
 
 ## Steering
 
@@ -234,6 +342,11 @@ resumed = Mistri.agent("claude-opus-4-8", session: Mistri::Session.new(store:, i
 resumed.run("Now finish it.")
 ```
 
+Sessions can move between built-in providers. Opaque reasoning and pairing
+metadata only replays to its provider of origin. In particular, a completed
+foreign tool exchange becomes ordinary text for Gemini, preserving its result
+without manufacturing a signed Gemini function call.
+
 In Rails, generate a model (name it whatever you like) and use the
 ActiveRecord store:
 
@@ -244,6 +357,16 @@ $ bin/rails generate mistri:install AgentEntry
 ```ruby
 require "mistri/stores/active_record"
 store = Mistri::Stores::ActiveRecord.new(AgentEntry)
+```
+
+The `Stores::ActiveRecord` store needs LONGTEXT for `payload` on MySQL and Trilogy
+because one legal parallel tool turn can exceed MEDIUMTEXT even when each call
+stays inside its own limit. The generator uses `size: :long` for new
+MySQL-family tables. An existing installation needs its own migration; changing
+the generator cannot widen a table that already exists:
+
+```ruby
+change_column :agent_entries, :payload, :text, size: :long, null: false
 ```
 
 ## Compaction
@@ -283,7 +406,16 @@ its kept tail.
 A run that must end in JSON matching a schema. Tools run as usual; providers
 constrain the final answer natively where they can, and the answer is
 validated client-side everywhere. A violation goes back to the model once,
-then raises. You get a guaranteed shape or a loud error, never silence.
+then raises. Task output uses the same portable subset and 8 MiB, 64-level,
+10,000-node, and 64 KiB numeric-token limits as tool input. A schema containing
+an assertion outside that subset fails at configuration time instead of
+claiming a guarantee Mistri cannot enforce. The prompt and final local check
+share one deeply frozen strict schema snapshot. Each provider derives a native
+constraint only when its structured-output subset can represent that contract,
+the model is catalogued for that provider, and documented complexity ceilings
+are satisfied. Otherwise Mistri omits the native constraint and relies on the
+same prompt, validation, and correction loop. You get a guaranteed shape or a
+loud error, never silence.
 
 ```ruby
 schema = {
@@ -444,6 +576,24 @@ tools = Mistri::MCP.tools(client, prefix: "linear",
 agent = Mistri.agent("claude-opus-4-8", tools: tools)
 ```
 
+Common MCP map input schemas work with Mistri's portable validator through
+schema-valued `additionalProperties`. Because a remote schema can guard approval
+policy, any standard assertion outside that subset requires the host's explicit,
+zero-coercion complete validator:
+
+```ruby
+tools = Mistri::MCP.tools(
+  client,
+  complete_argument_validator: ->(args, schema) { validator.errors(args, schema) }
+)
+```
+
+Omitted MCP `inputSchema` means a no-argument object. Explicit `null` and
+non-object roots are configuration errors. Same-document `$ref` and
+`$dynamicRef` values are accepted only with a complete validator; external
+references are rejected so validation never performs hidden network or file
+resolution.
+
 Remote URLs are untrusted input. Mistri accepts public HTTPS destinations by
 default, rejects the whole DNS result when any answer is non-public, and pins an
 approved address while keeping the hostname for Host, SNI, and certificate
@@ -485,11 +635,21 @@ collisions fail loud instead of one server's tool silently shadowing another's.
 
 Inbound JSON bodies, individual SSE lines, and stdio JSON records default to an
 8 MiB `max_record_bytes:` ceiling. It limits one atomic record, not the total
-length of a stream. Oversized responses close the transport; for `tools/call`,
-the error explicitly says the operation may have completed and must not be
-retried automatically. For a trusted server, configure a larger explicit limit.
-Other paths surface `ResponseTooLargeError`; its `kind` and `limit` also ride a
-provider error turn as machine-readable data.
+length of a stream. Each completed SSE JSON record also gets one bounded linear
+lexical scan with a 20,001-token ceiling, plus depth and 64 KiB numeric-token
+ceilings, before parsing. That scan can raise `ResponseTooComplexError`; byte
+overflow raises `ResponseTooLargeError`. Both errors carry `kind` and `limit` as
+machine-readable data.
+
+Either boundary closes and resets the MCP wire, including its session, protocol
+version, and server information, so the next operation performs a fresh
+handshake. If an unconfirmed `tools/call` crosses either boundary, Mistri raises
+`AmbiguousDeliveryError`: the operation may have completed and must not be
+retried automatically. A matching result received before an invalid trailing
+SSE record remains authoritative, but the wire is still reset. For a trusted
+server, configure a larger explicit byte limit; the structural ceilings remain
+fixed.
+
 Large tool output is better stored by the server or host and returned as an MCP
 `resource_link`; Mistri renders its URI for the model and never fetches the
 target itself.
@@ -620,6 +780,19 @@ are loop-owned: `:done` and `:error` reach the subscriber only for the
 accepted attempt, so a recovered retry never flashes an error it then walks
 back.
 
+Every provider attempt begins with one `:start` event carrying an immutable
+empty assistant snapshot. Each opened text, thinking, or tool-call block then
+has a matched start/delta/end sequence, including before a terminal failure.
+
+Built-in assemblers fail malformed known stream lifecycles instead of accepting
+content that could become executable. Terminal records fence later known
+content. Anthropic requires sequential/open block indexes and a delta kind that
+matches the open block. OpenAI requires one open item, checks its kind and any
+present item/output correlation fields on known deltas, and requires terminal
+event and response status to agree. Unknown future event and block types remain
+ignorable for forward compatibility. Interrupted tool calls remain marked
+incomplete and are removed before Agent persistence or execution.
+
 Tool execution emits `:tool_started` when each resolved call commits to
 execution, then `:tool_result` with an explicit `tool_error` boolean. Calls
 still queued behind `max_concurrency`, blocked by policy, waiting for approval,
@@ -660,9 +833,10 @@ Mistri.agent("gemini-3.1-pro-preview",
 ## Testing
 
 `rake test` is hermetic and fast. The Fake provider streams like the real
-ones, tool-call arguments included: each delta's partial carries the
-in-progress call with arguments parsed so far, so a UI that renders tool
-input as it arrives tests headless. `rake integration` runs every feature
+ones for ordinary small fixtures, tool-call arguments included: its eager
+partials make UI tests simple, while real Anthropic/OpenAI assemblers expose a
+bounded cached preview under adversarial fragmentation. A UI that renders tool
+input as it arrives still tests headless. `rake integration` runs every feature
 end to end against real provider APIs, once per model in the matrix: an
 Anthropic, an OpenAI, and a Gemini model by default. Scenarios assert that
 coined codenames (a ghost of a word like `Wraithowyn` exists in no training
@@ -676,8 +850,9 @@ $ MISTRI_INTEGRATION_MODELS=claude-opus-4-8 bundle exec rake integration
 
 ## Roadmap
 
-Next up: strict tool schemas, provider-native MCP passthrough, and the
-hardening that falls out of the first production applications.
+Next up: atomic cross-process claims for active session runners,
+provider-native MCP passthrough, optional full JSON Schema adapters, and
+resource-backed handling for very large tool results.
 
 ## Credits
 

--- a/lib/generators/mistri/install/install_generator.rb
+++ b/lib/generators/mistri/install/install_generator.rb
@@ -41,13 +41,17 @@ module Mistri
 
       private
 
-      # MySQL TEXT caps at 64KB, which a single large tool result can blow
-      # through; MEDIUMTEXT holds 16MB. Postgres text is unbounded.
+      # A parallel tool turn can legitimately exceed MySQL MEDIUMTEXT even
+      # though each call stays inside its own input limit. Postgres text is unbounded.
       def payload_size
         adapter = ::ActiveRecord::Base.connection_db_config.adapter.to_s
-        adapter.match?(/mysql|trilogy/) ? ", size: :medium" : ""
+        payload_size_for(adapter)
       rescue StandardError
         ""
+      end
+
+      def payload_size_for(adapter)
+        adapter.to_s.match?(/mysql|trilogy/) ? ", size: :long" : ""
       end
     end
   end

--- a/lib/generators/mistri/install/templates/migration.rb.tt
+++ b/lib/generators/mistri/install/templates/migration.rb.tt
@@ -7,8 +7,8 @@ class Create<%= table_name.camelize %> < ActiveRecord::Migration[<%= ActiveRecor
       t.timestamps
     end
 
-    # One session has one writer; a colliding append must raise, never
-    # silently reorder entries.
+    # The unique position is the optimistic concurrency boundary for
+    # independent appenders; a collision retries at the next position.
     add_index :<%= table_name %>, [:session_id, :position], unique: true
   end
 end

--- a/lib/mistri.rb
+++ b/lib/mistri.rb
@@ -5,6 +5,7 @@ require_relative "mistri/errors"
 require_relative "mistri/stop_reason"
 require_relative "mistri/usage"
 require_relative "mistri/models"
+require_relative "mistri/tool_arguments"
 require_relative "mistri/tool_call"
 require_relative "mistri/content"
 require_relative "mistri/message"
@@ -55,6 +56,8 @@ require_relative "mistri/providers/gemini"
 
 # Mistri (مستری): the fixer. An agent harness for Ruby applications.
 module Mistri
+  private_constant :ToolArguments
+
   PROVIDERS = { anthropic: Providers::Anthropic, openai: Providers::OpenAI,
                 gemini: Providers::Gemini }.freeze
   API_KEY_ENV = { anthropic: "ANTHROPIC_API_KEY", openai: "OPENAI_API_KEY",

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -20,6 +20,13 @@ module Mistri
   # into the transcript at the next turn boundary, and a background child's
   # report arrives through the same inbox.
   class Agent # rubocop:disable Metrics/ClassLength -- lifecycle order is the class contract
+    MAX_ARGUMENT_VIOLATIONS = 8
+    MAX_ARGUMENT_ERROR_BYTES = 2048
+    MAX_VIOLATION_SOURCE_BYTES = 4096
+    TOOL_ARGUMENT_VALIDATOR = Tool.instance_method(:validate_arguments)
+    private_constant :MAX_ARGUMENT_VIOLATIONS, :MAX_ARGUMENT_ERROR_BYTES,
+                     :MAX_VIOLATION_SOURCE_BYTES, :TOOL_ARGUMENT_VALIDATOR
+
     # compaction defaults on so long sessions survive their context window;
     # pass false to disable, or a tuned Compaction. It only ever triggers
     # when the model's window is known (catalog or Compaction#window).
@@ -44,6 +51,8 @@ module Mistri
       @tools_by_name = @tools.to_h { |tool| [tool.name, tool] }
       raise ConfigurationError, "duplicate tool names" if @tools_by_name.length != @tools.length
 
+      @tool_specs, @external_tool_validators = compile_tool_contracts
+
       @budget = budget || Budget.new
       @budget.validate_provider!(@provider)
       @max_concurrency = max_concurrency
@@ -64,7 +73,7 @@ module Mistri
     # schema, natively where the provider supports it. task adds validation
     # on top; run alone does not validate.
     def run(input, images: [], signal: nil, output_schema: nil, &emit)
-      if @session.open_approvals.any?
+      if refresh_tool_control.any?
         raise ConfigurationError,
               "session is awaiting approvals; call resume"
       end
@@ -84,7 +93,7 @@ module Mistri
     # carries on as if it never stopped, unless a settled call's tool ends
     # the turn, in which case its execution was the run's last word.
     def resume(signal: nil, &emit)
-      open = @session.open_approvals
+      open = refresh_tool_control
       pending = open.select { |approval| approval[:decision].nil? }
       if pending.any?
         return Result.new(message: nil, status: :awaiting_approval,
@@ -93,6 +102,10 @@ module Mistri
       end
 
       executed = settle(open, signal, &emit)
+      if signal&.aborted?
+        last = @session.messages.reverse_each.find(&:assistant?)
+        return finished(last, Usage.zero, signal)
+      end
       if executed.any? { |call| ends_turn?(call) }
         last = @session.messages.reverse_each.find(&:assistant?)
         return finished(last, Usage.zero, signal, handed_off: true)
@@ -113,8 +126,10 @@ module Mistri
     # belongs to whoever answers, and re-prompting for JSON would steal it
     # back. Ask again once the answer arrives.
     def task(input, schema:, images: [], signal: nil, fixes: 1, &emit)
-      result = run(TaskOutput.prompt(input, schema), images: images, signal: signal,
-                                                     output_schema: schema, &emit)
+      plan = Schema.task_plan(schema)
+      result = run(
+        TaskOutput.prompt(input, plan), images:, signal:, output_schema: plan, &emit
+      )
       spent = result.usage
       fixes.downto(0) do |remaining|
         result = result.with(usage: spent)
@@ -122,11 +137,11 @@ module Mistri
         return result if result.handed_off?
 
         value = TaskOutput.parse(result.text)
-        errors = TaskOutput.errors(value, schema)
+        errors = TaskOutput.errors(value, plan)
         return result.with(output: value) if errors.empty?
         raise SchemaError, "task output failed validation: #{errors.join("; ")}" if remaining.zero?
 
-        result = run(TaskOutput.fix_prompt(errors), signal: signal, output_schema: schema, &emit)
+        result = run(TaskOutput.fix_prompt(errors), signal:, output_schema: plan, &emit)
         spent += result.usage
       end
     end
@@ -238,12 +253,14 @@ module Mistri
       end
       attempt = 0
       usage = Usage.zero
+      schema = provider_output_schema(output_schema)
       loop do
         held = nil
         gate = emit && ->(event) { event.terminal? ? held = event : emit.call(event) }
         message = @provider.stream(messages: history, system: @system,
-                                   tools: @tools.map(&:spec), signal: signal,
-                                   output_schema: output_schema, &gate)
+                                   tools: @tool_specs, signal: signal,
+                                   output_schema: schema, &gate)
+        message, held = enforce_tool_call_envelope(message, held)
         attempt_usage = message.usage || Usage.new
         validate_usage!(attempt_usage, message:, kind: "turn", &emit)
         usage += attempt_usage
@@ -257,8 +274,16 @@ module Mistri
         end
         emit&.call(held) if held
         @session.append_message(message)
+        reserve_tool_call_ids(message.tool_calls)
         return [message, usage]
       end
+    end
+
+    def provider_output_schema(output_schema)
+      return output_schema unless output_schema.respond_to?(:native_fallback?)
+      return output_schema.schema unless @provider.respond_to?(:native_output_schema)
+
+      @provider.native_output_schema(output_schema.schema)
     end
 
     def retry_turn?(error, attempt, signal)
@@ -317,30 +342,414 @@ module Mistri
         return [[], false]
       end
 
-      screened, blocked = screen(calls, signal, &emit)
-      parked, free, rejected = partition_approval(screened)
+      prepared, batch = prepare_tool_batch(calls, signal, &emit)
+      return interrupt_tool_turn(prepared, signal, &emit) unless batch
+
+      complete_tool_batch(calls, prepared, batch, signal, provider: assistant.provider, &emit)
+    end
+
+    def complete_tool_batch(source_calls, prepared, batch, signal, provider:, &emit)
+      batch = protect_gemini_result_order(prepared, batch) if provider == :gemini
+      invalid, blocked, parked, free, rejected = batch
       executed = execute(free, signal, &emit)
-      answer_results(calls, [*blocked, *rejected, *executed], executed:, signal:, &emit)
+      if signal&.aborted?
+        uncommitted = [*invalid, *blocked, *rejected].map(&:first) + parked
+        results = [*executed, *interrupted_results(uncommitted)]
+        answer_results(prepared, results, executed:, signal:, &emit)
+        return [[], executed_ends_turn?(executed)]
+      end
+
+      answer_results(prepared, [*invalid, *blocked, *rejected, *executed],
+                     executed:, signal:, &emit)
+      if signal&.aborted?
+        answer_results(prepared, interrupted_results(parked),
+                       executed: [], signal:, &emit)
+        return [[], executed_ends_turn?(executed)]
+      end
+
+      sources = source_calls.to_h { |call| [call.id, call] }
       parked.each do |call|
-        @session.append("approval_request", "call" => call.to_h)
+        source = sources.fetch(call.id)
+        data = { "call" => call.to_h }
+        data["prepared_from"] = "assistant" unless call == source
+        @session.append("approval_request", data)
         emit&.call(Event.new(type: :approval_needed, tool_call: call))
       end
-      [parked, executed.any? { |call, _result, _seconds| ends_turn?(call) }]
+      [parked, executed_ends_turn?(executed)]
+    end
+
+    def executed_ends_turn?(executed)
+      executed.any? { |call, _result, _seconds| ends_turn?(call) }
+    end
+
+    # Before Gemini 3, same-name parallel calls may have no wire IDs and only
+    # order pairs their responses. A later immediate result cannot pass an
+    # earlier parked result without becoming ambiguous.
+    def protect_gemini_result_order(prepared, batch)
+      invalid, blocked, parked, free, rejected = batch
+      positions = prepared.each_with_index.to_h { |call, index| [call.id, index] }
+      immediate = [*invalid, *blocked, *rejected].map(&:first) + free
+      unsafe, safe = parked.partition do |parked_call|
+        parked_call.provider_call_id.nil? && immediate.any? do |call|
+          call.provider_call_id.nil? && call.name == parked_call.name &&
+            positions.fetch(call.id) > positions.fetch(parked_call.id)
+        end
+      end
+      failures = unsafe.map do |call|
+        content = "Gemini returned parallel same-name calls without IDs across an approval " \
+                  "boundary. This tool did not run; retry those calls separately."
+        [call, ToolResult.new(content:, error: true), nil]
+      end
+      [invalid, blocked, safe, free, [*rejected, *failures]]
     end
 
     # Returns the calls that actually executed (denied ones only answer).
     def settle(open, signal, &)
       approved, denied = open.partition { |approval| approval[:decision]["approved"] }
-      cleared, blocked = screen(approved.map { |approval| approval[:call] }, signal, &)
+      approved_calls = approved.map { |approval| approval[:call] }
+      _prepared, valid, invalid = prepare_calls(
+        approved_calls, normalize: false, signal:
+      )
+      return interrupt_settlement(open, approved_calls, denied, signal, &) if signal&.aborted?
+
+      cleared, blocked = screen(valid, signal, &)
+      return interrupt_settlement(open, approved_calls, denied, signal, &) if signal&.aborted?
+
       executed = execute(cleared, signal, &)
-      denials = denied.map do |approval|
+      denials = denial_results(denied)
+      results = if signal&.aborted?
+                  uncommitted = [*invalid, *blocked].map(&:first)
+                  [*executed, *interrupted_results(uncommitted), *denials]
+                else
+                  [*invalid, *blocked, *executed, *denials]
+                end
+      answer_results(open.map { |approval| approval[:call] },
+                     results, executed:, signal:, &)
+      executed.map(&:first)
+    end
+
+    def interrupt_settlement(open, approved, denied, signal, &)
+      results = [*interrupted_results(approved), *denial_results(denied)]
+      answer_results(open.map { |approval| approval[:call] }, results,
+                     executed: [], signal:, &)
+      []
+    end
+
+    def denial_results(denied)
+      denied.map do |approval|
         note = approval[:decision]["note"]
         text = "The user denied this tool call#{note ? ": #{note}" : "."}"
         [approval[:call], text, nil]
       end
-      answer_results(open.map { |approval| approval[:call] },
-                     [*blocked, *executed, *denials], executed:, signal:, &)
-      executed.map(&:first)
+    end
+
+    # Provider output is untrusted until the call has resolved to a current
+    # tool, passed its one allowed normalization, and satisfied both core and
+    # host schema checks. Rejections stay paired in band, while valid siblings
+    # continue through policy and execution.
+    def prepare_calls(calls, normalize:, signal: nil)
+      calls.each_with_object([[], [], []]) do |call, (ordered, valid, rejected)|
+        if signal&.aborted?
+          ordered << call
+          next
+        end
+
+        prepared, result = prepare_call(call, normalize:, signal:)
+        ordered << prepared
+        if result
+          rejected << [prepared, result, nil]
+        else
+          valid << prepared
+        end
+      end
+    end
+
+    def prepare_tool_batch(calls, signal, &)
+      prepared, valid, invalid = prepare_calls(calls, normalize: true, signal:)
+      return [prepared, nil] if signal&.aborted?
+
+      screened, blocked = screen(valid, signal, &)
+      return [prepared, nil] if signal&.aborted?
+
+      parked, free, rejected = partition_approval(screened, signal)
+      return [prepared, nil] if signal&.aborted?
+
+      [prepared, [invalid, blocked, parked, free, rejected]]
+    end
+
+    def prepare_call(call, normalize:, signal: nil)
+      call = call.with unless call.arguments_owned?
+      tool = @tools_by_name[call.name]
+      return [call, unavailable_tool(call.name)] unless tool
+
+      if call.arguments_error
+        violation = if call.arguments_error == "invalid_json"
+                      "arguments were not valid JSON"
+                    else
+                      "arguments were not valid bounded JSON"
+                    end
+        return [call, argument_failure(call.name, violation)]
+      end
+      unless call.arguments.is_a?(Hash)
+        return [call, argument_failure(call.name, "arguments must be a JSON object")]
+      end
+
+      prepared, failure = normalize ? normalize_call(tool, call) : [call, nil]
+      return [prepared, nil] if signal&.aborted?
+      return [prepared, failure] if failure
+
+      [prepared, validate_call(tool, prepared)]
+    end
+
+    # Tool-result correlation is provider-owned opaque state. If any ID is
+    # unusable, the whole assistant attempt is unpairable: discard it before
+    # persistence and let the ordinary provider retry contract request a
+    # clean turn. Inventing an ID would corrupt Anthropic tool_use_id and
+    # OpenAI Responses call_id replay.
+    def enforce_tool_call_envelope(message, held)
+      unless message.is_a?(Message) && message.assistant?
+        return reject_provider_message(message, "provider turns must be assistant messages")
+      end
+
+      violation = tool_call_envelope_violation(message.tool_calls) ||
+                  provider_tool_call_violation(message)
+      incomplete = message.tool_calls.any? { |call| call.arguments_error == "incomplete" }
+      return [message, held] unless violation || incomplete
+
+      if [StopReason::ERROR, StopReason::ABORTED, StopReason::LENGTH,
+          StopReason::BUDGET].include?(message.stop_reason)
+        sanitized = Message.assistant(content: message.content.grep_v(ToolCall),
+                                      model: message.model, provider: message.provider,
+                                      usage: message.usage, stop_reason: message.stop_reason,
+                                      error_message: message.error_message, error: message.error)
+        terminal = Event.new(type: held&.type || :error, reason: sanitized.stop_reason,
+                             message: sanitized,
+                             error_message: held&.error_message || sanitized.error_message)
+        return [sanitized, terminal]
+      end
+
+      text = "The provider returned malformed tool-call metadata. No tools ran."
+      detail = violation || "tool-call arguments were incomplete"
+      failure = ProviderError.new("#{text} #{detail}.")
+      rejected = Message.assistant(content: text, model: message.model,
+                                   provider: message.provider, usage: message.usage,
+                                   stop_reason: StopReason::ERROR,
+                                   error_message: failure.message,
+                                   error: ErrorData.for(failure))
+      terminal = Event.new(type: :error, reason: StopReason::ERROR, message: rejected,
+                           error_message: failure.message)
+      [rejected, terminal]
+    end
+
+    def reject_provider_message(message, reason)
+      text = "The provider returned an invalid message. No tools ran."
+      failure = ProviderError.new("#{text} #{reason}.")
+      usage = message.usage if message.is_a?(Message)
+      rejected = Message.assistant(content: text, usage:, stop_reason: StopReason::ERROR,
+                                   error_message: failure.message,
+                                   error: ErrorData.for(failure))
+      terminal = Event.new(type: :error, reason: StopReason::ERROR, message: rejected,
+                           error_message: failure.message)
+      [rejected, terminal]
+    end
+
+    # Gemini cryptographically binds a function call to its continuation.
+    # Replacing malformed signed arguments with {} makes that continuation
+    # fail at the provider, so the only replay-safe boundary is the complete
+    # attempt: retry it without persisting any part of the bad turn.
+    def provider_tool_call_violation(message)
+      return unless message.provider == :gemini
+      return unless message.tool_calls.any? do |call|
+        call.arguments_error || !call.arguments.is_a?(Hash)
+      end
+
+      "Gemini function-call arguments must be a valid JSON object"
+    end
+
+    def tool_call_envelope_violation(calls)
+      seen = {}
+      seen_provider_ids = {}
+      calls.each do |call|
+        problem = call_id_problem(call.id)
+        return problem if problem
+
+        return "tool call IDs must be unique within a session" if @tool_call_ids.include?(call.id)
+
+        problem = call_name_problem(call.name)
+        return problem if problem
+
+        problem = call_signature_problem(call.signature)
+        return problem if problem
+
+        if call.respond_to?(:provider_call_id)
+          problem = provider_call_id_problem(call.provider_call_id)
+          return problem if problem
+          if call.provider_call_id && seen_provider_ids.key?(call.provider_call_id)
+            return "provider tool call IDs must be unique within an assistant turn"
+          end
+        end
+
+        return "tool call IDs must be unique within an assistant turn" if seen.key?(call.id)
+
+        seen[call.id] = true
+        seen_provider_ids[call.provider_call_id] = true if call.provider_call_id
+      end
+      nil
+    end
+
+    def refresh_tool_control
+      state = @session.tool_control_state
+      @tool_call_ids = state.fetch(:tool_call_ids)
+      state.fetch(:approvals)
+    end
+
+    def reserve_tool_call_ids(calls)
+      calls.each { |call| @tool_call_ids << call.id }
+    end
+
+    def call_name_problem(name)
+      return "a tool name was missing" if name.nil?
+      return "tool names must be strings" unless name.is_a?(String)
+      unless name.encoding == Encoding::UTF_8 && name.valid_encoding?
+        return "tool names must be valid UTF-8"
+      end
+      return "tool names must not be blank" if name.match?(/\A[[:space:]]*\z/)
+
+      nil
+    end
+
+    def call_id_problem(id)
+      return "a tool call ID was missing" if id.nil?
+      return "tool call IDs must be strings" unless id.is_a?(String)
+      unless id.encoding == Encoding::UTF_8 && id.valid_encoding?
+        return "tool call IDs must be valid UTF-8"
+      end
+      return "tool call IDs must not be blank" if id.match?(/\A[[:space:]]*\z/)
+
+      nil
+    end
+
+    def provider_call_id_problem(id)
+      return nil if id.nil?
+      return "provider tool call IDs must be strings" unless id.is_a?(String)
+      unless id.encoding == Encoding::UTF_8 && id.valid_encoding?
+        return "provider tool call IDs must be valid UTF-8"
+      end
+      return "provider tool call IDs must not be blank" if id.match?(/\A[[:space:]]*\z/)
+
+      nil
+    end
+
+    def call_signature_problem(signature)
+      return nil if signature.nil?
+      return "tool call signatures must be strings" unless signature.is_a?(String)
+      unless signature.encoding == Encoding::UTF_8 && signature.valid_encoding?
+        return "tool call signatures must be valid UTF-8"
+      end
+      return "tool call signatures must not be blank" if signature.match?(/\A[[:space:]]*\z/)
+
+      nil
+    end
+
+    def normalize_call(tool, call)
+      return [call, nil] unless tool.respond_to?(:normalize_arguments)
+
+      normalized = tool.normalize_arguments(call.arguments)
+      prepared = normalized.equal?(call.arguments) ? call : call.with(arguments: normalized)
+      if prepared.arguments_error || !prepared.arguments.is_a?(Hash)
+        return [prepared, preparation_failure(call.name, "normalizer", TypeError)]
+      end
+
+      [prepared, nil]
+    rescue StandardError => e
+      [call, preparation_failure(call.name, "normalizer", e.class)]
+    end
+
+    def validate_call(tool, call)
+      validator = @external_tool_validators[call.name]
+      errors = if tool.is_a?(Tool)
+                 TOOL_ARGUMENT_VALIDATOR.bind_call(tool, call.arguments, owned: true)
+               else
+                 validator&.violations(call.arguments, owned: true) || []
+               end
+      if errors.empty? && !tool.is_a?(Tool) && tool.respond_to?(:prepared_argument_violations)
+        errors = tool.prepared_argument_violations(call.arguments)
+      end
+      errors.empty? ? nil : argument_failure(call.name, *errors)
+    rescue StandardError => e
+      preparation_failure(call.name, "validator", e.class)
+    end
+
+    def argument_failure(name, *violations)
+      header = "Invalid arguments for tool #{tool_label(name)}:\n"
+      footer = "\nThe tool did not run. Correct the arguments and try again."
+      available = MAX_ARGUMENT_ERROR_BYTES - header.bytesize - footer.bytesize
+      shown = violations.first(MAX_ARGUMENT_VIOLATIONS)
+      shown[-1] = "additional violations were omitted" if violations.length > shown.length
+      lines = shown.map do |violation|
+        "- #{safe_violation(violation)}"
+      end
+      body = utf8_prefix(lines.join("\n"), available)
+      ToolResult.new(content: "#{header}#{body}#{footer}", error: true)
+    end
+
+    def unavailable_tool(name)
+      content = "Unknown tool #{tool_label(name)}. The tool did not run; choose an available tool."
+      ToolResult.new(content: utf8_prefix(content, MAX_ARGUMENT_ERROR_BYTES), error: true)
+    end
+
+    def preparation_failure(name, phase, error_class)
+      klass = safe_violation(error_class.name || "Exception")
+      content = "Tool #{tool_label(name)} could not prepare arguments: its argument #{phase} " \
+                "failed (#{utf8_prefix(klass, 120)}). The tool did not run. This is a host " \
+                "configuration failure; do not retry the same call unchanged."
+      ToolResult.new(content: utf8_prefix(content, MAX_ARGUMENT_ERROR_BYTES), error: true)
+    end
+
+    def compile_tool_contracts
+      validators = {}
+      specs = @tools.map do |tool|
+        raw = tool.spec
+        unless raw.is_a?(Hash)
+          raise ConfigurationError, "tool #{tool.name.inspect} spec must be a Hash"
+        end
+
+        spec = raw.transform_keys(&:to_sym)
+        schema = spec.fetch(:input_schema) do
+          raise ConfigurationError, "tool #{tool.name.inspect} spec needs input_schema"
+        end
+        if tool.is_a?(Tool)
+          schema = tool.input_schema
+        else
+          complete = tool.respond_to?(:prepared_argument_violations)
+          plan = Schema.tool_validator(schema, complete:)
+          validators[tool.name] = plan
+          schema = plan.schema
+        end
+        spec.merge(input_schema: schema).freeze
+      end
+      [specs.freeze, validators.freeze]
+    end
+
+    def tool_label(name)
+      safe = safe_violation(name)
+      JSON.generate(utf8_prefix(safe, 120))
+    end
+
+    def safe_violation(violation)
+      raw = violation.to_s
+      prefix = raw.byteslice(0, MAX_VIOLATION_SOURCE_BYTES).dup.force_encoding(raw.encoding)
+      prefix.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "?")
+            .gsub(/[[:space:]]+/, " ").strip
+    end
+
+    def utf8_prefix(text, bytes)
+      return text if text.bytesize <= bytes
+      return "" if bytes <= 3
+
+      prefix = text.byteslice(0, bytes - 3).dup.force_encoding(Encoding::UTF_8)
+      prefix = prefix.byteslice(0, prefix.bytesize - 1) until prefix.valid_encoding?
+      "#{prefix}..."
     end
 
     # Runs calls without persisting them; the caller commits and rewrites
@@ -348,10 +757,23 @@ module Mistri
     def execute(calls, signal, &emit)
       return [] if calls.empty?
 
-      ToolExecutor.call(calls, @tools_by_name, signal: signal,
-                                               max_concurrency: @max_concurrency,
-                                               session: @session, emit: emit,
-                                               app: @context)
+      ToolExecutor.call_with_outcomes(calls, @tools_by_name, signal: signal,
+                                                             max_concurrency: @max_concurrency,
+                                                             session: @session, emit: emit,
+                                                             app: @context,
+                                                             prepared_arguments: true)
+    end
+
+    def interrupt_tool_turn(calls, signal, &)
+      answer_results(calls, interrupted_results(calls), executed: [], signal:, &)
+      [[], false]
+    end
+
+    def interrupted_results(calls)
+      calls.map do |call|
+        result = ToolResult.new(content: ToolExecutor::INTERRUPTED, error: true)
+        [call, result, nil]
+      end
     end
 
     # A blocked call answers in band, so the model reads the reason and
@@ -362,6 +784,11 @@ module Mistri
 
       context = hook_context(signal, emit)
       calls.each_with_object([[], []]) do |call, (cleared, blocked)|
+        if signal&.aborted?
+          cleared << call
+          next
+        end
+
         reason = begin
           @before_tool.call(call, context)
         rescue StandardError => e
@@ -416,7 +843,7 @@ module Mistri
     def answer_results(calls, results, executed:, signal:, &emit)
       executed_results = if @after_tool
                            {}.compare_by_identity.tap do |index|
-                             executed.each { |result| index[result] = true }
+                             executed.each { |result| index[result] = true if result[3] }
                            end
                          end
       by_call = {}.compare_by_identity
@@ -437,8 +864,13 @@ module Mistri
       tool ? tool.needs_approval?(call.arguments) : false
     end
 
-    def partition_approval(calls)
+    def partition_approval(calls, signal = nil)
       calls.each_with_object([[], [], []]) do |call, (parked, free, rejected)|
+        if signal&.aborted?
+          free << call
+          next
+        end
+
         (gated?(call) ? parked : free) << call
       rescue StandardError => e
         content = "Error evaluating approval policy for tool #{call.name.inspect}: " \

--- a/lib/mistri/console.rb
+++ b/lib/mistri/console.rb
@@ -172,11 +172,22 @@ module Mistri
       calls = blocks.filter_map do |block|
         next unless block.is_a?(Hash) && block["type"] == "tool_call"
 
-        "#{block["name"]}(#{JSON.generate(block["arguments"] || {})[0, 80]})"
+        "#{block["name"]}(#{Console.render_arguments(block)})"
       end
       text = Console.text_of(message["content"])
       parts = [text[0, 240], *calls].reject { |part| part.to_s.empty? }
       "#{message["role"]}: #{parts.join(" | ")}" unless parts.empty?
+    end
+
+    def render_arguments(block)
+      if block["arguments_error"]
+        details = { "arguments_error" => block["arguments_error"] }
+        details = { "arguments" => block["arguments"] }.merge(details) if block.key?("arguments")
+        return JSON.generate(details)[0, 80]
+      end
+
+      arguments = block.key?("arguments") ? block["arguments"] : {}
+      JSON.generate(arguments)[0, 80]
     end
 
     def text_of(content)

--- a/lib/mistri/content.rb
+++ b/lib/mistri/content.rb
@@ -17,7 +17,10 @@ module Mistri
     # `signature` carries opaque provider metadata that must round-trip, such as
     # the OpenAI Responses message id and output phase.
     Text = Data.define(:text, :signature) do
-      def initialize(text:, signature: nil) = super(text: Content.freeze_string(text), signature:)
+      def initialize(text:, signature: nil)
+        signature = Content.freeze_string(signature) if signature.is_a?(String)
+        super(text: Content.freeze_string(text), signature:)
+      end
 
       def type = :text
 
@@ -29,6 +32,7 @@ module Mistri
     # filter hid, leaving only the signature.
     Thinking = Data.define(:thinking, :signature, :redacted) do
       def initialize(thinking:, signature: nil, redacted: false)
+        signature = Content.freeze_string(signature) if signature.is_a?(String)
         super(thinking: Content.freeze_string(thinking), signature:, redacted:)
       end
 
@@ -89,8 +93,10 @@ module Mistri
                      redacted: h.fetch("redacted", false))
       when "image" then Image.new(data: h["data"], mime_type: h["mime_type"])
       when "tool_call"
-        ToolCall.new(id: h["id"], name: h["name"], arguments: h["arguments"] || {},
-                     signature: h["signature"])
+        arguments = h.key?("arguments") ? h["arguments"] : {}
+        ToolCall.new(id: h["id"], name: h["name"], arguments:,
+                     signature: h["signature"], arguments_error: h["arguments_error"],
+                     provider_call_id: h["provider_call_id"])
       else raise ArgumentError, "unknown content block type #{h["type"].inspect}"
       end
     end

--- a/lib/mistri/errors.rb
+++ b/lib/mistri/errors.rb
@@ -65,7 +65,19 @@ module Mistri
       @kind = kind
       @limit = limit
       label = kind.to_s.tr("_", " ")
-      super("#{label} exceeded max_record_bytes (#{limit} bytes)")
+      super("#{label} exceeded the byte limit (#{limit} bytes)")
+    end
+  end
+
+  # A JSON protocol record crossed a structural boundary before parsing.
+  class ResponseTooComplexError < Error
+    attr_reader :kind, :limit
+
+    def initialize(kind:, limit:)
+      @kind = kind
+      @limit = limit
+      label = kind.to_s.tr("_", " ")
+      super("#{label} exceeded the complexity limit (#{limit})")
     end
   end
 
@@ -129,6 +141,9 @@ module Mistri
           "retry_after" => reason.retry_after }.compact
       when ResponseTooLargeError
         { "type" => "ResponseTooLargeError", "kind" => reason.kind.to_s,
+          "limit" => reason.limit }
+      when ResponseTooComplexError
+        { "type" => "ResponseTooComplexError", "kind" => reason.kind.to_s,
           "limit" => reason.limit }
       when ProviderError
         { "type" => reason.class.name.split("::").last, "status" => reason.status }.compact

--- a/lib/mistri/mcp.rb
+++ b/lib/mistri/mcp.rb
@@ -17,6 +17,10 @@ module Mistri
   # {"name", "description", "inputSchema"} hashes) and call_tool(name, args)
   # bridges the same way, so the official mcp gem's client plugs in too.
   module MCP
+    EMPTY_INPUT_SCHEMA = {
+      "type" => "object", "properties" => {}.freeze, "additionalProperties" => false
+    }.freeze
+
     # A protocol-level failure: a JSON-RPC error, a missing response, an
     # unsupported negotiation.
     class Error < Mistri::Error
@@ -44,23 +48,36 @@ module Mistri
     # prefix namespaces local names ("linear__create_issue") against
     # collisions, and gates marks tools needing human approval
     # (gates: { "create_issue" => true }, or needs_approval: for all).
-    def tools(client, allow: nil, deny: [], prefix: nil, needs_approval: false, gates: {})
+    def tools(client, allow: nil, deny: [], prefix: nil, needs_approval: false, gates: {},
+              complete_argument_validator: nil)
       listed = client.tools
       listed = listed.select { |tool| allow.include?(tool["name"]) } if allow
       listed = listed.reject { |tool| deny.include?(tool["name"]) }
       listed.map do |tool|
-        bridge(client, tool, prefix: prefix, gate: gates.fetch(tool["name"], needs_approval))
+        bridge(client, tool, prefix: prefix, gate: gates.fetch(tool["name"], needs_approval),
+                             complete_argument_validator: complete_argument_validator)
       end
     end
 
-    def bridge(client, spec, prefix: nil, gate: false)
+    def bridge(client, spec, prefix: nil, gate: false, complete_argument_validator: nil)
       remote = spec.fetch("name")
       local = prefix ? "#{prefix}__#{remote}" : remote
+      if spec.key?("inputSchema") && spec["inputSchema"].nil?
+        raise ConfigurationError, "inputSchema must be an object, not null"
+      end
+
+      raw_schema = spec.fetch("inputSchema", EMPTY_INPUT_SCHEMA)
+      input_schema = Schema.validate_mcp!(
+        raw_schema, complete: !complete_argument_validator.nil?
+      )
       Tool.define(local, spec["description"].to_s,
-                  input_schema: spec["inputSchema"] || Tool::EMPTY_SCHEMA,
-                  needs_approval: gate) do |args|
+                  input_schema: input_schema,
+                  needs_approval: gate,
+                  complete_argument_validator: complete_argument_validator) do |args|
         answer(client.call_tool(remote, args || {}))
       end
+    rescue ConfigurationError => e
+      raise ConfigurationError, "MCP tool #{remote.inspect}: #{e.message}"
     end
 
     # An MCP result becomes model-readable content: text joins, images ride
@@ -110,4 +127,4 @@ require_relative "mcp/wires"
 require_relative "mcp/client"
 require_relative "mcp/oauth"
 
-Mistri::MCP.private_constant :Egress, :WireError
+Mistri::MCP.private_constant :Egress, :WireError, :EMPTY_INPUT_SCHEMA

--- a/lib/mistri/mcp/client.rb
+++ b/lib/mistri/mcp/client.rb
@@ -145,7 +145,7 @@ module Mistri
         end
 
         result
-      rescue ResponseTooLargeError, WireError => e
+      rescue ResponseTooLargeError, ResponseTooComplexError, WireError => e
         reset_wire
         raise if replayable
         return result if responded

--- a/lib/mistri/providers/anthropic.rb
+++ b/lib/mistri/providers/anthropic.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "schema_capabilities"
+
 module Mistri
   module Providers
     # The Anthropic Messages API, streamed. Defaults target the current model
@@ -41,9 +43,16 @@ module Mistri
         @catalog_pricing && Models.priced?(model) && @service_tier.to_s == "standard_only"
       end
 
+      def native_output_schema(schema)
+        return unless Models.find(model)&.provider == :anthropic
+
+        SchemaCapabilities.derive(schema, :anthropic)
+      end
+
       def stream(messages:, system: nil, tools: [], signal: nil, **overrides, &emit)
         model = overrides.fetch(:model, @model)
         assembler = Anthropic::Assembler.new(model: model, catalog_pricing: @catalog_pricing)
+        assembler.start(&emit)
         body = build_body(model, messages, system, tools, overrides)
         outcome = @transport.stream_post("/v1/messages", body: body, headers: headers,
                                                          signal: signal) do |record|

--- a/lib/mistri/providers/anthropic/assembler.rb
+++ b/lib/mistri/providers/anthropic/assembler.rb
@@ -6,11 +6,12 @@ module Mistri
       # Folds the Messages API stream into the event union, building the
       # assistant message block by block. Every emitted event carries an
       # immutable snapshot of the message so far; in-flight tool arguments
-      # parse via PartialJson so consumers can read them mid-stream.
+      # expose a bounded, cached PartialJson preview so hostile fragmentation
+      # cannot make snapshot construction quadratic.
       #
       # Unknown event and block types are skipped by contract: the API adds
       # types over time and a live stream must survive them.
-      class Assembler
+      class Assembler # rubocop:disable Metrics/ClassLength -- one stream owns block order
         def initialize(model:, catalog_pricing: true)
           @model = model
           @catalog_pricing = catalog_pricing
@@ -20,17 +21,30 @@ module Mistri
           @usage = Usage.new
           @stop_reason = nil
           @done = false
+          @next_wire_index = 0
+          @open_wire_index = nil
+          @message_phase = false
         end
 
+        STREAM_EVENTS = %w[
+          message_start content_block_start content_block_delta content_block_stop
+          message_delta message_stop error
+        ].freeze
+
         def feed(record, &)
-          case record["type"]
+          type = record["type"]
+          if @done && STREAM_EVENTS.include?(type)
+            return protocol_error("stream continued after message_stop", &)
+          end
+
+          case type
           when "message_start" then message_start(record)
           when "content_block_start" then start_block(record, &)
           when "content_block_delta" then delta_block(record, &)
           when "content_block_stop" then stop_block(record, &)
-          when "message_delta" then message_delta(record)
-          when "message_stop" then @done = true
-          when "error" then @error = wire_error(record["error"])
+          when "message_delta" then message_delta(record, &)
+          when "message_stop" then stop_message(&)
+          when "error" then @error ||= wire_error(record["error"])
           end
         end
 
@@ -45,6 +59,9 @@ module Mistri
                                usage_known: @done && @usage_authoritative, &emit)
           end
           return fail_stream("stream ended without message_stop", &emit) unless @done
+          if @open_wire_index
+            return fail_stream("content block ended without content_block_stop", &emit)
+          end
 
           invalidate_cost unless @usage_authoritative
           @message = assemble(stop_reason: @stop_reason || StopReason::STOP)
@@ -53,7 +70,7 @@ module Mistri
         end
 
         def abort(&emit)
-          finalize_current
+          close_current(interrupted: true, &emit)
           invalidate_cost
           @message = assemble(stop_reason: StopReason::ABORTED, error_message: "aborted")
           emit&.call(Event.new(type: :error, reason: StopReason::ABORTED, message: @message,
@@ -65,12 +82,21 @@ module Mistri
         # as retryable, not fold into prose.
         def wire_error(payload)
           message = payload&.dig("message") || "provider error"
-          klass = payload&.dig("type").to_s.include?("overloaded") ? OverloadedError : ProviderError
-          klass.new(message)
+          type = payload&.dig("type").to_s
+          klass = case type
+                  when "authentication_error" then AuthenticationError
+                  when "rate_limit_error" then RateLimitError
+                  when "overloaded_error" then OverloadedError
+                  when "api_error" then ServerError
+                  when "timeout_error" then ProviderError
+                  else InvalidRequestError
+                  end
+          detail = type.empty? ? message : "#{type}: #{message}"
+          klass.new(detail)
         end
 
         def fail_stream(reason, usage_known: false, &emit)
-          finalize_current
+          close_current(interrupted: true, &emit)
           invalidate_cost unless usage_known
           text = case reason
                  when ProviderError then "#{reason.class}: #{reason.describe}"
@@ -86,7 +112,24 @@ module Mistri
 
         def message = @message ||= finish
 
-        Builder = Struct.new(:kind, :index, :text, :json, :signature, :id, :name, :redacted)
+        Builder = Struct.new(:kind, :index, :text, :json, :signature, :id, :name, :redacted,
+                             :argument_bytes, :argument_error, :argument_preview, :preview_bytes)
+        DELTA_KINDS = {
+          "text_delta" => :text,
+          "thinking_delta" => :thinking,
+          "signature_delta" => :thinking,
+          "input_json_delta" => :toolcall
+        }.freeze
+
+        PREVIEW_EAGER_BYTES = 4 * 1024
+        PREVIEW_STEP_BYTES = 4 * 1024
+        PREVIEW_MAX_BYTES = 64 * 1024
+        MAX_SIGNATURE_BYTES = ToolArguments::MAX_BYTES
+        MAX_REFUSAL_BYTES = 2048
+
+        def start(&emit)
+          emit&.call(Event.new(type: :start, partial: assemble))
+        end
 
         private
 
@@ -97,28 +140,80 @@ module Mistri
         end
 
         def start_block(record, &)
+          return if @error
+          return protocol_error("stream opened content after the message delta phase", &) \
+            if @message_phase
+          if @open_wire_index
+            return protocol_error("stream opened a content block before closing the prior block", &)
+          end
+
+          index = record["index"]
+          unless index == @next_wire_index
+            return protocol_error("stream opened a content block at an unexpected index", &)
+          end
+
+          @open_wire_index = index
+          @next_wire_index += 1
+
           block = record["content_block"] || {}
+          if block["type"] == "tool_use" && block.key?("input") &&
+             (!block["input"].is_a?(Hash) || !block["input"].empty?)
+            return protocol_error("tool_use started with nonempty input before its deltas", &)
+          end
+
           kind = { "text" => :text, "thinking" => :thinking, "redacted_thinking" => :thinking,
                    "tool_use" => :toolcall }[block["type"]]
           return unless kind
 
           @current = Builder.new(kind, @blocks.size, +"", +"", nil,
-                                 block["id"], block["name"], block["type"] == "redacted_thinking")
+                                 block["id"], block["name"], block["type"] == "redacted_thinking",
+                                 0, nil, ToolArguments::EMPTY_OBJECT, 0)
           @current.signature = block["data"] if @current.redacted
           emit_event(:"#{kind}_start", content_index: @current.index, &)
         end
 
         def delta_block(record, &)
+          return if @error
+          return protocol_error("stream sent content after the message delta phase", &) \
+            if @message_phase
+          unless @open_wire_index && record["index"] == @open_wire_index
+            return protocol_error("stream sent a delta for a different content block", &)
+          end
           return unless @current
 
           delta = record["delta"] || {}
-          case delta["type"]
-          when "text_delta" then text_delta(delta["text"], &)
-          when "thinking_delta" then thinking_delta(delta["thinking"], &)
-          when "signature_delta"
-            @current.signature = "#{@current.signature}#{delta["signature"]}"
-          when "input_json_delta" then input_delta(delta["partial_json"], &)
+          expected = DELTA_KINDS[delta["type"]]
+          return unless expected
+          unless @current.kind == expected
+            return protocol_error("stream sent a delta outside its matching content block", &)
           end
+
+          route_delta(delta, &)
+        end
+
+        def route_delta(delta, &)
+          case delta["type"]
+          when "text_delta"
+            text_delta(delta["text"], &)
+          when "thinking_delta"
+            thinking_delta(delta["thinking"], &)
+          when "signature_delta"
+            signature_delta(delta["signature"])
+          when "input_json_delta"
+            input_delta(delta["partial_json"], &)
+          end
+        end
+
+        def signature_delta(fragment)
+          fragment = fragment.to_s
+          current = @current.signature || +""
+          if fragment.bytesize > MAX_SIGNATURE_BYTES - current.bytesize
+            raise ResponseTooLargeError.new(kind: :thinking_signature,
+                                            limit: MAX_SIGNATURE_BYTES)
+          end
+
+          @current.signature = current
+          current << fragment
         end
 
         def text_delta(text, &)
@@ -132,22 +227,59 @@ module Mistri
         end
 
         def input_delta(fragment, &)
-          @current.json << fragment.to_s
+          append_arguments(@current, fragment.to_s)
           emit_event(:toolcall_delta, content_index: @current.index, delta: fragment, &)
         end
 
-        def stop_block(_record, &)
-          return unless @current
+        def append_arguments(builder, fragment)
+          return if builder.argument_error
 
-          block = finalize_current
-          kind = block.is_a?(ToolCall) ? :toolcall : block.type
-          fields = { content_index: @blocks.size - 1 }
-          fields[:tool_call] = block if block.is_a?(ToolCall)
-          fields[:content] = @blocks.last.is_a?(ToolCall) ? nil : builder_text(block)
-          emit_event(:"#{kind}_end", **fields.compact, &)
+          if fragment.bytesize > ToolArguments::MAX_BYTES - builder.argument_bytes
+            builder.argument_error = "too_large"
+            # String#clear may retain its backing allocation.
+            builder.json = +""
+            return
+          end
+
+          builder.json << fragment
+          builder.argument_bytes += fragment.bytesize
+          refresh_argument_preview(builder)
         end
 
-        def message_delta(record)
+        def refresh_argument_preview(builder)
+          target = [builder.argument_bytes, PREVIEW_MAX_BYTES].min
+          eager = target <= PREVIEW_EAGER_BYTES
+          milestone = target - builder.preview_bytes >= PREVIEW_STEP_BYTES
+          return unless eager || milestone || target == PREVIEW_MAX_BYTES
+          return if target == builder.preview_bytes
+
+          source = if target == builder.json.bytesize
+                     builder.json
+                   else
+                     builder.json.byteslice(0, target)
+                   end
+          builder.argument_preview = ToolArguments.freeze_partial(PartialJson.parse(source))
+          builder.preview_bytes = target
+        end
+
+        def stop_block(record, &)
+          return if @error
+          return protocol_error("stream stopped content after the message delta phase", &) \
+            if @message_phase
+          unless @open_wire_index && record["index"] == @open_wire_index
+            return protocol_error("stream stopped a different content block", &)
+          end
+
+          close_current(&) if @current
+          @open_wire_index = nil
+        end
+
+        def message_delta(record, &)
+          @message_phase = true
+          if @open_wire_index
+            return protocol_error("message delta arrived before the content block stopped", &)
+          end
+
           reason = record.dig("delta", "stop_reason")
           @stop_reason = map_stop_reason(reason) if reason
           if reason == "refusal"
@@ -163,30 +295,54 @@ module Mistri
           @usage_authoritative = true
         end
 
-        def finalize_current
+        def stop_message(&)
+          protocol_error("message stopped before the content block stopped", &) if @open_wire_index
+          @done = true
+        end
+
+        def close_current(interrupted: false, &)
           return unless @current
 
-          built = build_block(@current)
+          built = build_block(@current, interrupted:)
           @blocks << built
           @current = nil
+          kind = built.is_a?(ToolCall) ? :toolcall : built.type
+          fields = { content_index: @blocks.size - 1 }
+          fields[:tool_call] = built if built.is_a?(ToolCall)
+          fields[:content] = builder_text(built) unless built.is_a?(ToolCall)
+          emit_event(:"#{kind}_end", **fields, &)
           built
         end
 
-        def build_block(builder)
+        def build_block(builder, final: true, interrupted: false)
           case builder.kind
           when :text then Content::Text.new(text: builder.text)
           when :thinking
-            Content::Thinking.new(thinking: builder.text, signature: builder.signature,
-                                  redacted: builder.redacted)
+            signature = interrupted ? nil : builder.signature
+            redacted = interrupted ? false : builder.redacted
+            Content::Thinking.new(thinking: builder.text, signature:, redacted:)
           when :toolcall
+            arguments, error = if interrupted
+                                 [nil, "incomplete"]
+                               elsif final
+                                 if builder.argument_error
+                                   [nil, builder.argument_error]
+                                 else
+                                   parsed_arguments(builder.json)
+                                 end
+                               else
+                                 [builder.argument_preview, nil]
+                               end
             ToolCall.new(id: builder.id, name: builder.name,
-                         arguments: parsed_arguments(builder.json), signature: nil)
+                         arguments:, signature: nil, arguments_error: error,
+                         canonicalize: final)
           end
         end
 
         def parsed_arguments(json)
-          parsed = json.strip.empty? ? {} : PartialJson.parse(json)
-          parsed.is_a?(Hash) ? parsed : {}
+          return [{}, nil] if json.empty?
+
+          ToolArguments.parse_json(json)
         end
 
         def builder_text(block)
@@ -197,9 +353,24 @@ module Mistri
           emit&.call(Event.new(type:, partial: assemble, **fields))
         end
 
+        def protocol_error(message, &)
+          @error ||= ProviderError.new(message)
+          close_current(interrupted: true, &)
+          @blocks.map! do |block|
+            if block.is_a?(ToolCall)
+              block.with(arguments: nil,
+                         arguments_error: "incomplete")
+            else
+              block
+            end
+          end
+          @open_wire_index = nil
+          nil
+        end
+
         def assemble(**meta)
           blocks = @blocks.dup
-          blocks << build_block(@current) if @current
+          blocks << build_block(@current, final: false) if @current
           Message.assistant(content: blocks, model: @model, provider: :anthropic,
                             usage: @usage, **meta)
         end
@@ -218,10 +389,31 @@ module Mistri
         # retry of this one, so it fails fast; stop_details names the policy
         # category when the API provides one.
         def refusal_error
-          details = [@refusal&.dig("category"), @refusal&.dig("explanation")].compact.join(": ")
+          details = bounded_refusal(@refusal&.dig("category"),
+                                    @refusal&.dig("explanation"))
           text = +"the model refused to respond"
           text << " (#{details})" unless details.empty?
           InvalidRequestError.new(text)
+        end
+
+        def bounded_refusal(*values)
+          output = +""
+          values.each do |value|
+            next unless value.is_a?(String)
+
+            separator = output.empty? ? "" : ": "
+            remaining = MAX_REFUSAL_BYTES - output.bytesize - separator.bytesize
+            break unless remaining.positive?
+
+            output << separator << utf8_prefix(value, remaining)
+          end
+          output
+        end
+
+        def utf8_prefix(value, limit)
+          prefix = value.byteslice(0, limit).dup.force_encoding(value.encoding)
+          prefix.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "?")
+                .scrub.byteslice(0, limit).to_s.force_encoding(Encoding::UTF_8).scrub
         end
 
         def parse_usage(raw)
@@ -245,7 +437,7 @@ module Mistri
         def invalidate_cost
           @usage = @usage.with(cost: @usage.cost.with(known: false))
         end
-      end
+      end # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/lib/mistri/providers/anthropic/serializer.rb
+++ b/lib/mistri/providers/anthropic/serializer.rb
@@ -42,12 +42,14 @@ module Mistri
         end
 
         def message(msg)
-          { role: msg.role.to_s, content: msg.content.filter_map { |block| block(block) } }
+          own = msg.provider == :anthropic
+          { role: msg.role.to_s,
+            content: msg.content.filter_map { |content| block(content, own:) } }
         end
 
         def tool_results(group)
           { role: "user", content: group.map do |msg|
-            blocks = msg.content.filter_map { |block| block(block) }
+            blocks = msg.content.filter_map { |content| block(content, own: false) }
             # The API rejects an empty tool_result; a space stands in for a
             # tool that returned nothing.
             blocks = [{ type: "text", text: " " }] if blocks.empty?
@@ -59,15 +61,16 @@ module Mistri
 
         # Returns nil for a block the API would reject (empty text, unusable
         # thinking), so callers filter_map it out.
-        def block(block)
+        def block(block, own: true)
           case block
           when Content::Text then text_block(block)
-          when Content::Thinking then thinking_block(block)
+          when Content::Thinking then thinking_block(block, own:)
           when Content::Image
             { type: "image",
               source: { type: "base64", media_type: block.mime_type, data: block.data } }
           when ToolCall
-            { type: "tool_use", id: block.id, name: block.name, input: block.arguments }
+            { type: "tool_use", id: block.id, name: block.name,
+              input: ToolArguments.replay_object(block) }
           else
             raise SchemaError, "cannot serialize #{block.class} for Anthropic"
           end
@@ -82,9 +85,9 @@ module Mistri
         # its opaque payload; a normal thinking block missing its signature
         # (an aborted turn cut before signature_delta) cannot replay, so it
         # degrades to its text, or drops when even that is empty.
-        def thinking_block(block)
-          return { type: "redacted_thinking", data: block.signature } if block.redacted?
-          if block.signature
+        def thinking_block(block, own: true)
+          return { type: "redacted_thinking", data: block.signature } if own && block.redacted?
+          if own && block.signature
             return { type: "thinking", thinking: block.thinking,
                      signature: block.signature }
           end

--- a/lib/mistri/providers/fake.rb
+++ b/lib/mistri/providers/fake.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "securerandom"
 
 module Mistri
   module Providers
@@ -31,6 +32,8 @@ module Mistri
         end
         @chunk_size = [chunk_size, 1].max
         @requests = []
+        @tool_call_prefix = SecureRandom.uuid
+        @tool_call_sequence = 0
       end
 
       def prices_usage? = @prices_usage
@@ -72,14 +75,15 @@ module Mistri
         kind == :text ? Content::Text.new(text:) : Content::Thinking.new(thinking: text)
       end
 
-      # Arguments stream in chunks, and every delta's partial carries the
-      # in-progress call with the arguments parsed so far, the same shape a
-      # real assembler builds, so a consumer that renders tool input as it
-      # arrives (a page preview, a code block) is testable headless.
-      def stream_tool_call(spec, position, blocks, emit)
+      # Small scripted arguments parse eagerly on every chunk for precise UI
+      # tests. Real assemblers cap their refresh schedule under hostile fragmentation.
+      def stream_tool_call(spec, _position, blocks, emit)
         spec = spec.transform_keys(&:to_sym)
-        call = ToolCall.new(id: spec[:id] || "call_#{position + 1}", name: spec[:name],
-                            arguments: (spec[:arguments] || {}).transform_keys(&:to_s))
+        arguments = spec.key?(:arguments) ? spec[:arguments] : {}
+        id = spec.key?(:id) ? spec[:id] : next_tool_call_id
+        call = ToolCall.new(id:, name: spec[:name], arguments:, signature: spec[:signature],
+                            arguments_error: spec[:arguments_error],
+                            provider_call_id: spec[:provider_call_id])
         index = blocks.size
         emit_event(emit, :toolcall_start, blocks, content_index: index)
         built = +""
@@ -93,9 +97,16 @@ module Mistri
       end
 
       def in_progress(call, json)
-        parsed = PartialJson.parse(json)
+        parsed = ToolArguments.freeze_partial(PartialJson.parse(json))
         ToolCall.new(id: call.id, name: call.name,
-                     arguments: parsed.is_a?(Hash) ? parsed : {})
+                     arguments: parsed, signature: call.signature,
+                     provider_call_id: call.provider_call_id,
+                     canonicalize: false)
+      end
+
+      def next_tool_call_id
+        @tool_call_sequence += 1
+        "fake_#{@tool_call_prefix}_#{@tool_call_sequence}"
       end
 
       def finish(turn, blocks, emit)

--- a/lib/mistri/providers/gemini.rb
+++ b/lib/mistri/providers/gemini.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "schema_capabilities"
+
 module Mistri
   module Providers
     # The Gemini API (v1beta generateContent), streamed over SSE and
@@ -32,11 +34,18 @@ module Mistri
         @catalog_pricing && Models.priced?(model) && tier_known
       end
 
+      def native_output_schema(schema)
+        return unless Models.find(model)&.provider == :gemini
+
+        SchemaCapabilities.derive(schema, :gemini)
+      end
+
       def stream(messages:, system: nil, tools: [], signal: nil, **overrides, &emit)
         model = overrides.fetch(:model, @model)
         service_tier = overrides.fetch(:service_tier, @service_tier)
         assembler = Gemini::Assembler.new(model: model, catalog_pricing: @catalog_pricing,
                                           service_tier:)
+        assembler.start(&emit)
         body = build_body(messages, system, tools, overrides)
         path = "/v1beta/models/#{model}:streamGenerateContent?alt=sse"
         outcome = @transport.stream_post(path, body: body, headers: headers,

--- a/lib/mistri/providers/gemini/assembler.rb
+++ b/lib/mistri/providers/gemini/assembler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "securerandom"
 
 module Mistri
   module Providers
@@ -22,6 +23,7 @@ module Mistri
           @current = nil
           @usage = Usage.new
           @finish_reason = nil
+          @terminal = false
         end
 
         # Finish reasons that are the provider's verdict on the content
@@ -30,31 +32,53 @@ module Mistri
         # evading it, so these fail fast.
         VERDICTS = %w[SAFETY RECITATION LANGUAGE BLOCKLIST PROHIBITED_CONTENT SPII
                       IMAGE_SAFETY IMAGE_PROHIBITED_CONTENT IMAGE_RECITATION].freeze
+        # Missing replay state accuses the request rather than the generated
+        # content, but retrying the same history is equally deterministic.
+        INPUT_ERRORS = %w[MISSING_THOUGHT_SIGNATURE].freeze
         # The model fumbled its own output (an invalid or runaway tool call,
         # a missing image), or the API stopped for a reason it cannot name
         # (OTHER is documented as "Unknown reason"). The input stands accused
         # of nothing, so these error retryably; a regeneration usually lands.
         FUMBLES = %w[MALFORMED_FUNCTION_CALL UNEXPECTED_TOOL_CALL TOO_MANY_TOOL_CALLS
-                     NO_IMAGE OTHER IMAGE_OTHER].freeze
+                     NO_IMAGE OTHER IMAGE_OTHER MALFORMED_RESPONSE
+                     FINISH_REASON_UNSPECIFIED].freeze
+
+        def start(&emit)
+          emit&.call(Event.new(type: :start, partial: assemble))
+        end
 
         def feed(record, &)
-          if (error = record["error"])
-            @error = ProviderError.new(error["message"] || "provider error",
-                                       status: error["code"])
-            return
-          end
+          return after_terminal(record, &) if @terminal
+          return record_error(record["error"]) if record["error"]
 
+          fold_record(record, &)
+        end
+
+        def after_terminal(record, &)
+          return ingest_usage(record) unless terminal_content?(record)
+
+          protocol_error("stream continued after its terminal record", &)
+        end
+
+        def record_error(error)
+          @error = ProviderError.new(error["message"] || "provider error",
+                                     status: error["code"])
+          @terminal = true
+        end
+
+        def fold_record(record, &)
           block = record.dig("promptFeedback", "blockReason").to_s
           @block_reason = block unless block.empty? || block == "BLOCK_REASON_UNSPECIFIED"
           candidate = record.dig("candidates", 0) || {}
-          Array(candidate.dig("content", "parts")).each { |part| fold_part(part, &) }
-          @finish_reason = candidate["finishReason"] if candidate["finishReason"]
-          if (raw_usage = record["usageMetadata"])
-            @service_tier = raw_usage["serviceTier"] if raw_usage.key?("serviceTier")
-            @usage = priced(parse_usage(raw_usage))
-            @usage_authoritative = true if @finish_reason || @block_reason
+          Array(candidate.dig("content", "parts")).each_with_index do |part, index|
+            fold_part(part, part_boundary: index.positive?, &)
           end
+          @finish_reason = candidate["finishReason"] if candidate["finishReason"]
+          @terminal = true if @finish_reason || @block_reason
+          close_current(&) if @terminal
+          ingest_usage(record)
         end
+        private :after_terminal, :record_error, :fold_record
 
         # A stream that ended without a finishReason was truncated, not
         # cancelled: fail it so the loop can treat it as retryable.
@@ -65,6 +89,13 @@ module Mistri
           end
           return fail_stream("stream ended without a finish reason", &emit) unless @finish_reason
 
+          if @blocks.any?(ToolCall) && !%w[STOP MAX_TOKENS].include?(@finish_reason)
+            invalidate_tool_calls
+            reason = ProviderError.new("generation ended before its tool calls were confirmed: " \
+                                       "#{@finish_reason}")
+            return fail_stream(reason, usage_known: @usage_authoritative, &emit)
+          end
+
           close_current(&emit)
           invalidate_cost unless @usage_authoritative
           @message = assemble(stop_reason: stop_reason)
@@ -73,13 +104,13 @@ module Mistri
         end
 
         def abort(&)
-          close_current
+          close_current(&)
           invalidate_cost
           terminal(StopReason::ABORTED, "aborted", &)
         end
 
         def fail_stream(reason, usage_known: false, &)
-          close_current
+          close_current(&)
           invalidate_cost unless usage_known
           text = case reason
                  when ProviderError then "#{reason.class}: #{reason.describe}"
@@ -95,16 +126,52 @@ module Mistri
 
         private
 
-        def fold_part(part, &)
+        def fold_part(part, part_boundary: false, &)
           if part.key?("functionCall")
             fold_function_call(part, &)
           elsif part.key?("text")
-            fold_text(part, part["thought"] ? :thinking : :text, &)
+            fold_text(part, part["thought"] ? :thinking : :text, part_boundary:, &)
           end
         end
 
-        def fold_text(part, kind, &)
-          close_current(&) if @current && @current.kind != kind
+        def terminal_content?(record)
+          return true if record["error"]
+          return true unless record.dig("promptFeedback", "blockReason").to_s.empty?
+
+          candidate = record.dig("candidates", 0)
+          candidate && (candidate["finishReason"] ||
+            !Array(candidate.dig("content", "parts")).empty?)
+        end
+
+        def ingest_usage(record)
+          raw = record["usageMetadata"]
+          return unless raw
+
+          @service_tier = raw["serviceTier"] if raw.key?("serviceTier")
+          @usage = priced(parse_usage(raw))
+          @usage_authoritative = true if @terminal
+        end
+
+        def protocol_error(message, &)
+          @error ||= ProviderError.new(message)
+          close_current(&)
+          invalidate_tool_calls
+          nil
+        end
+
+        def invalidate_tool_calls
+          @blocks.map! do |block|
+            if block.is_a?(ToolCall)
+              block.with(arguments: nil, arguments_error: "incomplete")
+            else
+              block
+            end
+          end
+        end
+
+        def fold_text(part, kind, part_boundary:, &)
+          close_current(&) if @current && (@current.kind != kind || part_boundary ||
+                                           @current.signature)
           unless @current
             @current = Builder.new(kind, @blocks.size, +"", nil)
             emit_event(:"#{kind}_start", content_index: @current.index, &)
@@ -120,14 +187,15 @@ module Mistri
         def fold_function_call(part, &)
           close_current(&)
           call_spec = part["functionCall"] || {}
-          arguments = call_spec["args"].is_a?(Hash) ? call_spec["args"] : {}
-          call = ToolCall.new(id: call_spec["id"] || "call_#{@blocks.size + 1}",
+          arguments = call_spec.key?("args") ? call_spec["args"] : {}
+          wire_id = call_spec["id"]
+          call = ToolCall.new(id: wire_id || "gemini_#{SecureRandom.uuid}",
                               name: call_spec["name"], arguments: arguments,
-                              signature: part["thoughtSignature"])
+                              signature: part["thoughtSignature"], provider_call_id: wire_id)
           index = @blocks.size
           emit_event(:toolcall_start, content_index: index, &)
           emit_event(:toolcall_delta, content_index: index,
-                                      delta: JSON.generate(arguments), &)
+                                      delta: JSON.generate(call.arguments), &)
           @blocks << call
           emit_event(:toolcall_end, content_index: index, tool_call: call, &)
         end
@@ -161,7 +229,7 @@ module Mistri
             return InvalidRequestError.new("the prompt was blocked: #{@block_reason}")
           end
           return unless @finish_reason
-          if VERDICTS.include?(@finish_reason)
+          if VERDICTS.include?(@finish_reason) || INPUT_ERRORS.include?(@finish_reason)
             return InvalidRequestError.new("generation stopped: #{@finish_reason}")
           end
           return unless FUMBLES.include?(@finish_reason)
@@ -170,8 +238,8 @@ module Mistri
         end
 
         def stop_reason
-          return StopReason::TOOL_USE if @blocks.any?(ToolCall)
           return StopReason::LENGTH if @finish_reason == "MAX_TOKENS"
+          return StopReason::TOOL_USE if @blocks.any?(ToolCall)
 
           StopReason::STOP
         end

--- a/lib/mistri/providers/gemini/serializer.rb
+++ b/lib/mistri/providers/gemini/serializer.rb
@@ -12,14 +12,29 @@ module Mistri
       # signature would be rejected. Thinking summaries are output-only and
       # never replay. Consecutive user turns stay separate: Gemini accepts
       # them, and mixing a text part into a functionResponse turn makes it
-      # answer an empty candidate.
+      # answer an empty candidate. Completed tool exchanges from another
+      # provider become ordinary text: Gemini rejects foreign functionCall
+      # history because it has no Gemini thought signature.
       module Serializer
         module_function
 
         def contents(history)
-          groups = history.reject(&:system?).chunk_while { |a, b| a.tool? && b.tool? }
+          origins = tool_call_origins(history)
+          wire_ids = provider_call_ids(history)
+          groups = history.reject(&:system?).chunk_while do |a, b|
+            a.tool? && b.tool? && native_tool_result?(a, origins) ==
+              native_tool_result?(b, origins)
+          end
           groups.filter_map do |group|
-            group.first.tool? ? tool_turn(group) : turn(group.first)
+            if group.first.tool?
+              if native_tool_result?(group.first, origins)
+                tool_turn(group, wire_ids)
+              else
+                foreign_tool_turn(group)
+              end
+            else
+              turn(group.first)
+            end
           end
         end
 
@@ -33,7 +48,7 @@ module Mistri
           declarations = definitions.map do |tool|
             spec = tool.transform_keys(&:to_sym)
             { name: spec[:name], description: spec[:description],
-              parameters: spec[:input_schema] }
+              parametersJsonSchema: spec[:input_schema] }
           end
           [{ functionDeclarations: declarations }]
         end
@@ -47,15 +62,27 @@ module Mistri
 
         # Gemini pairs a functionResponse to its call by NAME; a wrong name
         # silently mismatches, so a missing one fails loudly instead.
-        def tool_turn(group)
+        def tool_turn(group, wire_ids = {})
           { role: "user", parts: group.map do |msg|
             unless msg.tool_name
               raise SchemaError, "Gemini tool results need tool_name to pair with their call"
             end
 
             key = msg.tool_error? ? "error" : "result"
-            { functionResponse: { name: msg.tool_name,
-                                  response: { key => result_text(msg) } } }
+            response = { name: msg.tool_name, response: { key => result_text(msg) } }
+            response[:id] = wire_ids[msg.tool_call_id] if wire_ids[msg.tool_call_id]
+            { functionResponse: response }
+          end }
+        end
+
+        def foreign_tool_turn(group)
+          { role: "user", parts: group.map do |msg|
+            raise SchemaError, "Gemini tool results need tool_name" unless msg.tool_name
+
+            label = msg.tool_error? ? "error" : "result"
+            text = "Tool #{JSON.generate(msg.tool_name)} #{label} " \
+                   "(call #{JSON.generate(msg.tool_call_id)}): #{result_text(msg)}"
+            { text: text }
           end }
         end
 
@@ -85,8 +112,47 @@ module Mistri
             case block
             when Content::Text then signed({ text: block.text }, block.signature, own)
             when ToolCall
-              signed({ functionCall: { name: block.name, args: block.arguments } },
-                     block.signature, own)
+              own ? native_function_call(block) : foreign_function_call(block)
+            end
+          end
+        end
+
+        def native_function_call(block)
+          arguments = ToolArguments.replay_object(block)
+          signature = block.signature if arguments.equal?(block.arguments)
+          call = { name: block.name, args: arguments }
+          call[:id] = block.provider_call_id if block.provider_call_id
+          signed({ functionCall: call }, signature, true)
+        end
+
+        def foreign_function_call(block)
+          arguments = if block.arguments_error
+                        "unavailable (#{block.arguments_error})"
+                      else
+                        JSON.generate(block.arguments)
+                      end
+          { text: "Tool call #{JSON.generate(block.name)} " \
+                  "(call #{JSON.generate(block.id)}) with arguments: #{arguments}" }
+        end
+
+        def native_tool_result?(message, origins)
+          origins[message.tool_call_id] == :gemini
+        end
+
+        def tool_call_origins(history)
+          history.each_with_object({}) do |message, origins|
+            next unless message.assistant?
+
+            message.tool_calls.each { |call| origins[call.id] = message.provider }
+          end
+        end
+
+        def provider_call_ids(history)
+          history.each_with_object({}) do |message, ids|
+            next unless message.assistant? && message.provider == :gemini
+
+            message.tool_calls.each do |call|
+              ids[call.id] = call.provider_call_id if call.provider_call_id
             end
           end
         end

--- a/lib/mistri/providers/openai.rb
+++ b/lib/mistri/providers/openai.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "schema_capabilities"
+
 module Mistri
   module Providers
     # The OpenAI Responses API, streamed and stateless: store is always false,
@@ -31,9 +33,16 @@ module Mistri
         @catalog_pricing && Models.priced?(model) && @service_tier.to_s == "default"
       end
 
+      def native_output_schema(schema)
+        return unless Models.find(model)&.provider == :openai
+
+        SchemaCapabilities.derive(schema, :openai)
+      end
+
       def stream(messages:, system: nil, tools: [], signal: nil, **overrides, &emit)
         model = overrides.fetch(:model, @model)
         assembler = OpenAI::Assembler.new(model: model, catalog_pricing: @catalog_pricing)
+        assembler.start(&emit)
         body = build_body(model, messages, system, tools, overrides)
         outcome = @transport.stream_post("/v1/responses", body: body, headers: headers,
                                                           signal: signal) do |record|

--- a/lib/mistri/providers/openai/assembler.rb
+++ b/lib/mistri/providers/openai/assembler.rb
@@ -10,8 +10,9 @@ module Mistri
       # output_item.done closes it with the complete item, whose ids and
       # encrypted reasoning land in the signature slots for replay.
       #
-      # Unknown event and item types are skipped by contract.
-      class Assembler
+      # Argument deltas expose a bounded, cached preview; the completed item
+      # stays authoritative. Unknown event and item types are skipped by contract.
+      class Assembler # rubocop:disable Metrics/ClassLength -- one stream owns item order
         def initialize(model:, catalog_pricing: true)
           @model = model
           @catalog_pricing = catalog_pricing
@@ -24,27 +25,46 @@ module Mistri
         end
 
         def feed(record, &)
-          case record["type"]
-          when "response.output_item.added" then start_item(record["item"], &)
-          when "response.output_text.delta" then text_delta(record["delta"], &)
+          type = record["type"]
+          if @status && STREAM_EVENTS.include?(type)
+            return protocol_error("response continued after its terminal event", &)
+          end
+
+          dispatch_record(record, &)
+        end
+
+        def dispatch_record(record, &)
+          type = record["type"]
+          case type
+          when "response.output_item.added" then start_item(record, &)
+          when "response.output_text.delta" then text_delta(record, &)
           when "response.reasoning_summary_text.delta"
-            thinking_delta(record["delta"], record["summary_index"], &)
-          when "response.function_call_arguments.delta" then arguments_delta(record["delta"], &)
-          when "response.output_item.done" then finish_item(record["item"], &)
+            thinking_delta(record, &)
+          when "response.refusal.delta" then refusal_delta(record, &)
+          when "response.function_call_arguments.delta" then arguments_delta(record, &)
+          when "response.output_item.done" then finish_item(record, &)
           when "response.completed", "response.incomplete", "response.failed"
-            finish_response(record["response"] || {})
-          when "error" then @error = wire_error(record)
+            finish_response(record, &)
+          when "error" then @error ||= wire_error(record)
           end
         end
+        private :dispatch_record
 
         # A stream that ended without a terminal response event was truncated,
         # not cancelled: fail it so the loop can treat it as retryable.
         def finish(&emit)
           return fail_stream(@error, &emit) if @error
+          return fail_stream(@refusal_error, &emit) if @refusal_error
           return fail_stream(filter_error, &emit) if @incomplete_reason == "content_filter"
-          return fail_stream("stream ended without a terminal event", &emit) unless @status
 
-          @message = assemble(stop_reason: stop_reason)
+          if @status == "incomplete" && @incomplete_reason != "max_output_tokens"
+            detail = @incomplete_reason || "unspecified reason"
+            return fail_stream("response was incomplete: #{detail}", &emit)
+          end
+          return fail_stream("stream ended without a terminal event", &emit) unless @status
+          return fail_stream("output item ended without output_item.done", &emit) if @current
+
+          @message = assemble(final: true, stop_reason: stop_reason)
           emit&.call(Event.new(type: :done, reason: @message.stop_reason, message: @message))
           @message
         end
@@ -58,11 +78,7 @@ module Mistri
         def wire_error(record)
           message = record["message"] || "provider error"
           code = record["code"].to_s
-          klass = if code.include?("rate_limit") then RateLimitError
-                  elsif code.include?("server") then ServerError
-                  else ProviderError
-                  end
-          klass.new(message)
+          classify_error(code, message, unknown: ProviderError)
         end
 
         def fail_stream(reason, &)
@@ -76,58 +92,174 @@ module Mistri
 
         def message = @message ||= finish
 
-        Builder = Struct.new(:kind, :index, :text, :json)
+        Builder = Struct.new(:kind, :index, :output_index, :text, :json,
+                             :argument_bytes, :argument_error,
+                             :argument_preview, :preview_bytes, :item_id, :call_id, :name)
         KINDS = { "message" => :text, "reasoning" => :thinking,
                   "function_call" => :toolcall }.freeze
+        STREAM_EVENTS = %w[
+          response.output_item.added response.output_text.delta
+          response.reasoning_summary_text.delta response.refusal.delta
+          response.function_call_arguments.delta response.output_item.done
+          response.completed response.incomplete response.failed error
+        ].freeze
+        TERMINAL_STATUSES = {
+          "response.completed" => "completed",
+          "response.incomplete" => "incomplete",
+          "response.failed" => "failed"
+        }.freeze
+        PREVIEW_EAGER_BYTES = 4 * 1024
+        PREVIEW_STEP_BYTES = 4 * 1024
+        PREVIEW_MAX_BYTES = 64 * 1024
+        MAX_REFUSAL_BYTES = 2048
+
+        def start(&emit)
+          emit&.call(Event.new(type: :start, partial: assemble))
+        end
 
         private
 
-        def start_item(item, &)
+        def start_item(record, &)
+          return if @error
+          if @current
+            return protocol_error("response opened an output item before closing the prior item", &)
+          end
+
+          item = record["item"]
           kind = KINDS[item&.fetch("type", nil)]
           return unless kind
 
-          @current = Builder.new(kind, @blocks.size, +"", +"")
+          @current = Builder.new(kind, @blocks.size, record["output_index"], +"", +"", 0, nil,
+                                 ToolArguments::EMPTY_OBJECT, 0,
+                                 item["id"], item["call_id"], item["name"])
           @summary_part = nil
           emit_event(:"#{kind}_start", content_index: @current.index, &)
         end
 
-        def text_delta(delta, &)
-          return unless @current
+        def text_delta(record, &)
+          return unless matching_current?(:text, "output text delta", record, &)
 
-          @current.text << delta.to_s
-          emit_event(:text_delta, content_index: @current.index, delta: delta, &)
+          @current.text << record["delta"].to_s
+          emit_event(:text_delta, content_index: @current.index, delta: record["delta"], &)
         end
 
         # A reasoning item carries one or more summary parts, each its own
         # paragraph; the boundary streams as a delta so live views keep the
         # break the finished text will have.
-        def thinking_delta(delta, part, &)
-          return unless @current
+        def thinking_delta(record, &)
+          return unless matching_current?(:thinking, "reasoning summary delta", record, &)
 
+          part = record["summary_index"]
           if @summary_part && part && part != @summary_part
             @current.text << "\n\n"
             emit_event(:thinking_delta, content_index: @current.index, delta: "\n\n", &)
           end
           @summary_part = part if part
-          @current.text << delta.to_s
-          emit_event(:thinking_delta, content_index: @current.index, delta: delta, &)
+          @current.text << record["delta"].to_s
+          emit_event(:thinking_delta, content_index: @current.index, delta: record["delta"], &)
         end
 
-        def arguments_delta(delta, &)
-          return unless @current
+        def arguments_delta(record, &)
+          return unless matching_current?(:toolcall, "function arguments delta", record, &)
 
-          @current.json << delta.to_s
-          emit_event(:toolcall_delta, content_index: @current.index, delta: delta, &)
+          append_arguments(@current, record["delta"].to_s)
+          emit_event(:toolcall_delta, content_index: @current.index, delta: record["delta"], &)
+        end
+
+        def refusal_delta(record, &)
+          return unless matching_current?(:text, "refusal delta", record, &)
+
+          available = MAX_REFUSAL_BYTES - (@refusal_preview&.bytesize || 0)
+          accepted = available.positive? ? bounded_utf8(record["delta"], available) : ""
+          @refusal_preview ||= +""
+          @refusal_preview << accepted
+          unless accepted.empty?
+            @current.text << accepted
+            emit_event(:text_delta, content_index: @current.index, delta: accepted, &)
+          end
+          @refusal_error = refusal_from(@refusal_preview)
+        end
+
+        def append_arguments(builder, fragment)
+          return if builder.argument_error
+
+          if fragment.bytesize > ToolArguments::MAX_BYTES - builder.argument_bytes
+            builder.argument_error = "too_large"
+            # String#clear may retain its backing allocation.
+            builder.json = +""
+            return
+          end
+
+          builder.json << fragment
+          builder.argument_bytes += fragment.bytesize
+          refresh_argument_preview(builder)
+        end
+
+        def refresh_argument_preview(builder)
+          target = [builder.argument_bytes, PREVIEW_MAX_BYTES].min
+          eager = target <= PREVIEW_EAGER_BYTES
+          milestone = target - builder.preview_bytes >= PREVIEW_STEP_BYTES
+          return unless eager || milestone || target == PREVIEW_MAX_BYTES
+          return if target == builder.preview_bytes
+
+          source = if target == builder.json.bytesize
+                     builder.json
+                   else
+                     builder.json.byteslice(0, target)
+                   end
+          builder.argument_preview = ToolArguments.freeze_partial(PartialJson.parse(source))
+          builder.preview_bytes = target
         end
 
         # The done item is authoritative: its text, arguments, ids, and
         # encrypted content replace whatever the deltas accumulated.
-        def finish_item(item, &)
-          kind = KINDS[item&.fetch("type", nil)]
-          return unless kind
+        def finish_item(record, &)
+          return if @error
 
-          index = @current&.index || @blocks.size
-          block = build_block(kind, item)
+          item = record["item"]
+          kind = KINDS[item&.fetch("type", nil)]
+          return unless kind || @current
+
+          problem = completed_item_problem(record, item, kind)
+          return protocol_error(problem, &) if problem
+          return if finish_refusal?(item, kind, &)
+
+          commit_item(item, kind, &)
+        end
+
+        def completed_item_problem(record, item, kind)
+          return "response closed an output item that was never opened" unless @current
+          unless kind == @current.kind
+            return "response changed an output item's type before closing it"
+          end
+          if @current.item_id && item["id"] && item["id"] != @current.item_id
+            return "response closed a different output item than it opened"
+          end
+          if @current.output_index && record["output_index"] &&
+             record["output_index"] != @current.output_index
+            return "response closed an unexpected output index"
+          end
+
+          nil
+        end
+
+        def finish_refusal?(item, kind, &)
+          return false unless kind == :text && (error = refusal_error(item))
+
+          index = @current.index
+          @refusal_error = error
+          if @current.text.empty?
+            @current = nil
+            emit_event(:text_end, content_index: index, content: "", &)
+          else
+            close_current(&)
+          end
+          true
+        end
+
+        def commit_item(item, kind, &)
+          index = @current.index
+          block = build_block(kind, item, streamed: @current)
           @blocks << block
           @current = nil
           fields = { content_index: index }
@@ -138,7 +270,35 @@ module Mistri
           emit_event(:"#{kind}_end", **fields.compact, &)
         end
 
-        def build_block(kind, item)
+        # A refusal is an explicit provider verdict outside the requested
+        # schema, not an empty successful answer to send through a fix loop.
+        def refusal_error(item)
+          part = Array(item["content"]).find { |candidate| candidate["type"] == "refusal" }
+          return unless part
+
+          detail = bounded_refusal(part["refusal"])
+          refusal_from(detail)
+        end
+
+        def refusal_from(detail)
+          message = "OpenAI refused the request"
+          message = "#{message}: #{detail}" unless detail.empty?
+          InvalidRequestError.new(message)
+        end
+
+        def bounded_refusal(value)
+          bounded_utf8(value, MAX_REFUSAL_BYTES)
+        end
+
+        def bounded_utf8(value, limit)
+          return "" unless value.is_a?(String)
+
+          prefix = value.byteslice(0, limit).dup.force_encoding(value.encoding)
+          prefix.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "?")
+                .scrub.byteslice(0, limit).to_s.force_encoding(Encoding::UTF_8).scrub
+        end
+
+        def build_block(kind, item, streamed: nil)
           case kind
           when :text
             text = Array(item["content"]).filter_map { |part| part["text"] }.join
@@ -147,23 +307,31 @@ module Mistri
             summary = Array(item["summary"]).filter_map { |part| part["text"] }.join("\n\n")
             Content::Thinking.new(thinking: summary, signature: JSON.generate(item))
           when :toolcall
+            arguments, error = if item.key?("arguments")
+                                 ToolArguments.parse_json(item["arguments"])
+                               elsif streamed&.argument_error
+                                 [nil, streamed.argument_error]
+                               else
+                                 [nil, "invalid_json"]
+                               end
             ToolCall.new(id: item["call_id"], name: item["name"],
-                         arguments: parse_arguments(item["arguments"]), signature: item["id"])
+                         arguments:, signature: item["id"], arguments_error: error)
           end
         end
 
-        def parse_arguments(raw)
-          parsed = raw.to_s.strip.empty? ? {} : JSON.parse(raw)
-          parsed.is_a?(Hash) ? parsed : {}
-        rescue JSON::ParserError
-          fallback = PartialJson.parse(raw)
-          fallback.is_a?(Hash) ? fallback : {}
-        end
-
-        def finish_response(response)
-          @status = response["status"] || "completed"
+        def finish_response(record, &)
+          response = record["response"] || {}
+          if @current
+            protocol_error("response ended before output_item.done closed its output item",
+                           &)
+          end
+          expected = TERMINAL_STATUSES.fetch(record["type"])
+          if response["status"] && response["status"] != expected
+            protocol_error("response terminal event disagreed with its status", &)
+          end
+          @status = expected
           @incomplete_reason = response.dig("incomplete_details", "reason")
-          @error = failure_error(response["error"]) if @status == "failed"
+          @error ||= failure_error(response["error"]) if @status == "failed"
           @service_tier = response["service_tier"]
           usage = response["usage"]
           @usage = priced(parse_usage(usage)) if usage
@@ -179,9 +347,14 @@ module Mistri
           code = error["code"].to_s
           message = [code, error["message"] || "the response failed"]
                     .reject(&:empty?).join(": ")
+          classify_error(code, message, unknown: InvalidRequestError)
+        end
+
+        def classify_error(code, message, unknown:)
           klass = if code.include?("rate_limit") then RateLimitError
                   elsif code.include?("server") then ServerError
                   elsif code.include?("timeout") then ProviderError
+                  elsif code.empty? then unknown
                   else InvalidRequestError
                   end
           klass.new(message)
@@ -200,7 +373,8 @@ module Mistri
         def filter_error = InvalidRequestError.new("the response was cut by the content filter")
 
         def terminal(reason, text, error: nil, &emit)
-          @message = assemble(stop_reason: reason, error_message: text, error: error)
+          close_current(interrupted: true, &emit)
+          @message = assemble(final: true, stop_reason: reason, error_message: text, error: error)
           emit&.call(Event.new(type: :error, reason: reason, message: @message,
                                error_message: text))
           @message
@@ -210,21 +384,87 @@ module Mistri
           emit&.call(Event.new(type:, partial: assemble, **fields))
         end
 
-        def assemble(**meta)
-          blocks = @blocks.dup
-          blocks << partial_block(@current) if @current
-          Message.assistant(content: blocks, model: @model, provider: :openai,
-                            usage: @usage, **meta)
+        def matching_current?(kind, label, record, &)
+          return false if @error
+
+          unless @current&.kind == kind
+            protocol_error("response sent a #{label} outside its matching output item", &)
+            return false
+          end
+          if @current.item_id && record["item_id"] && record["item_id"] != @current.item_id
+            protocol_error("response sent a #{label} for a different output item", &)
+            return false
+          end
+          if @current.output_index && record["output_index"] &&
+             record["output_index"] != @current.output_index
+            protocol_error("response sent a #{label} for an unexpected output index", &)
+            return false
+          end
+
+          true
         end
 
-        def partial_block(builder)
+        def protocol_error(message, &)
+          @error ||= ProviderError.new(message)
+          close_current(interrupted: true, &)
+          invalidate_tool_calls
+          nil
+        end
+
+        def invalidate_tool_calls
+          @blocks.map! do |block|
+            if block.is_a?(ToolCall)
+              block.with(arguments: nil, arguments_error: "incomplete")
+            else
+              block
+            end
+          end
+        end
+
+        def close_current(interrupted: false, &)
+          return unless @current
+
+          builder = @current
+          block = interrupted ? interrupted_block(builder) : partial_block(builder, final: true)
+          @blocks << block
+          @current = nil
+          fields = { content_index: builder.index }
+          fields[:tool_call] = block if block.is_a?(ToolCall)
+          unless block.is_a?(ToolCall)
+            fields[:content] = block.respond_to?(:text) ? block.text : block.thinking
+          end
+          emit_event(:"#{builder.kind}_end", **fields, &)
+          block
+        end
+
+        def interrupted_block(builder)
           case builder.kind
           when :text then Content::Text.new(text: builder.text)
           when :thinking then Content::Thinking.new(thinking: builder.text)
           when :toolcall
-            args = PartialJson.parse(builder.json)
+            ToolCall.new(id: builder.call_id, name: builder.name, arguments: nil,
+                         signature: builder.item_id, arguments_error: "incomplete")
+          end
+        end
+
+        def assemble(final: false, **meta)
+          blocks = @blocks.dup
+          if @current && (block = partial_block(@current, final:))
+            blocks << block
+          end
+          Message.assistant(content: blocks, model: @model, provider: :openai,
+                            usage: @usage, **meta)
+        end
+
+        def partial_block(builder, final: false)
+          case builder.kind
+          when :text then Content::Text.new(text: builder.text)
+          when :thinking then Content::Thinking.new(thinking: builder.text)
+          when :toolcall
+            return nil if final
+
             ToolCall.new(id: "pending", name: "pending",
-                         arguments: args.is_a?(Hash) ? args : {})
+                         arguments: builder.argument_preview, canonicalize: false)
           end
         end
 
@@ -246,7 +486,7 @@ module Mistri
           rates = Models.rates(@model, usage:, at: @pricing_at)
           rates ? usage.with_cost(rates) : usage
         end
-      end
+      end # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/lib/mistri/providers/openai/serializer.rb
+++ b/lib/mistri/providers/openai/serializer.rb
@@ -62,22 +62,23 @@ module Mistri
         end
 
         def assistant_items(msg)
-          msg.content.filter_map { |block| assistant_item(block) }
+          own = msg.provider == :openai
+          msg.content.filter_map { |block| assistant_item(block, own:) }
         end
 
-        def assistant_item(block)
+        def assistant_item(block, own: true)
           case block
-          when Content::Thinking then reasoning_item(block)
-          when Content::Text then message_item(block)
-          when ToolCall then function_call_item(block)
+          when Content::Thinking then reasoning_item(block, own:)
+          when Content::Text then message_item(block, own:)
+          when ToolCall then function_call_item(block, own:)
           end
         end
 
         # The reasoning item replays exactly as it arrived or not at all. An
         # item without encrypted_content triggers a server-side id lookup that
         # cannot succeed under store: false, so it drops rather than 404s.
-        def reasoning_item(block)
-          return nil unless block.signature
+        def reasoning_item(block, own: true)
+          return nil unless own && block.signature
 
           item = JSON.parse(block.signature)
           item.is_a?(Hash) && item["encrypted_content"] ? item : nil
@@ -85,17 +86,17 @@ module Mistri
           nil
         end
 
-        def message_item(block)
+        def message_item(block, own: true)
           item = { type: "message", role: "assistant",
                    content: [{ type: "output_text", text: block.text }] }
-          item[:id] = block.signature if block.signature
+          item[:id] = block.signature if own && block.signature
           item
         end
 
-        def function_call_item(block)
+        def function_call_item(block, own: true)
           item = { type: "function_call", call_id: block.id, name: block.name,
-                   arguments: JSON.generate(block.arguments) }
-          item[:id] = block.signature if block.signature
+                   arguments: JSON.generate(ToolArguments.replay_value(block)) }
+          item[:id] = block.signature if own && block.signature && !block.arguments_error
           item
         end
       end

--- a/lib/mistri/providers/schema_capabilities.rb
+++ b/lib/mistri/providers/schema_capabilities.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+module Mistri
+  module Providers
+    # Keeps provider grammar limits out of task semantics: an incompatible
+    # native schema is omitted while the prompt and local validator stay exact.
+    module SchemaCapabilities
+      COMMON_KEYWORDS = %w[
+        type properties required additionalProperties items enum description
+      ].freeze
+      PROFILES = {
+        openai: {
+          keywords: COMMON_KEYWORDS,
+          root_object: true,
+          boolean_schemas: false,
+          tuple_arrays: false,
+          all_properties_required: true,
+          max_depth: 10,
+          max_properties: 5000,
+          max_enum_values: 1000,
+          max_schema_string_chars: 120_000,
+          large_enum_threshold: 250,
+          max_large_enum_chars: 15_000
+        }.freeze,
+        anthropic: {
+          keywords: COMMON_KEYWORDS,
+          root_object: false,
+          boolean_schemas: false,
+          tuple_arrays: false,
+          all_properties_required: false,
+          max_optional_properties: 24
+        }.freeze,
+        gemini: {
+          keywords: (COMMON_KEYWORDS + %w[prefixItems format title]).freeze,
+          root_object: false,
+          boolean_schemas: true,
+          tuple_arrays: true,
+          all_properties_required: false,
+          formats: %w[date-time date time].freeze,
+          enum_types: %w[string number integer].freeze
+        }.freeze
+      }.freeze
+
+      module_function
+
+      def derive(schema, provider)
+        profile = PROFILES.fetch(provider)
+        state = { properties: 0, optional_properties: 0, enum_values: 0,
+                  schema_string_chars: 0 }
+        return unless supported?(schema, profile, state, root: true, depth: 0)
+
+        schema
+      end
+
+      def supported?(schema, profile, state, depth:, root: false)
+        return profile[:boolean_schemas] if schema.equal?(true) || schema.equal?(false)
+        return false unless schema_shape_supported?(schema, profile)
+
+        type = schema["type"]
+        depth += 1 if %w[object array].include?(type)
+        return false unless node_supported?(schema, type, profile, state, root:, depth:)
+
+        child_schemas(schema).all? do |member|
+          supported?(member, profile, state, depth:)
+        end
+      end
+      private_class_method :supported?
+
+      def schema_shape_supported?(schema, profile)
+        schema.is_a?(Hash) && schema["type"].is_a?(String) &&
+          (schema.keys - profile[:keywords]).empty?
+      end
+      private_class_method :schema_shape_supported?
+
+      def node_supported?(schema, type, profile, state, root:, depth:)
+        within_limit?(depth, profile[:max_depth]) &&
+          root_supported?(type, profile, root) &&
+          object_supported?(schema, type, profile, state) &&
+          array_supported?(schema, type, profile) &&
+          format_supported?(schema, type, profile) &&
+          enum_supported?(schema, type, profile, state)
+      end
+      private_class_method :node_supported?
+
+      def root_supported?(type, profile, root)
+        !root || !profile[:root_object] || type == "object"
+      end
+      private_class_method :root_supported?
+
+      def object_supported?(schema, type, profile, state)
+        object_keywords = schema.key?("properties") || schema.key?("required") ||
+                          schema.key?("additionalProperties")
+        return true unless type == "object" || object_keywords
+        return false unless valid_object_shape?(schema, type)
+
+        properties = schema["properties"]
+        required = schema["required"]
+        return false unless required_properties_declared?(required, properties)
+
+        required_index = required.to_h { |name| [name, true] }
+        record_object_limits(state, properties, required_index)
+        return false unless object_limits_supported?(state, profile)
+        return true unless profile[:all_properties_required]
+
+        required_index.length == properties.length &&
+          required_index.each_key.all? { |key| properties.key?(key) }
+      end
+      private_class_method :object_supported?
+
+      def required_properties_declared?(required, properties)
+        required.all? { |name| properties.key?(name) }
+      end
+      private_class_method :required_properties_declared?
+
+      def valid_object_shape?(schema, type)
+        type == "object" && schema["properties"].is_a?(Hash) &&
+          schema["required"].is_a?(Array) && schema["additionalProperties"] == false
+      end
+      private_class_method :valid_object_shape?
+
+      def record_object_limits(state, properties, required)
+        state[:properties] += properties.length
+        state[:optional_properties] += properties.keys.count { |name| !required.key?(name) }
+        state[:schema_string_chars] += properties.keys.sum(&:length)
+      end
+      private_class_method :record_object_limits
+
+      def object_limits_supported?(state, profile)
+        within_limit?(state[:properties], profile[:max_properties]) &&
+          within_limit?(state[:optional_properties], profile[:max_optional_properties]) &&
+          within_limit?(state[:schema_string_chars], profile[:max_schema_string_chars])
+      end
+      private_class_method :object_limits_supported?
+
+      def array_supported?(schema, type, profile)
+        array_keywords = schema.key?("items") || schema.key?("prefixItems")
+        return true unless type == "array" || array_keywords
+        return false unless type == "array"
+        return false if schema.key?("prefixItems") && !profile[:tuple_arrays]
+        return false unless schema.key?("items") || schema.key?("prefixItems")
+
+        true
+      end
+      private_class_method :array_supported?
+
+      def format_supported?(schema, type, profile)
+        return true unless schema.key?("format")
+
+        profile[:formats]&.include?(schema["format"]) && type == "string"
+      end
+      private_class_method :format_supported?
+
+      def enum_supported?(schema, type, profile, state)
+        values = schema["enum"]
+        return true unless values
+        return false unless values.is_a?(Array)
+        return false unless enum_domain_supported?(values, type, profile)
+
+        state[:enum_values] += values.length
+        strings = values.grep(String)
+        string_chars = strings.sum(&:length)
+        state[:schema_string_chars] += string_chars
+        return false unless within_limit?(state[:enum_values], profile[:max_enum_values])
+        return false unless within_limit?(state[:schema_string_chars],
+                                          profile[:max_schema_string_chars])
+
+        threshold = profile[:large_enum_threshold]
+        return true unless threshold && values.length > threshold && strings.length == values.length
+
+        string_chars <= profile[:max_large_enum_chars]
+      end
+      private_class_method :enum_supported?
+
+      def enum_domain_supported?(values, type, profile)
+        return true unless profile[:enum_types]
+        return false unless profile[:enum_types].include?(type)
+
+        case type
+        when "string" then values.all?(String)
+        when "number" then values.all? { |value| finite_number?(value) }
+        when "integer" then values.all? { |value| integer_number?(value) }
+        end
+      end
+      private_class_method :enum_domain_supported?
+
+      def finite_number?(value)
+        value.is_a?(Integer) || (value.is_a?(Float) && value.finite?)
+      end
+      private_class_method :finite_number?
+
+      def integer_number?(value)
+        value.is_a?(Integer) || (value.is_a?(Float) && value.finite? && value.to_i == value)
+      end
+      private_class_method :integer_number?
+
+      def within_limit?(value, limit)
+        !limit || value <= limit
+      end
+      private_class_method :within_limit?
+
+      def child_schemas(schema)
+        children = schema.fetch("properties", {}).values
+        items = schema["items"]
+        children << items if items.is_a?(Hash) || items.equal?(true) || items.equal?(false)
+        children.concat(schema.fetch("prefixItems", []))
+        additional = schema["additionalProperties"]
+        children << additional if additional.is_a?(Hash) || additional.equal?(true)
+        children
+      end
+      private_class_method :child_schemas
+    end
+    private_constant :SchemaCapabilities
+  end
+end

--- a/lib/mistri/schema.rb
+++ b/lib/mistri/schema.rb
@@ -1,21 +1,22 @@
 # frozen_string_literal: true
 
+require "json"
+require "uri"
+
+require_relative "tool_arguments"
+
 module Mistri
-  # A small builder for tool argument schemas, so a tool declares its inputs
-  # in Ruby instead of hand-writing JSON Schema. It emits the object schema
-  # every provider accepts:
-  #
-  #   Schema.build do
-  #     string :city, "City name", required: true
-  #     string :units, "Temperature units", enum: %w[celsius fahrenheit]
-  #     integer :days, "Forecast length"
-  #   end
-  #
-  # A raw JSON Schema hash is always accepted directly for anything the
-  # builder does not cover, so the DSL is a convenience, never a ceiling.
+  # Builds tool schemas and validates the portable JSON Schema subset Mistri owns.
   class Schema
-    # instance_exec, not instance_eval: it binds self to the builder without
-    # passing an argument, so a zero-arity lambda works as naturally as a proc.
+    DIALECT = "https://json-schema.org/draft/2020-12/schema"
+    MAX_VIOLATIONS = 8
+    MAX_DEPTH = 64
+    MAX_NODES = 10_000
+    MAX_BYTES = 8 * 1024 * 1024
+    JSON_TYPES = %w[object array string integer number boolean null].freeze
+
+    # instance_exec binds self to the builder without passing an argument, so
+    # zero-arity lambdas and procs behave the same way.
     def self.build(&block)
       raise ConfigurationError, "schema needs a block" unless block
 
@@ -63,35 +64,78 @@ module Mistri
     end
 
     class << self
-      # Violations of a value against the schema subset the harness emits and
-      # providers constrain: types (including type arrays), object properties
-      # with required and additionalProperties: false, array items, enum.
-      # Empty means valid; entries are human-readable, written to be fed back
-      # to a model for one-shot correction.
-      def violations(value, schema, path = "$")
-        spec = schema.transform_keys(&:to_s)
-        mismatch = type_violation(value, spec, path)
-        return [mismatch] if mismatch
+      # Definition checks cover the complete JSON document. Unsupported
+      # assertion keywords remain provider guidance in this general API.
+      def validate_definition!(schema)
+        Compiled.new(schema)
+        schema
+      end
 
-        errors = []
-        if (enum = spec["enum"]) && !enum.include?(value)
-          errors << "#{path} must be one of: #{enum.join(", ")}"
-        end
-        case value
-        when Hash then errors.concat(object_violations(value, spec, path))
-        when Array then errors.concat(array_violations(value, spec, path))
-        end
-        errors
+      # Returns bounded, model-readable failures for the subset Mistri owns:
+      # type, enum, required, properties, additionalProperties, items, and
+      # prefixItems. The input is first normalized to the JSON value providers see.
+      def violations(value, schema, path = "$")
+        Compiled.new(schema).violations(value, path)
+      end
+
+      # A Tool keeps this plan for its lifetime. complete is explicit authority
+      # for a host validator to own schema interactions core cannot represent.
+      def tool_validator(schema, complete: false)
+        Compiled.new(schema, tool: true, complete: complete)
+      end
+
+      # MCP schemas are untrusted contracts. Core may preserve unsupported
+      # assertions as provider guidance for host-authored tools, but a remote
+      # schema needs an explicitly complete validator before policy can trust it.
+      def validate_mcp!(schema, complete: false)
+        compiled = Compiled.new(schema, tool: true, complete: complete)
+        AssertionContract.new(complete:, context: "MCP input schema").call(compiled.schema)
+        compiled.schema
+      end
+
+      # Paths to standard assertions that the zero-dependency validator does
+      # not implement. An empty list means local validation owns the contract.
+      def unsupported_assertions(schema)
+        compiled = Compiled.new(schema)
+        AssertionScanner.new.call(compiled.schema).map(&:first).freeze
+      end
+
+      # Task mode validates only schemas whose complete assertion contract is
+      # implemented locally; provider constrained decoding is an optimization.
+      def task_violations(value, schema, path = "$")
+        task_plan(schema).violations(value, path)
+      end
+
+      # One task plan owns the strict prompt and validation schema. Providers
+      # may derive a compatible native constraint, but local validation remains
+      # the guarantee when their structured-output subset is narrower.
+      def task_plan(schema, all_required: false)
+        source = compile_task_schema(schema)
+        strict = strict_at(source.schema, all_required:, path: "$")
+        TaskPlan.new(Compiled.new(strict))
       end
 
       # Prepares a schema for constrained decoding without turning a freeform
-      # object into one that accepts only {}. Direct objects with declared
-      # properties close for provider strict modes; explicit openness fails.
+      # object into one that accepts only {}. Definition compilation happens
+      # first so recursive transformation never sees a cyclic or hostile graph.
       def strict(schema, all_required: false)
-        strict_at(schema, all_required: all_required, path: "$")
+        source = Compiled.new(schema)
+        strict_at(source.schema, all_required:, path: "$")
+      end
+
+      private
+
+      def compile_task_schema(schema)
+        compiled = Compiled.new(schema)
+        AssertionContract.new(complete: false, context: "task output schema").call(
+          compiled.schema
+        )
+        compiled
       end
 
       def strict_at(schema, all_required:, path:)
+        return schema if schema.equal?(true) || schema.equal?(false)
+
         spec = schema.transform_keys(&:to_s)
         out = spec.dup
         if spec["type"] == "object" || spec.key?("properties")
@@ -100,28 +144,32 @@ module Mistri
           props = raw_props.to_h do |key, member|
             member_path = "#{path}.#{key}"
             [key.to_s, strict_at(member, all_required: all_required, path: member_path)]
-          end
+          end.freeze
           out["properties"] = props
           out["additionalProperties"] = false
-          out["required"] = all_required ? props.keys : Array(spec["required"]).map(&:to_s)
+          required = all_required ? props.keys : Array(spec["required"]).map(&:to_s)
+          out["required"] = required.freeze
         end
-        if spec["items"].is_a?(Hash)
+        if schema_value?(spec["items"])
           out["items"] = strict_at(
             spec["items"], all_required: all_required, path: "#{path}[]"
           )
         end
-        out
+        strict_prefix_items(spec, out, all_required, path)
+        out.freeze
       end
-      private :strict_at
 
-      TYPES = {
-        "object" => ->(v) { v.is_a?(Hash) }, "array" => ->(v) { v.is_a?(Array) },
-        "string" => ->(v) { v.is_a?(String) }, "integer" => ->(v) { v.is_a?(Integer) },
-        "number" => ->(v) { v.is_a?(Numeric) }, "boolean" => ->(v) { [true, false].include?(v) },
-        "null" => lambda(&:nil?)
-      }.freeze
+      def strict_prefix_items(spec, out, all_required, path)
+        return unless spec["prefixItems"].is_a?(Array)
 
-      private
+        out["prefixItems"] = spec["prefixItems"].each_with_index.map do |member, index|
+          strict_at(member, all_required: all_required, path: "#{path}[#{index}]")
+        end.freeze
+      end
+
+      def schema_value?(value)
+        value.is_a?(Hash) || value.equal?(true) || value.equal?(false)
+      end
 
       def reject_open_object!(spec, properties, path)
         if spec.key?("additionalProperties") && spec["additionalProperties"] != false
@@ -133,37 +181,43 @@ module Mistri
         raise ConfigurationError,
               "#{path} is freeform and cannot be represented by a strict schema"
       end
+    end
 
-      def type_violation(value, spec, path)
-        names = Array(spec["type"]).map(&:to_s)
-        return nil if names.empty?
-        return nil if names.any? { |name| TYPES.fetch(name, ->(_) { true }).call(value) }
+    # Shared JSON semantics keep definition and instance handling identical.
+    module ValidationSupport
+      IDENTIFIER = /\A[A-Za-z_][A-Za-z0-9_]*\z/
+      MAX_KEY_BYTES = 64
+      MAX_PATH_BYTES = 240
+      MAX_SEGMENT_BYTES = 96
 
-        "#{path} must be #{names.join(" or ")}, got #{json_type(value)}"
+      module_function
+
+      def root_path(path)
+        bounded_utf8(path.to_s, MAX_PATH_BYTES).gsub(/[[:cntrl:]]/, "?")
       end
 
-      def object_violations(value, spec, path)
-        props = (spec["properties"] || {}).transform_keys(&:to_s)
-        errors = Array(spec["required"]).map(&:to_s).filter_map do |key|
-          "#{path}.#{key} is required" unless value.key?(key)
-        end
-        value.each do |key, member|
-          if (member_schema = props[key.to_s])
-            errors.concat(violations(member, member_schema, "#{path}.#{key}"))
-          elsif spec["additionalProperties"] == false
-            errors << "#{path}.#{key} is not allowed"
-          end
-        end
-        errors
+      def child_path(path, key)
+        key_text = bounded_utf8(key, MAX_KEY_BYTES)
+        segment = key_text.match?(IDENTIFIER) ? ".#{key_text}" : "[#{JSON.generate(key_text)}]"
+        segment = "[\"...\"]" if segment.bytesize > MAX_SEGMENT_BYTES
+        joined = "#{path}#{segment}"
+        joined.bytesize <= MAX_PATH_BYTES ? joined : "$...#{segment}"
       end
 
-      def array_violations(value, spec, path)
-        items = spec["items"]
-        return [] unless items.is_a?(Hash)
+      def index_path(path, index)
+        segment = "[#{index}]"
+        joined = "#{path}#{segment}"
+        joined.bytesize <= MAX_PATH_BYTES ? joined : "$...#{segment}"
+      end
 
-        value.each_with_index.flat_map do |member, index|
-          violations(member, items, "#{path}[#{index}]")
-        end
+      def item_path(path) = "#{path}[]"
+
+      def json_number?(value)
+        value.is_a?(Integer) || (value.is_a?(Float) && value.finite?)
+      end
+
+      def json_integer?(value)
+        value.is_a?(Integer) || (value.is_a?(Float) && value.finite? && value.modulo(1).zero?)
       end
 
       def json_type(value)
@@ -172,12 +226,721 @@ module Mistri
         when Array then "array"
         when String then "string"
         when Integer then "integer"
-        when Numeric then "number"
+        when Float then "number"
         when true, false then "boolean"
         when nil then "null"
-        else value.class.name
+        else "non-JSON value"
+        end
+      end
+
+      def bounded_utf8(value, max_bytes)
+        source = value.to_s
+        truncated = source.bytesize > max_bytes
+        source = source.byteslice(0, max_bytes) if truncated
+        text = source.encode(Encoding::UTF_8, invalid: :replace,
+                                              undef: :replace, replace: "?")
+        return text if !truncated && text.bytesize <= max_bytes
+
+        prefix = text.byteslice(0, max_bytes - 3).dup.force_encoding(Encoding::UTF_8).scrub
+        "#{prefix}..."
+      end
+      private_class_method :bounded_utf8
+    end
+    private_constant :ValidationSupport
+
+    # Canonicalization creates the exact immutable JSON document provider
+    # serializers receive, preventing encoding and post-definition mutation drift.
+    class DefinitionCompiler
+      def initialize
+        @nodes = 0
+        @bytes = 0
+        @active = {}.compare_by_identity
+      end
+
+      def call(schema)
+        owned = copy(schema, "$", 0)
+        unless ToolArguments.serialized_size_within_limit?(owned, limit: MAX_BYTES)
+          configuration!("$", "exceeds the schema byte limit")
+        end
+        DefinitionValidator.new.call(owned)
+        owned
+      end
+
+      private
+
+      def copy(value, path, depth)
+        count!(path, depth)
+        case value
+        when Hash then copy_hash(value, path, depth)
+        when Array then copy_array(value, path, depth)
+        when String then copy_string(value, path)
+        when Symbol then copy_string(value.to_s, path)
+        when Integer, true, false, nil then value
+        when Float
+          configuration!(path, "must contain only finite JSON numbers") unless value.finite?
+          value
+        else configuration!(path, "must contain only JSON values")
+        end
+      end
+
+      def copy_hash(value, path, depth)
+        within(value, path) do
+          value.each_with_object({}) do |(key, member), out|
+            unless key.is_a?(String) || key.is_a?(Symbol)
+              configuration!(path, "must use string or symbol keys")
+            end
+            name = copy_string(key.to_s, path)
+            configuration!(path, "contains duplicate JSON keys") if out.key?(name)
+            out[name] = copy(member, ValidationSupport.child_path(path, name), depth + 1)
+          end.freeze
+        end
+      end
+
+      def copy_array(value, path, depth)
+        within(value, path) do
+          value.each_with_index.map do |member, index|
+            copy(member, ValidationSupport.index_path(path, index), depth + 1)
+          end.freeze
+        end
+      end
+
+      def copy_string(value, path)
+        if value.encoding == Encoding::UTF_8
+          configuration!(path, "must use valid UTF-8 strings") unless value.valid_encoding?
+          string = value.dup
+        else
+          string = value.encode(Encoding::UTF_8)
+        end
+        @bytes += string.bytesize
+        configuration!(path, "exceeds the schema byte limit") if @bytes > MAX_BYTES
+        string.freeze
+      rescue EncodingError
+        configuration!(path, "must use valid UTF-8 strings")
+      end
+
+      def within(value, path)
+        configuration!(path, "contains a cycle") if @active[value]
+
+        @active[value] = true
+        inserted = true
+        yield
+      ensure
+        @active.delete(value) if inserted
+      end
+
+      def count!(path, depth)
+        configuration!(path, "exceeds the schema depth limit") if depth > MAX_DEPTH
+        @nodes += 1
+        configuration!(path, "exceeds the schema size limit") if @nodes > MAX_NODES
+      end
+
+      def configuration!(path, problem)
+        raise ConfigurationError, "#{path} #{problem}"
+      end
+    end
+    private_constant :DefinitionCompiler
+
+    # Keyword shape checks are distinct from the full-document JSON scan so
+    # ignored extensions cannot evade ownership and resource limits.
+    class DefinitionValidator
+      STRING_KEYWORDS = %w[
+        title description pattern format contentEncoding contentMediaType $comment
+      ].freeze
+      BOOLEAN_KEYWORDS = %w[uniqueItems deprecated readOnly writeOnly].freeze
+      NUMBER_KEYWORDS = %w[maximum exclusiveMaximum minimum exclusiveMinimum].freeze
+      NONNEGATIVE_INTEGER_KEYWORDS = %w[
+        maxLength minLength maxItems minItems maxContains minContains
+        maxProperties minProperties
+      ].freeze
+      URI_KEYWORDS = %w[$id $ref $dynamicRef].freeze
+      ANCHOR = /\A[A-Za-z_][-A-Za-z0-9._]*\z/
+      SCHEMA_MAPS = %w[$defs definitions dependentSchemas].freeze
+      SCHEMA_ARRAYS = %w[allOf anyOf oneOf].freeze
+      SCHEMA_VALUES = %w[
+        not if then else contains propertyNames unevaluatedProperties
+        unevaluatedItems contentSchema
+      ].freeze
+
+      def call(schema)
+        walk_schema(schema, "$")
+        schema
+      end
+
+      private
+
+      def walk_schema(schema, path)
+        return if schema.equal?(true) || schema.equal?(false)
+
+        configuration!(path, "must be a schema object or boolean") unless schema.is_a?(Hash)
+        validate_dialect(schema, path)
+        validate_core_keywords(schema, path)
+        validate_annotation_keywords(schema, path)
+        validate_assertion_shapes(schema, path)
+        validate_type(schema, path)
+        validate_enum(schema, path)
+        validate_required(schema, path)
+        validate_schema_map(schema, "properties", path)
+        validate_schema_map(schema, "patternProperties", path)
+        validate_items(schema, path)
+        validate_prefix_items(schema, path)
+        validate_additional_properties(schema, path)
+        validate_dependent_required(schema, path)
+        SCHEMA_MAPS.each { |keyword| validate_schema_map(schema, keyword, path) }
+        SCHEMA_ARRAYS.each { |keyword| validate_schema_array(schema, keyword, path) }
+        SCHEMA_VALUES.each { |keyword| validate_schema_value(schema, keyword, path) }
+      end
+
+      def validate_dialect(spec, path)
+        return unless spec.key?("$schema")
+        return if spec["$schema"] == DIALECT
+
+        configuration!("#{path}.$schema", "must declare JSON Schema 2020-12")
+      end
+
+      def validate_core_keywords(spec, path)
+        validate_uri_keywords(spec, path)
+        validate_anchor_keywords(spec, path)
+        validate_vocabulary(spec, path)
+      end
+
+      def validate_uri_keywords(spec, path)
+        URI_KEYWORDS.each do |keyword|
+          next unless spec.key?(keyword)
+
+          uri = validate_uri_reference(spec[keyword], "#{path}.#{keyword}")
+          next unless keyword == "$id" && uri.fragment && !uri.fragment.empty?
+
+          configuration!("#{path}.$id", "must not contain a non-empty fragment")
+        end
+      end
+
+      def validate_anchor_keywords(spec, path)
+        %w[$anchor $dynamicAnchor].each do |keyword|
+          next unless spec.key?(keyword)
+          next if spec[keyword].is_a?(String) && spec[keyword].match?(ANCHOR)
+
+          configuration!("#{path}.#{keyword}", "must be a valid plain-name anchor")
+        end
+      end
+
+      def validate_vocabulary(spec, path)
+        return unless spec.key?("$vocabulary")
+
+        vocabulary = spec["$vocabulary"]
+        unless vocabulary.is_a?(Hash) && vocabulary.values.all? do |required|
+                 required.equal?(true) || required.equal?(false)
+               end
+          configuration!("#{path}.$vocabulary", "must map URI strings to booleans")
+        end
+        vocabulary.each_key do |uri|
+          validate_absolute_normalized_uri(uri, "#{path}.$vocabulary")
+        end
+      end
+
+      def validate_annotation_keywords(spec, path)
+        STRING_KEYWORDS.each do |keyword|
+          next unless spec.key?(keyword)
+          next if spec[keyword].is_a?(String)
+
+          configuration!("#{path}.#{keyword}", "must be a string")
+        end
+        BOOLEAN_KEYWORDS.each do |keyword|
+          next unless spec.key?(keyword)
+          next if spec[keyword].equal?(true) || spec[keyword].equal?(false)
+
+          configuration!("#{path}.#{keyword}", "must be a boolean")
+        end
+        return unless spec.key?("examples")
+        return if spec["examples"].is_a?(Array)
+
+        configuration!("#{path}.examples", "must be an array")
+      end
+
+      def validate_assertion_shapes(spec, path)
+        NUMBER_KEYWORDS.each do |keyword|
+          next unless spec.key?(keyword)
+          next if ValidationSupport.json_number?(spec[keyword])
+
+          configuration!("#{path}.#{keyword}", "must be a number")
+        end
+        NONNEGATIVE_INTEGER_KEYWORDS.each do |keyword|
+          next unless spec.key?(keyword)
+
+          value = spec[keyword]
+          next if ValidationSupport.json_integer?(value) && value >= 0
+
+          configuration!("#{path}.#{keyword}", "must be a non-negative integer")
+        end
+        return unless spec.key?("multipleOf")
+        return if ValidationSupport.json_number?(spec["multipleOf"]) && spec["multipleOf"].positive?
+
+        configuration!("#{path}.multipleOf", "must be a number greater than zero")
+      end
+
+      def validate_uri_reference(value, path)
+        configuration!(path, "must be a URI-reference string") unless value.is_a?(String)
+
+        URI.parse(value)
+      rescue URI::InvalidURIError
+        configuration!(path, "must be a valid URI-reference")
+      end
+
+      def validate_absolute_normalized_uri(value, path)
+        configuration!(path, "must use absolute normalized URI keys") unless value.is_a?(String)
+
+        uri = URI.parse(value)
+        return uri if uri.absolute? && uri.normalize.to_s == value
+
+        configuration!(path, "must use absolute normalized URI keys")
+      rescue URI::InvalidURIError
+        configuration!(path, "must use absolute normalized URI keys")
+      end
+
+      def validate_type(spec, path)
+        return unless spec.key?("type")
+
+        raw = spec["type"]
+        names = raw.is_a?(Array) ? raw : [raw]
+        valid = !names.empty? && names.all?(String)
+        configuration!("#{path}.type", "must be a primitive or non-empty union") unless valid
+        unknown = names - JSON_TYPES
+        configuration!("#{path}.type", "contains an unknown JSON type") unless unknown.empty?
+        configuration!("#{path}.type", "must not repeat a JSON type") if names.uniq != names
+      end
+
+      def validate_enum(spec, path)
+        return unless spec.key?("enum")
+
+        values = spec["enum"]
+        configuration!("#{path}.enum", "must be an array") unless values.is_a?(Array)
+      end
+
+      def validate_required(spec, path)
+        return unless spec.key?("required")
+
+        keys = spec["required"]
+        unless keys.is_a?(Array) && keys.all?(String)
+          configuration!("#{path}.required", "must be an array of unique strings")
+        end
+        return if keys.uniq == keys
+
+        configuration!("#{path}.required", "must be an array of unique strings")
+      end
+
+      def validate_dependent_required(spec, path)
+        return unless spec.key?("dependentRequired")
+
+        dependencies = spec["dependentRequired"]
+        unless dependencies.is_a?(Hash)
+          configuration!("#{path}.dependentRequired", "must be an object")
+        end
+        dependencies.each do |key, members|
+          next if members.is_a?(Array) && members.all?(String) && members.uniq == members
+
+          member_path = ValidationSupport.child_path("#{path}.dependentRequired", key)
+          configuration!(member_path, "must be an array of unique strings")
+        end
+      end
+
+      def validate_schema_map(spec, keyword, path)
+        return unless spec.key?(keyword)
+
+        members = spec[keyword]
+        configuration!("#{path}.#{keyword}", "must be an object") unless members.is_a?(Hash)
+        members.each do |key, member|
+          walk_schema(member, ValidationSupport.child_path("#{path}.#{keyword}", key))
+        end
+      end
+
+      def validate_schema_array(spec, keyword, path)
+        return unless spec.key?(keyword)
+
+        members = spec[keyword]
+        unless members.is_a?(Array) && !members.empty?
+          configuration!("#{path}.#{keyword}", "must be a non-empty array of schemas")
+        end
+        members.each_with_index do |member, index|
+          walk_schema(member, ValidationSupport.index_path("#{path}.#{keyword}", index))
+        end
+      end
+
+      def validate_schema_value(spec, keyword, path)
+        return unless spec.key?(keyword)
+
+        walk_schema(spec[keyword], "#{path}.#{keyword}")
+      end
+
+      def validate_items(spec, path)
+        return unless spec.key?("items")
+
+        items = spec["items"]
+        if items.is_a?(Array)
+          configuration!("#{path}.items",
+                         "must be a schema in JSON Schema 2020-12; use prefixItems for tuples")
+        end
+        walk_schema(items, ValidationSupport.item_path(path))
+      end
+
+      def validate_prefix_items(spec, path)
+        return unless spec.key?("prefixItems")
+
+        members = spec["prefixItems"]
+        unless members.is_a?(Array) && !members.empty?
+          configuration!("#{path}.prefixItems", "must be a non-empty array of schemas")
+        end
+        members.each_with_index do |member, index|
+          walk_schema(member, ValidationSupport.index_path("#{path}.prefixItems", index))
+        end
+      end
+
+      def validate_additional_properties(spec, path)
+        return unless spec.key?("additionalProperties")
+
+        walk_schema(spec["additionalProperties"], "#{path}.additionalProperties")
+      end
+
+      def configuration!(path, problem)
+        raise ConfigurationError, "#{path} #{problem}"
+      end
+    end
+    private_constant :DefinitionValidator
+
+    # Finds standard assertions that the portable validator intentionally
+    # leaves to a complete JSON Schema implementation.
+    class AssertionScanner
+      ASSERTIONS = %w[
+        $ref $dynamicRef allOf anyOf oneOf not if then else
+        patternProperties dependentSchemas dependentRequired dependencies
+        propertyNames unevaluatedProperties unevaluatedItems contains
+        multipleOf maximum exclusiveMaximum minimum exclusiveMinimum
+        maxLength minLength pattern maxItems minItems uniqueItems
+        maxContains minContains maxProperties minProperties const
+      ].freeze
+      SCHEMA_MAPS = %w[properties patternProperties $defs definitions dependentSchemas].freeze
+      SCHEMA_ARRAYS = %w[allOf anyOf oneOf prefixItems].freeze
+      SCHEMA_VALUES = %w[
+        not if then else contains propertyNames unevaluatedProperties
+        unevaluatedItems additionalProperties items
+      ].freeze
+
+      def call(schema)
+        @findings = []
+        walk(schema, "$")
+        @findings.freeze
+      end
+
+      private
+
+      def walk(schema, path)
+        return if schema.equal?(true) || schema.equal?(false)
+
+        record_assertions(schema, path)
+        walk_maps(schema, path)
+        walk_arrays(schema, path)
+        walk_values(schema, path)
+      end
+
+      def record_assertions(schema, path)
+        ASSERTIONS.each do |keyword|
+          next unless schema.key?(keyword)
+          next if ignorable_empty_map?(schema, keyword)
+
+          @findings << ["#{path}.#{keyword}".freeze, keyword, schema[keyword]].freeze
+        end
+        schema.fetch("$vocabulary", {}).each do |uri, required|
+          next unless required
+
+          vocabulary_path = ValidationSupport.child_path("#{path}.$vocabulary", uri)
+          @findings << [vocabulary_path.freeze, "$vocabulary", uri].freeze
+        end
+      end
+
+      def ignorable_empty_map?(schema, keyword)
+        return false unless %w[
+          patternProperties dependentSchemas dependentRequired dependencies
+        ].include?(keyword)
+
+        schema[keyword].is_a?(Hash) && schema[keyword].empty?
+      end
+
+      def walk_maps(schema, path)
+        SCHEMA_MAPS.each do |keyword|
+          schema.fetch(keyword, {}).each do |key, member|
+            walk(member, ValidationSupport.child_path("#{path}.#{keyword}", key))
+          end
+        end
+      end
+
+      def walk_arrays(schema, path)
+        SCHEMA_ARRAYS.each do |keyword|
+          Array(schema[keyword]).each_with_index do |member, index|
+            walk(member, ValidationSupport.index_path("#{path}.#{keyword}", index))
+          end
+        end
+      end
+
+      def walk_values(schema, path)
+        SCHEMA_VALUES.each do |keyword|
+          member = schema[keyword]
+          walk(member, "#{path}.#{keyword}") if member.is_a?(Hash)
         end
       end
     end
+    private_constant :AssertionScanner
+
+    # Unsupported assertions are safe as generation guidance for a local Tool,
+    # but not as a claimed validation or remote-policy boundary.
+    class AssertionContract
+      def initialize(complete:, context:)
+        @complete = complete
+        @context = context
+      end
+
+      def call(schema)
+        findings = AssertionScanner.new.call(schema)
+        reject_external_references(findings)
+        return if @complete || findings.empty?
+
+        paths = findings.first(3).map(&:first).join(", ")
+        suffix = findings.length > 3 ? ", and #{findings.length - 3} more" : ""
+        raise ConfigurationError,
+              "#{@context} uses assertions Mistri cannot validate at #{paths}#{suffix}"
+      end
+
+      private
+
+      def reject_external_references(findings)
+        finding = findings.find do |(_, keyword, value)|
+          %w[$ref $dynamicRef].include?(keyword) && !value.start_with?("#")
+        end
+        return unless finding
+
+        raise ConfigurationError,
+              "#{finding.first} must be a same-document reference beginning with #"
+      end
+    end
+    private_constant :AssertionContract
+
+    # Core never approximates regex-key semantics. A full validator is explicit
+    # authority whenever patternProperties can match an argument key.
+    class ToolContract
+      def initialize(complete:)
+        @complete = complete
+      end
+
+      def call(schema)
+        unless schema.is_a?(Hash) && schema["type"] == "object"
+          configuration!("$", "must declare type object for tool arguments")
+        end
+
+        walk(schema, "$")
+      end
+
+      private
+
+      def walk(schema, path)
+        return if schema.equal?(true) || schema.equal?(false)
+
+        require_complete_for_patterns(schema, path)
+        each_subschema(schema, path) { |member, member_path| walk(member, member_path) }
+      end
+
+      def require_complete_for_patterns(spec, path)
+        patterns = spec["patternProperties"]
+        return unless patterns.is_a?(Hash) && !patterns.empty?
+        return if @complete
+
+        configuration!("#{path}.patternProperties",
+                       "non-empty pattern properties require a complete argument validator")
+      end
+
+      def each_subschema(spec, path, &block)
+        %w[properties patternProperties $defs definitions dependentSchemas].each do |keyword|
+          spec.fetch(keyword, {}).each do |key, member|
+            block.call(member, ValidationSupport.child_path("#{path}.#{keyword}", key))
+          end
+        end
+        %w[allOf anyOf oneOf prefixItems].each do |keyword|
+          Array(spec[keyword]).each_with_index do |member, index|
+            block.call(member, ValidationSupport.index_path("#{path}.#{keyword}", index))
+          end
+        end
+        %w[
+          not if then else contains propertyNames unevaluatedProperties
+          unevaluatedItems additionalProperties
+        ].each do |keyword|
+          member = spec[keyword]
+          block.call(member, "#{path}.#{keyword}") if member.is_a?(Hash)
+        end
+        items = spec["items"]
+        block.call(items, ValidationSupport.item_path(path)) if items.is_a?(Hash)
+      end
+
+      def configuration!(path, problem)
+        raise ConfigurationError, "#{path} #{problem}"
+      end
+    end
+    private_constant :ToolContract
+
+    # One immutable validation plan is reused for every call to a Tool.
+    class Compiled
+      attr_reader :schema
+
+      def initialize(schema, tool: false, complete: false)
+        @schema = DefinitionCompiler.new.call(schema)
+        ToolContract.new(complete: complete).call(@schema) if tool
+        freeze
+      end
+
+      def violations(value, path = "$", owned: false)
+        unless owned
+          value, error = ToolArguments.canonicalize(value)
+          if ToolArguments.resource_error?(error)
+            return ["#{ValidationSupport.root_path(path)} validation limit exceeded"]
+          end
+          return ["#{ValidationSupport.root_path(path)} must be valid JSON"] if error
+        end
+        PortableValidator.new.call(value, @schema, path)
+      end
+    end
+    private_constant :Compiled
+
+    # A task's prompt and local validator share one immutable schema. The marker
+    # lets providers omit native constraints they cannot represent faithfully.
+    class TaskPlan
+      attr_reader :schema
+
+      def initialize(validator)
+        @validator = validator
+        @schema = validator.schema
+        freeze
+      end
+
+      def violations(value, path = "$")
+        @validator.violations(value, path)
+      end
+
+      def native_fallback? = true
+    end
+    private_constant :TaskPlan
+
+    # Runtime validation is deliberately smaller than JSON Schema. It never
+    # approximates pattern semantics; a Tool requiring them supplies a full validator.
+    class PortableValidator
+      TYPES = {
+        "object" => ->(value) { value.is_a?(Hash) },
+        "array" => ->(value) { value.is_a?(Array) },
+        "string" => ->(value) { value.is_a?(String) },
+        "integer" => ->(value) { ValidationSupport.json_integer?(value) },
+        "number" => ->(value) { ValidationSupport.json_number?(value) },
+        "boolean" => ->(value) { value.equal?(true) || value.equal?(false) },
+        "null" => lambda(&:nil?)
+      }.freeze
+
+      def initialize
+        @errors = []
+        @root_path = "$"
+        @truncated = false
+      end
+
+      def call(value, schema, path)
+        @root_path = ValidationSupport.root_path(path)
+        walk(value, schema, @root_path)
+        @errors
+      end
+
+      private
+
+      def walk(value, schema, path)
+        return if full? || schema.equal?(true)
+        return add("#{path} is not allowed") if schema.equal?(false)
+
+        mismatch = type_violation(value, schema, path)
+        return add(mismatch) if mismatch
+
+        enum = schema["enum"]
+        add("#{path} must match enum") if enum && !enum.include?(value)
+        return if full?
+
+        object_violations(value, schema, path) if value.is_a?(Hash)
+        array_violations(value, schema, path) if value.is_a?(Array)
+      end
+
+      def type_violation(value, spec, path)
+        return unless spec.key?("type")
+
+        names = spec["type"].is_a?(Array) ? spec["type"] : [spec["type"]]
+        return if names.any? { |name| TYPES.fetch(name).call(value) }
+
+        "#{path} must be #{names.join(" or ")}, got #{ValidationSupport.json_type(value)}"
+      end
+
+      def object_violations(value, spec, path)
+        properties = spec.fetch("properties", {})
+        spec.fetch("required", []).each do |key|
+          add("#{ValidationSupport.child_path(path, key)} is required") unless value.key?(key)
+          break if full?
+        end
+        return if full?
+
+        value.each do |key, member|
+          if properties.key?(key)
+            walk(member, properties[key], ValidationSupport.child_path(path, key))
+          else
+            validate_additional(member, key, spec, path)
+          end
+          break if full?
+        end
+      end
+
+      def validate_additional(member, key, spec, path)
+        additional = spec.fetch("additionalProperties", true)
+        patterns = spec["patternProperties"]
+        return if patterns.is_a?(Hash) && !patterns.empty? && additional != true
+        return if additional.equal?(true)
+
+        member_path = ValidationSupport.child_path(path, key)
+        if additional.equal?(false)
+          add("#{member_path} is not allowed")
+        else
+          walk(member, additional, member_path)
+        end
+      end
+
+      def array_violations(value, spec, path)
+        prefix = spec.fetch("prefixItems", [])
+        prefix.each_with_index do |member_schema, index|
+          break if index >= value.length
+
+          walk(value[index], member_schema, ValidationSupport.index_path(path, index))
+          break if full?
+        end
+        return if full?
+
+        items = spec["items"]
+        return unless items.is_a?(Hash) || items.equal?(true) || items.equal?(false)
+
+        index = prefix.length
+        while index < value.length
+          walk(value[index], items, ValidationSupport.index_path(path, index))
+          return if full?
+
+          index += 1
+        end
+      end
+
+      def add(message)
+        if @errors.length < MAX_VIOLATIONS - 1
+          @errors << message
+        else
+          @errors << "#{@root_path} additional violations omitted"
+          @truncated = true
+        end
+      end
+
+      def full? = @truncated
+    end
+    private_constant :PortableValidator, :MAX_VIOLATIONS, :MAX_DEPTH, :MAX_NODES,
+                     :MAX_BYTES, :JSON_TYPES
   end
 end

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -12,7 +12,7 @@ module Mistri
   #
   # A store implements two methods: append(id, entry_hash) and load(id) ->
   # array of entry hashes in append order. Everything else lives here.
-  class Session
+  class Session # rubocop:disable Metrics/ClassLength -- append-only ordering is the class contract
     attr_reader :id, :store
 
     def initialize(store:, id: nil)
@@ -36,6 +36,21 @@ module Mistri
     end
 
     def entries = @store.load(@id)
+
+    # Every call ID is a session-wide correlation key. Read and validate the
+    # append-only history once, returning an owned set the loop can extend as
+    # it accepts later turns. Approval control entries are audited in the same
+    # ordered pass: they may only advance a prior assistant call.
+    def tool_control_state
+      audited = audit_history(entries)
+      approvals = audited.fetch(:approvals).map do |approval|
+        decision = approval[:decision] && own_json(approval[:decision])
+        { call: rebuild_call(approval[:call]), decision: }
+      end
+      { tool_call_ids: audited.fetch(:tool_call_ids), approvals: }
+    end
+
+    def tool_call_ids = tool_control_state.fetch(:tool_call_ids)
 
     # The conversation as the model replays it.
     def messages = replay.map(&:first)
@@ -157,24 +172,360 @@ module Mistri
     # Parked tool calls not yet settled by a tool result, each with its
     # decision when one has been recorded. Derived from the entry log alone,
     # so it survives crashes and reads the same from every process.
-    def open_approvals
-      answered = []
-      decisions = {}
-      requests = []
-      entries.each do |entry|
-        case entry["type"]
-        when "message"
-          call_id = entry.dig("message", "tool_call_id")
-          answered << call_id if call_id
-        when "approval_request" then requests << entry["call"]
-        when "approval_decision" then decisions[entry["call_id"]] = entry
-        end
-      end
-      requests.reject { |call| answered.include?(call["id"]) }
-              .map { |call| { call: rebuild_call(call), decision: decisions[call["id"]] } }
-    end
+    def open_approvals = tool_control_state.fetch(:approvals)
 
     private
+
+    def tool_calls_from(entry)
+      Array(entry.dig("message", "content")).select do |block|
+        block.is_a?(Hash) && block["type"].to_s == "tool_call"
+      end
+    end
+
+    def record_assistant_calls(entry, message, index, audit)
+      calls = audit.fetch(:calls)
+      unresolved = audit.fetch(:unresolved)
+      reserved = audit.fetch(:reserved)
+      batch = { calls: [], provider_call_ids: {} }
+      parsed_calls = message.tool_calls
+      tool_calls_from(entry).each_with_index do |call, position|
+        id = validated_persisted_call(call)
+        if reserved.include?(id)
+          raise ConfigurationError, "session contains a duplicate tool call ID"
+        end
+
+        owned = id.dup.freeze
+        source_call = parsed_calls.fetch(position)
+        provider_id = source_call.provider_call_id
+        if provider_id && batch[:provider_call_ids].key?(provider_id)
+          raise ConfigurationError, "session contains a duplicate provider tool call ID"
+        end
+
+        batch[:provider_call_ids][provider_id] = true if provider_id
+        state = { source: call, source_call:,
+                  source_provider: message.provider,
+                  source_stop_reason: message.stop_reason,
+                  source_index: index, source_position: position,
+                  batch:, status: :pending }
+        calls[owned] = state
+        batch[:calls] << state
+        unresolved << owned
+        reserved << owned
+      end
+    end
+
+    def audit_history(log)
+      calls = {}
+      unresolved = Set.new
+      reserved = Set.new
+      audit = { calls:, unresolved:, reserved: }
+      latest_compaction = nil
+
+      log.each_with_index do |entry, index|
+        unless entry.is_a?(Hash)
+          raise ConfigurationError, "session contains an entry that is not an object"
+        end
+
+        message = validate_message_entry!(entry) if entry["type"] == "message"
+
+        if message&.tool?
+          record_tool_result(entry, index, calls, unresolved)
+        elsif message
+          close_unsettled_calls(calls, unresolved)
+          record_assistant_calls(entry, message, index, audit) if message.assistant?
+        elsif entry["type"] == "approval_request"
+          record_approval_call(entry, calls)
+        elsif entry["type"] == "approval_decision"
+          record_approval_decision(entry, calls)
+        elsif entry["type"] == "compaction"
+          latest_compaction = entry
+        end
+      end
+
+      approvals = open_approval_states(calls)
+      validate_compaction!(calls, approvals, latest_compaction)
+      { tool_call_ids: reserved, approvals: }
+    end
+
+    # Control entries can authorize side effects, so every message in the
+    # same durable history must deserialize before any approval is exposed.
+    def validate_message_entry!(entry)
+      Message.from_h(entry["message"])
+    rescue StandardError => e
+      raise ConfigurationError,
+            "session contains an invalid persisted message (#{e.class.name})"
+    end
+
+    def record_tool_result(entry, index, calls, unresolved)
+      id = entry.dig("message", "tool_call_id")
+      problem = required_string_problem(id, "tool result call IDs")
+      raise ConfigurationError, "session contains #{problem}" if problem
+
+      state = calls[id]
+      unless state
+        raise ConfigurationError, "session contains a tool result without a prior assistant " \
+                                  "tool call"
+      end
+
+      name = entry.dig("message", "tool_name")
+      problem = required_string_problem(name, "tool result names")
+      raise ConfigurationError, "session contains #{problem}" if problem
+      unless name == state[:source]["name"]
+        raise ConfigurationError, "session contains a tool result whose name does not match " \
+                                  "its assistant tool call"
+      end
+
+      case state[:status]
+      when :pending
+        if state[:batch][:approval_phase_started]
+          raise ConfigurationError, "session contains a direct tool result after approval " \
+                                    "settlement began"
+        end
+        advance_call_order!(state, :direct_result_position, "tool results")
+        state[:status] = :answered
+        state[:result_index] = index
+        unresolved.delete(id)
+      when :decided
+        advance_call_order!(state, :approval_result_position, "approval tool results")
+        state[:status] = :answered
+        state[:result_index] = index
+        unresolved.delete(id)
+      when :approval_requested
+        raise ConfigurationError, "session contains a tool result for an approval without a " \
+                                  "prior decision"
+      when :answered
+        raise ConfigurationError, "session contains a duplicate tool result"
+      when :interrupted
+        raise ConfigurationError, "session contains a late tool result for a crash-healed call"
+      end
+    end
+
+    def advance_call_order!(state, key, label)
+      previous = state[:batch][key]
+      if previous && state[:source_position] < previous
+        raise ConfigurationError, "session contains #{label} out of assistant call order"
+      end
+
+      state[:batch][key] = state[:source_position]
+    end
+
+    def close_unsettled_calls(calls, unresolved)
+      unresolved.each do |id|
+        state = calls.fetch(id)
+        unless state[:status] == :pending
+          raise ConfigurationError, "session continues past an unsettled approval"
+        end
+
+        state[:status] = :interrupted
+      end
+      unresolved.clear
+    end
+
+    def record_approval_call(entry, calls)
+      call = entry["call"]
+      unless call.is_a?(Hash)
+        raise ConfigurationError, "session contains an invalid approval request"
+      end
+
+      id = validated_persisted_call(call)
+      state = calls[id]
+      unless state
+        raise ConfigurationError, "session contains an approval request without a prior " \
+                                  "assistant tool call"
+      end
+      if state[:status] == :answered
+        raise ConfigurationError, "session contains an approval request for an already " \
+                                  "answered tool call"
+      end
+      if state[:status] == :interrupted
+        raise ConfigurationError, "session contains a stale approval request for a " \
+                                  "crash-healed tool call"
+      end
+      unless state[:status] == :pending
+        raise ConfigurationError, "session contains a duplicate approval request ID"
+      end
+      unless state[:source_stop_reason] == StopReason::TOOL_USE
+        raise ConfigurationError, "session contains an approval request for an assistant turn " \
+                                  "that did not stop for tool use"
+      end
+      validate_gemini_approval_order!(state)
+      validate_approval_provenance!(entry, call, state)
+
+      advance_call_order!(state, :approval_request_position, "approval requests")
+      state[:batch][:approval_phase_started] = true
+      state[:status] = :approval_requested
+      state[:approval] = { call:, decision: nil, source_index: state[:source_index] }
+    end
+
+    def validate_approval_provenance!(entry, call, state)
+      if entry["prepared_from"] == "assistant"
+        validate_normalizable_source!(state)
+        validate_prepared_call!(call, state[:source])
+      elsif entry.key?("prepared_from")
+        raise ConfigurationError, "session contains invalid approval provenance"
+      elsif entry.key?("source_call")
+        validate_approval_source!(entry["source_call"], call, state)
+      elsif !approval_mirrors?(state[:source], call)
+        raise ConfigurationError, "session contains an approval request that does not " \
+                                  "match its assistant tool call"
+      end
+    end
+
+    # Pre-ID Gemini calls pair same-name results by position. Once a later
+    # sibling has answered, resuming an earlier side effect would make replay
+    # ambiguous even when the durable history predates the live-run guard.
+    def validate_gemini_approval_order!(state)
+      source = state[:source_call]
+      return unless state[:source_provider] == :gemini && source.provider_call_id.nil?
+
+      unsafe = state[:batch][:calls].any? do |sibling|
+        sibling[:source_position] > state[:source_position] && sibling[:status] == :answered &&
+          sibling[:source_call].provider_call_id.nil? && sibling[:source_call].name == source.name
+      end
+      return unless unsafe
+
+      raise ConfigurationError, "session contains an ambiguous Gemini approval after a later " \
+                                "same-name tool result"
+    end
+
+    def record_approval_decision(entry, calls)
+      id = entry["call_id"]
+      problem = required_string_problem(id, "approval decision call IDs")
+      raise ConfigurationError, "session contains #{problem}" if problem
+
+      state = calls[id]
+      unless state && state[:approval]
+        raise ConfigurationError, "session contains an approval decision without a prior " \
+                                  "matching approval request"
+      end
+      if state[:status] == :answered
+        raise ConfigurationError, "session contains an approval decision for an already " \
+                                  "answered tool call"
+      end
+      if state[:status] == :decided
+        raise ConfigurationError, "session contains a duplicate approval decision"
+      end
+      unless state[:status] == :approval_requested
+        raise ConfigurationError, "session contains an approval decision without a prior " \
+                                  "matching approval request"
+      end
+      unless entry["approved"].equal?(true) || entry["approved"].equal?(false)
+        raise ConfigurationError, "session contains an approval decision whose approved " \
+                                  "value is not true or false"
+      end
+
+      state[:approval][:decision] = entry
+      state[:status] = :decided
+    end
+
+    def open_approval_states(calls)
+      calls.values.filter_map do |state|
+        state[:approval] if %i[approval_requested decided].include?(state[:status])
+      end
+    end
+
+    def validate_compaction!(calls, approvals, compaction)
+      return unless compaction
+
+      kept_from = compaction["kept_from"]
+      unless kept_from.is_a?(Integer) && kept_from >= 0
+        raise ConfigurationError, "session contains an invalid compaction boundary"
+      end
+      if approvals.any? { |approval| approval[:source_index] < kept_from }
+        raise ConfigurationError, "session contains an open approval whose assistant tool call " \
+                                  "was removed by compaction"
+      end
+      split = calls.values.any? do |state|
+        state[:result_index] && state[:source_index] < kept_from &&
+          state[:result_index] >= kept_from
+      end
+      return unless split
+
+      raise ConfigurationError, "session contains a compaction boundary that splits a tool call " \
+                                "from its result"
+    end
+
+    def validate_approval_source!(source, prepared, state)
+      unless source.is_a?(Hash)
+        raise ConfigurationError, "session contains an invalid approval source call"
+      end
+
+      validated_persisted_call(source)
+      unless state[:source] && approval_mirrors?(state[:source], source)
+        raise ConfigurationError, "session contains an approval source that does not " \
+                                  "match its assistant tool call"
+      end
+      return if approval_mirrors?(prepared, source)
+
+      validate_normalizable_source!(state)
+      return if prepared_call_from_source?(prepared, source)
+
+      raise ConfigurationError, "session contains prepared approval metadata that does not " \
+                                "match its source call"
+    end
+
+    def validate_normalizable_source!(state)
+      source = state[:source_call]
+      return if source && !source.arguments_error? && source.arguments.is_a?(Hash)
+
+      raise ConfigurationError, "session contains an approval source that could not have " \
+                                "been normalized"
+    end
+
+    def validate_prepared_call!(prepared, assistant)
+      return if prepared_call_from_source?(prepared, assistant)
+
+      raise ConfigurationError, "session contains prepared approval metadata that does not " \
+                                "match its assistant tool call"
+    end
+
+    def validated_persisted_call(call)
+      unless call["type"].to_s == "tool_call"
+        raise ConfigurationError, "session contains an invalid tool call type"
+      end
+
+      problem = required_string_problem(call["id"], "tool call IDs")
+      raise ConfigurationError, "session contains #{problem}" if problem
+
+      problem = required_string_problem(call["name"], "tool call names")
+      raise ConfigurationError, "session contains #{problem}" if problem
+
+      validate_optional_string!(call["signature"], "tool call signatures")
+      validate_optional_string!(call["provider_call_id"], "provider tool call IDs")
+      call["id"]
+    end
+
+    def validate_optional_string!(value, label)
+      return if value.nil?
+
+      problem = required_string_problem(value, label)
+      raise ConfigurationError, "session contains #{problem}" if problem
+    end
+
+    def required_string_problem(value, label)
+      return "#{label} with no value" if value.nil?
+      return "#{label} that are not strings" unless value.is_a?(String)
+      unless value.encoding == Encoding::UTF_8 && value.valid_encoding?
+        return "#{label} that are not valid UTF-8"
+      end
+      return "#{label} that are blank" if value.match?(/\A[[:space:]]*\z/)
+
+      nil
+    end
+
+    def approval_mirrors?(assistant, approval)
+      assistant == approval
+    end
+
+    def prepared_call_from_source?(prepared, source)
+      %w[id name signature provider_call_id].all? do |field|
+        persisted_call_field(prepared, field) == persisted_call_field(source, field)
+      end
+    end
+
+    def persisted_call_field(call, field)
+      call[field]
+    end
 
     def replay_from(log)
       compaction = log.reverse_each.find { |entry| entry["type"] == "compaction" }
@@ -246,8 +597,11 @@ module Mistri
     end
 
     def decide(call_id, approved:, note:)
-      unless open_approvals.any? { |open| open[:call].id == call_id }
-        raise ConfigurationError, "no open approval for #{call_id.inspect}"
+      open = open_approvals.find { |approval| approval[:call].id == call_id }
+      raise ConfigurationError, "no open approval for #{call_id.inspect}" unless open
+
+      if open[:decision]
+        raise ConfigurationError, "approval for #{call_id.inspect} has already been decided"
       end
 
       entry = { "call_id" => call_id, "approved" => approved }
@@ -255,9 +609,21 @@ module Mistri
       append("approval_decision", entry)
     end
 
-    def rebuild_call(hash)
-      ToolCall.new(id: hash["id"], name: hash["name"],
-                   arguments: hash["arguments"] || {}, signature: hash["signature"])
+    def own_json(value)
+      case value
+      when Hash then value.to_h { |key, nested| [own_json(key), own_json(nested)] }
+      when Array then value.map { |nested| own_json(nested) }
+      when String then value.dup
+      else value
+      end
     end
-  end
+
+    def rebuild_call(hash)
+      arguments = hash.key?("arguments") ? hash["arguments"] : {}
+      ToolCall.new(id: hash["id"], name: hash["name"],
+                   arguments:, signature: hash["signature"],
+                   arguments_error: hash["arguments_error"],
+                   provider_call_id: hash["provider_call_id"])
+    end
+  end # rubocop:enable Metrics/ClassLength
 end

--- a/lib/mistri/sse.rb
+++ b/lib/mistri/sse.rb
@@ -70,6 +70,18 @@ module Mistri
       line.strip!
       return if line.empty? || line == "[DONE]"
 
+      case ToolArguments.raw_json_resource_error(line)
+      when "too_many_nodes"
+        raise ResponseTooComplexError.new(kind: :sse_record_tokens,
+                                          limit: ToolArguments::MAX_LEXICAL_TOKENS)
+      when "too_deep"
+        raise ResponseTooComplexError.new(kind: :sse_record_depth,
+                                          limit: ToolArguments::MAX_DEPTH)
+      when "number_too_large"
+        raise ResponseTooComplexError.new(kind: :sse_numeric_token,
+                                          limit: ToolArguments::MAX_NUMBER_BYTES)
+      end
+
       decoded = JSON.parse(line)
       yield decoded if decoded.is_a?(Hash)
     rescue JSON::ParserError

--- a/lib/mistri/stores/active_record.rb
+++ b/lib/mistri/stores/active_record.rb
@@ -15,7 +15,7 @@ module Mistri
     #   create_table :mistri_entries do |t|
     #     t.string :session_id, null: false, index: true
     #     t.integer :position, null: false
-    #     t.text :payload, size: :medium, null: false
+    #     t.text :payload, size: :long, null: false
     #     t.timestamps
     #   end
     #   add_index :mistri_entries, [:session_id, :position], unique: true

--- a/lib/mistri/stores/memory.rb
+++ b/lib/mistri/stores/memory.rb
@@ -10,12 +10,31 @@ module Mistri
       end
 
       def append(id, entry)
-        @mutex.synchronize { @entries[id] << entry }
+        @mutex.synchronize { @entries[id] << json_copy(entry, freeze: true) }
         nil
       end
 
       def load(id)
-        @mutex.synchronize { @entries[id].dup }
+        @mutex.synchronize do
+          @entries[id].map { |entry| json_copy(entry, freeze: false) }
+        end
+      end
+
+      private
+
+      # Memory must preserve the same value ownership as stores that decode
+      # every read; otherwise a transcript reader can rewrite durable history.
+      def json_copy(value, freeze:)
+        owned = case value
+                when Hash
+                  value.to_h do |key, nested|
+                    [json_copy(key, freeze:), json_copy(nested, freeze:)]
+                  end
+                when Array then value.map { |nested| json_copy(nested, freeze:) }
+                when String then value.dup
+                else value
+                end
+        freeze ? owned.freeze : owned
       end
     end
   end

--- a/lib/mistri/task_output.rb
+++ b/lib/mistri/task_output.rb
@@ -9,26 +9,37 @@ module Mistri
   module TaskOutput
     # Distinguishable from a parsed nil: JSON "null" is a valid value.
     PARSE_FAILED = Object.new.freeze
+    OUTPUT_TOO_LARGE = Object.new.freeze
+    OUTPUT_TOO_COMPLEX = Object.new.freeze
 
     module_function
 
     def prompt(input, schema)
+      plan = plan_for(schema)
       "#{input}\n\nAnswer with ONLY a JSON value matching this schema:\n" \
-        "#{JSON.generate(Schema.strict(schema))}"
+        "#{JSON.generate(plan.schema)}"
     end
 
     def parse(text)
-      body = text.to_s.strip
+      body = text.to_s
+      return OUTPUT_TOO_LARGE if body.bytesize > ToolArguments::MAX_BYTES
+
+      body = body.strip
       body = body[/\A```(?:json)?\s*(.*?)```\z/m, 1] || body
-      JSON.parse(body)
-    rescue JSON::ParserError
-      PARSE_FAILED
+      value, error = ToolArguments.parse_json(body)
+      return OUTPUT_TOO_LARGE if error == "too_large"
+      return OUTPUT_TOO_COMPLEX if %w[too_deep too_many_nodes number_too_large].include?(error)
+      return PARSE_FAILED if error
+
+      value
     end
 
     def errors(value, schema)
+      return ["the answer exceeds the output byte limit"] if value.equal?(OUTPUT_TOO_LARGE)
+      return ["the answer exceeds the output complexity limit"] if value.equal?(OUTPUT_TOO_COMPLEX)
       return ["the answer is not valid JSON"] if value.equal?(PARSE_FAILED)
 
-      Schema.violations(value, schema)
+      plan_for(schema).violations(value)
     end
 
     def fix_prompt(errors)
@@ -36,5 +47,12 @@ module Mistri
       "Your answer did not satisfy the required output schema. Problems:\n" \
         "#{lines}\nReply with ONLY the corrected JSON."
     end
+
+    def plan_for(schema)
+      return schema if schema.respond_to?(:schema) && schema.respond_to?(:violations)
+
+      Schema.task_plan(schema)
+    end
+    private_class_method :plan_for
   end
 end

--- a/lib/mistri/tool.rb
+++ b/lib/mistri/tool.rb
@@ -4,40 +4,66 @@ require "json"
 
 module Mistri
   # A tool the agent can call: a name, a description, a JSON Schema for its
-  # arguments, and a handler. The handler receives the parsed arguments hash
-  # (string keys, exactly as the model sent them) and returns a String, a Hash
-  # (serialized as JSON), or content blocks, so a tool can hand back images as
-  # naturally as text.
+  # arguments, and a handler. Model calls reach the handler as canonical
+  # argument hashes, optionally normalized by the tool before policy sees
+  # them. Trusted direct calls keep ordinary Ruby Hash semantics.
   class Tool
     # A no-argument tool still needs a valid object schema; providers reject a
     # bare empty hash.
-    EMPTY_SCHEMA = { type: "object", properties: {} }.freeze
+    EMPTY_SCHEMA = {
+      type: "object", properties: {}.freeze, required: [].freeze,
+      additionalProperties: false
+    }.freeze
 
     attr_reader :name, :description, :input_schema, :timeout
 
-    # Define a tool. Give the argument shape as a raw JSON Schema hash via
-    # input_schema:, or build it in Ruby with a schema: block.
+    # Define a tool. Give the argument shape as a JSON Schema value via
+    # input_schema:, or build it in Ruby with a schema: block. The result is
+    # canonicalized and owned once so provider and local semantics cannot drift.
     #
     #   Tool.define("get_weather", "Weather for a city",
     #               schema: -> { string :city, "City name", required: true }) do |args|
     #     Weather.for(args["city"])
     #   end
     def self.define(name, description, input_schema: nil, schema: nil, **, &handler)
-      input_schema ||= schema ? Schema.build(&schema) : EMPTY_SCHEMA
+      raise ArgumentError, "choose input_schema or schema, not both" if schema && !input_schema.nil?
+
+      input_schema = schema ? Schema.build(&schema) : EMPTY_SCHEMA if input_schema.nil?
       new(name: name, description: description, input_schema: input_schema, **, &handler)
     end
 
     def initialize(name:, description:, input_schema: EMPTY_SCHEMA, eager_input_streaming: false,
-                   needs_approval: false, ends_turn: false, timeout: nil, &handler)
+                   needs_approval: false, ends_turn: false, timeout: nil,
+                   argument_normalizer: nil, argument_validator: nil,
+                   complete_argument_validator: nil, &handler)
       raise ArgumentError, "tool #{name.inspect} needs a handler block" unless handler
+      unless argument_normalizer.nil? || argument_normalizer.respond_to?(:call)
+        raise ArgumentError, "argument_normalizer must be callable"
+      end
+      unless argument_validator.nil? || argument_validator.respond_to?(:call)
+        raise ArgumentError, "argument_validator must be callable"
+      end
+      unless complete_argument_validator.nil? || complete_argument_validator.respond_to?(:call)
+        raise ArgumentError, "complete_argument_validator must be callable"
+      end
+      if argument_validator && complete_argument_validator
+        raise ArgumentError,
+              "choose argument_validator or complete_argument_validator, not both"
+      end
 
       @name = name.to_s
       @description = description
-      @input_schema = input_schema
+      @schema_validator = Schema.tool_validator(
+        input_schema, complete: !complete_argument_validator.nil?
+      )
+      @input_schema = @schema_validator.schema
       @eager_input_streaming = eager_input_streaming
       @needs_approval = needs_approval
       @ends_turn = ends_turn
       @timeout = timeout
+      @argument_normalizer = argument_normalizer
+      @argument_validator = argument_validator
+      @complete_argument_validator = complete_argument_validator
       @handler = handler
     end
 
@@ -47,12 +73,42 @@ module Mistri
     #
     # Handlers receive (arguments, context). A proc that declares one
     # parameter ignores the context invisibly; a lambda opts in by arity.
+    # Direct calls are trusted host invocations: they apply the compatibility
+    # normalizer, but do not canonicalize or validate as model calls do. The
+    # executor marks arguments the Agent already prepared so subclasses keep
+    # the historical #call extension point without running normalization twice.
     def call(arguments, context = ToolContext.new)
+      arguments = normalize_arguments(arguments || {}) unless prepared_context?(context)
       result = invoke(arguments || {}, context)
       return serialize_result(result) unless result.is_a?(ToolResult)
 
       result.with(content: serialize_result(result.content),
                   ui: result.ui && JSON.parse(JSON.generate(result.ui)))
+    end
+
+    # Normalization is an explicit per-tool migration boundary, never a
+    # global coercion policy. Agent calls this once before policy; direct
+    # trusted invocations get the same compatibility behavior through #call.
+    def normalize_arguments(arguments)
+      return arguments unless @argument_normalizer
+
+      normalized = @argument_normalizer.call(arguments)
+      raise ArgumentError, "argument_normalizer must return a Hash" unless normalized.is_a?(Hash)
+
+      normalized
+    end
+
+    # Core validation is always authoritative for its portable subset. A
+    # supplemental validator adds domain rules; an explicitly complete one
+    # additionally owns schema interactions core cannot represent.
+    def argument_violations(arguments)
+      validate_arguments(arguments, owned: false)
+    end
+
+    # Agent has already moved the value through ToolCall's ownership boundary,
+    # so its hot path can avoid copying the same immutable JSON twice.
+    def prepared_argument_violations(arguments)
+      validate_arguments(arguments, owned: true)
     end
 
     # Whether this call should pause for a human. true/false, or a callable
@@ -78,6 +134,30 @@ module Mistri
     end
 
     private
+
+    def prepared_context?(context)
+      context.respond_to?(:arguments_prepared?) && context.arguments_prepared?
+    end
+
+    def validate_arguments(arguments, owned:)
+      unless owned
+        arguments, error = ToolArguments.canonicalize(arguments)
+        return ["$ validation limit exceeded"] if ToolArguments.resource_error?(error)
+        return ["$ must be valid JSON"] if error
+      end
+
+      errors = @schema_validator.violations(arguments, owned: true)
+      custom_validator = @complete_argument_validator || @argument_validator
+      return errors if errors.any? || !custom_validator
+
+      custom = custom_validator.call(arguments, @input_schema)
+      unless custom.is_a?(Array) && custom.all?(String)
+        name = @complete_argument_validator ? "complete_argument_validator" : "argument_validator"
+        raise TypeError, "#{name} must return an Array of Strings"
+      end
+
+      custom
+    end
 
     def invoke(arguments, context)
       if @handler.lambda? && @handler.arity.between?(0, 1)

--- a/lib/mistri/tool_arguments.rb
+++ b/lib/mistri/tool_arguments.rb
@@ -1,0 +1,377 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Mistri
+  # Owns model-supplied JSON before it crosses a durable or policy boundary.
+  module ToolArguments # rubocop:disable Metrics/ModuleLength -- one JSON ownership boundary
+    MAX_DEPTH = 64
+    MAX_NODES = 10_000
+    MAX_LEXICAL_TOKENS = (MAX_NODES * 2) + 1
+    MAX_BYTES = 8 * 1024 * 1024
+    MAX_NUMBER_BYTES = 64 * 1024
+    EMPTY_OBJECT = {}.freeze
+    ERROR_CODES = %w[
+      invalid_arguments invalid_encoding invalid_json invalid_key duplicate_key
+      cyclic_value too_deep too_large too_many_nodes number_too_large
+      non_finite_number non_json_value incomplete
+    ].freeze
+    RESOURCE_ERRORS = %w[too_deep too_large too_many_nodes number_too_large].freeze
+
+    Failure = Class.new(StandardError) do
+      attr_reader :code
+
+      def initialize(code)
+        @code = code
+        super
+      end
+    end
+    private_constant :Failure
+
+    module_function
+
+    def canonicalize(value)
+      state = { nodes: 0, bytes: 0, active: {} }
+      value = copy(value, state, 0)
+      raise Failure, "too_large" unless serialized_size_within_limit?(value)
+
+      [value, nil]
+    rescue Failure => e
+      [nil, e.code]
+    end
+
+    # Counts the generated JSON envelope without materializing it. Integer
+    # digits are conservatively bounded so a hostile Bignum cannot allocate an
+    # oversized decimal string before the limit is enforced.
+    def serialized_size_within_limit?(value, limit: MAX_BYTES)
+      return false unless limit.is_a?(Integer) && limit >= 0
+
+      state = { limit:, remaining: limit, active: {} }
+      count_json(value, state, 0)
+      true
+    rescue Failure
+      false
+    end
+
+    # Provider assemblers parse completed argument payloads strictly. Partial
+    # JSON belongs only to transient streaming snapshots, never executable calls.
+    def parse_json(raw)
+      return [nil, "invalid_json"] unless raw.is_a?(String)
+      return [nil, "too_large"] if raw.bytesize > MAX_BYTES
+      if (resource_error = raw_json_resource_error(raw))
+        return [nil, resource_error]
+      end
+
+      [JSON.parse(raw, max_nesting: MAX_DEPTH + 1), nil]
+    rescue JSON::NestingError
+      [nil, "too_deep"]
+    rescue JSON::ParserError, TypeError
+      [nil, "invalid_json"]
+    end
+
+    def normalize_error(code)
+      candidate = code.to_s
+      ERROR_CODES.include?(candidate) ? candidate.freeze : "invalid_arguments"
+    end
+
+    def resource_error?(code) = RESOURCE_ERRORS.include?(code)
+
+    # A lexical pass bounds parser allocation without duplicating JSON's
+    # grammar. Counting keys as tokens leaves room for every valid document
+    # under MAX_NODES while stopping wide hostile inputs before JSON.parse.
+    # This byte-state machine must branch on JSON token starts without building a tree.
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    def raw_json_resource_error(raw)
+      tokens = 0
+      depth = 0
+      index = 0
+      while index < raw.bytesize
+        byte = raw.getbyte(index)
+        case byte
+        when 34
+          tokens += 1
+          return "too_many_nodes" if tokens > MAX_LEXICAL_TOKENS
+
+          index = string_end(raw, index + 1)
+        when 91, 123
+          tokens += 1
+          return "too_many_nodes" if tokens > MAX_LEXICAL_TOKENS
+
+          depth += 1
+          return "too_deep" if depth > MAX_DEPTH + 1
+
+          index += 1
+        when 93, 125
+          depth -= 1 if depth.positive?
+          index += 1
+        when 45, 48..57
+          tokens += 1
+          return "too_many_nodes" if tokens > MAX_LEXICAL_TOKENS
+
+          number_start = index
+          index = number_end(raw, index + 1)
+          return "number_too_large" if index - number_start > MAX_NUMBER_BYTES
+        when 116
+          tokens += 1
+          return "too_many_nodes" if tokens > MAX_LEXICAL_TOKENS
+
+          index += raw.byteslice(index, 4) == "true" ? 4 : 1
+        when 102
+          tokens += 1
+          return "too_many_nodes" if tokens > MAX_LEXICAL_TOKENS
+
+          index += raw.byteslice(index, 5) == "false" ? 5 : 1
+        when 110
+          tokens += 1
+          return "too_many_nodes" if tokens > MAX_LEXICAL_TOKENS
+
+          index += raw.byteslice(index, 4) == "null" ? 4 : 1
+        else
+          index += 1
+        end
+      end
+      nil
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+
+    def string_end(raw, index)
+      while index < raw.bytesize
+        case raw.getbyte(index)
+        when 34 then return index + 1
+        when 92 then index += 2
+        else index += 1
+        end
+      end
+      index
+    end
+    private_class_method :string_end
+
+    def number_end(raw, index)
+      while index < raw.bytesize
+        byte = raw.getbyte(index)
+        break unless byte == 43 || byte == 45 || byte == 46 || byte == 69 || byte == 101 ||
+                     byte.between?(48, 57)
+
+        index += 1
+      end
+      index
+    end
+    private_class_method :number_end
+
+    # Anthropic and Gemini require an object when an earlier invalid call is
+    # replayed. The paired error result preserves the truth; this shape only
+    # keeps the provider transcript structurally valid.
+    def replay_object(call)
+      return EMPTY_OBJECT if call.arguments_error
+      return EMPTY_OBJECT unless call.arguments.is_a?(Hash)
+
+      call.arguments
+    end
+
+    # OpenAI carries function arguments as a JSON string, so every completed
+    # JSON value can replay exactly; only an unparseable value needs a placeholder.
+    def replay_value(call)
+      call.arguments_error ? EMPTY_OBJECT : call.arguments
+    end
+
+    # Assemblers own freshly parsed previews, so they can freeze the tree in
+    # place without the copy that completed values require.
+    def freeze_partial(value)
+      return value if value.frozen?
+
+      case value
+      when Hash
+        value.each do |key, nested|
+          freeze_partial(key)
+          freeze_partial(nested)
+        end
+      when Array
+        value.each { |nested| freeze_partial(nested) }
+      end
+      value.freeze if value.respond_to?(:freeze)
+      value
+    end
+
+    def copy(value, state, depth)
+      raise Failure, "too_deep" if depth > MAX_DEPTH
+
+      state[:nodes] += 1
+      raise Failure, "too_large" if state[:nodes] > MAX_NODES
+
+      case value
+      when nil, true, false then value
+      when Integer then copy_integer(value)
+      when Float then copy_float(value)
+      when String then copy_string(value, state)
+      when Array then copy_array(value, state, depth)
+      when Hash then copy_hash(value, state, depth)
+      else raise Failure, "non_json_value"
+      end
+    end
+    private_class_method :copy
+
+    def copy_float(value)
+      raise Failure, "non_finite_number" unless value.finite?
+
+      value
+    end
+    private_class_method :copy_float
+
+    def copy_integer(value)
+      upper_bound = integer_decimal_upper_bound(value)
+      raise Failure, "number_too_large" if upper_bound > MAX_NUMBER_BYTES + 1
+      if upper_bound > MAX_NUMBER_BYTES && value.to_s.bytesize > MAX_NUMBER_BYTES
+        raise Failure, "number_too_large"
+      end
+
+      value
+    end
+    private_class_method :copy_integer
+
+    def copy_string(value, state)
+      string = if value.encoding == Encoding::UTF_8
+                 raise Failure, "too_large" if value.bytesize > MAX_BYTES - state[:bytes]
+                 raise Failure, "invalid_encoding" unless value.valid_encoding?
+
+                 value.dup
+               else
+                 value.encode(Encoding::UTF_8)
+               end
+      state[:bytes] += string.bytesize
+      raise Failure, "too_large" if state[:bytes] > MAX_BYTES
+
+      string.freeze
+    rescue EncodingError
+      raise Failure, "invalid_encoding"
+    end
+    private_class_method :copy_string
+
+    def copy_array(value, state, depth)
+      within(value, state) do
+        copied = []
+        # Array#map preallocates from an untrusted length before the node ceiling fires.
+        # rubocop:disable Style/MapIntoArray
+        value.each { |item| copied << copy(item, state, depth + 1) }
+        # rubocop:enable Style/MapIntoArray
+        copied.freeze
+      end
+    end
+    private_class_method :copy_array
+
+    def copy_hash(value, state, depth)
+      within(value, state) do
+        value.each_with_object({}) do |(key, item), copy|
+          key = copy_key(key, state)
+          raise Failure, "duplicate_key" if copy.key?(key)
+
+          copy[key] = copy(item, state, depth + 1)
+        end.freeze
+      end
+    end
+    private_class_method :copy_hash
+
+    def copy_key(key, state)
+      raise Failure, "invalid_key" unless key.is_a?(String) || key.is_a?(Symbol)
+
+      copy_string(key.to_s, state)
+    end
+    private_class_method :copy_key
+
+    def within(value, state)
+      identity = value.object_id
+      raise Failure, "cyclic_value" if state[:active].key?(identity)
+
+      state[:active][identity] = true
+      inserted = true
+      yield
+    ensure
+      state[:active].delete(identity) if inserted
+    end
+    private_class_method :within
+
+    def count_json(value, state, depth)
+      raise Failure, "too_deep" if depth > MAX_DEPTH
+
+      case value
+      when nil, true then consume(state, 4)
+      when false then consume(state, 5)
+      when Integer then count_integer(value, state)
+      when Float then count_float(value, state)
+      when String then count_string(value, state)
+      when Array then count_array(value, state, depth)
+      when Hash then count_hash(value, state, depth)
+      else raise Failure, "non_json_value"
+      end
+    end
+    private_class_method :count_json
+
+    def count_float(value, state)
+      raise Failure, "non_finite_number" unless value.finite?
+
+      consume(state, JSON.generate(value).bytesize)
+    end
+    private_class_method :count_float
+
+    def count_integer(value, state)
+      copy_integer(value)
+      upper_bound = integer_decimal_upper_bound(value)
+      # A bit length can straddle one decimal boundary. One byte of bounded
+      # slack lets the exact count decide without exposing an oversized allocation.
+      raise Failure, "too_large" if upper_bound > state[:limit] + 1
+
+      consume(state, value.to_s.bytesize)
+    end
+    private_class_method :count_integer
+
+    def integer_decimal_upper_bound(value)
+      digits = ((value.bit_length * 30_103) / 100_000) + 1
+      digits + (value.negative? ? 1 : 0)
+    end
+    private_class_method :integer_decimal_upper_bound
+
+    def count_string(value, state)
+      valid_utf8 = value.encoding == Encoding::UTF_8 && value.valid_encoding?
+      raise Failure, "invalid_encoding" unless valid_utf8
+
+      short_controls = value.count("\b\t\n\f\r")
+      controls = value.count("\u0000-\u001f")
+      escaped = value.count('"') + value.count("\\")
+      size = value.bytesize + 2 + escaped + short_controls + ((controls - short_controls) * 5)
+      consume(state, size)
+    end
+    private_class_method :count_string
+
+    def count_array(value, state, depth)
+      within(value, state) do
+        consume(state, 2)
+        value.each_with_index do |item, index|
+          consume(state, 1) unless index.zero?
+          count_json(item, state, depth + 1)
+        end
+      end
+    end
+    private_class_method :count_array
+
+    def count_hash(value, state, depth)
+      within(value, state) do
+        consume(state, 2)
+        value.each_with_index do |(key, item), index|
+          raise Failure, "invalid_key" unless key.is_a?(String)
+
+          consume(state, 1) unless index.zero?
+          count_string(key, state)
+          consume(state, 1)
+          count_json(item, state, depth + 1)
+        end
+      end
+    end
+    private_class_method :count_hash
+
+    def consume(state, bytes)
+      raise Failure, "too_large" if bytes > state[:remaining]
+
+      state[:remaining] -= bytes
+    end
+    private_class_method :consume
+  end # rubocop:enable Metrics/ModuleLength
+end

--- a/lib/mistri/tool_call.rb
+++ b/lib/mistri/tool_call.rb
@@ -1,18 +1,52 @@
 # frozen_string_literal: true
 
+require_relative "tool_arguments"
+
 module Mistri
-  # One tool invocation requested by the model. `arguments` is the parsed Hash
-  # exactly as the model emitted it, string keys and all; the top level is owned
-  # and frozen, nested values stay as parsed. `signature` is the opaque
-  # reasoning payload some providers attach to the call and require echoed back,
-  # such as Gemini's thoughtSignature.
-  ToolCall = Data.define(:id, :name, :arguments, :signature) do
-    def initialize(id:, name:, arguments: {}, signature: nil)
-      super(id:, name:, arguments: arguments.dup.freeze, signature:)
+  # One immutable tool invocation requested by the model. Completed arguments
+  # are deeply owned JSON; arguments_error records why an unsafe value became
+  # nil instead of letting it cross the execution boundary. Signature carries
+  # opaque replay state; provider_call_id distinguishes an optional wire ID
+  # from Mistri's always-present session correlation ID.
+  ToolCall = Data.define(:id, :name, :arguments, :signature, :arguments_error,
+                         :provider_call_id) do
+    def initialize(id:, name:, arguments: {}, signature: nil, arguments_error: nil,
+                   provider_call_id: nil, canonicalize: true)
+      id = id.dup.freeze if id.is_a?(String)
+      name = name.dup.freeze if name.is_a?(String)
+      signature = signature.dup.freeze if signature.is_a?(String)
+      provider_call_id = provider_call_id.dup.freeze if provider_call_id.is_a?(String)
+      @arguments_owned = canonicalize || !arguments_error.nil?
+      if arguments_error.nil?
+        arguments, arguments_error = ToolArguments.canonicalize(arguments) if canonicalize
+      else
+        arguments = nil
+        arguments_error = ToolArguments.normalize_error(arguments_error)
+      end
+      super(id:, name:, arguments:, signature:, arguments_error:, provider_call_id:)
     end
 
     def type = :tool_call
 
-    def to_h = { type: :tool_call, id:, name:, arguments:, signature: }.compact
+    def arguments_error? = !arguments_error.nil?
+
+    def arguments_owned? = @arguments_owned
+
+    # Data#with bypasses custom initializers; this value must re-enter the
+    # ownership boundary whenever a normalizer replaces its arguments.
+    def with(id: self.id, name: self.name, arguments: self.arguments,
+             signature: self.signature, arguments_error: self.arguments_error,
+             provider_call_id: self.provider_call_id)
+      self.class.new(id:, name:, arguments:, signature:, arguments_error:, provider_call_id:)
+    end
+
+    def to_h
+      hash = { type: :tool_call, id:, name: }.compact
+      hash[:arguments] = arguments
+      hash[:signature] = signature unless signature.nil?
+      hash[:arguments_error] = arguments_error unless arguments_error.nil?
+      hash[:provider_call_id] = provider_call_id unless provider_call_id.nil?
+      hash
+    end
   end
 end

--- a/lib/mistri/tool_context.rb
+++ b/lib/mistri/tool_context.rb
@@ -15,8 +15,10 @@ module Mistri
   #
   #   agent = Mistri.agent("claude-opus-4-8", tools: tools,
   #                        context: { traveler: current_traveler })
-  #   Mistri::Tool.define("book_hotel", "Books the chosen hotel.") do |args, context|
-  #     Bookings.create(args, traveler: context.app[:traveler])
+  #   Mistri::Tool.define("book_hotel", "Books the chosen hotel.", schema: -> {
+  #     string :hotel_id, "Hotel ID", required: true
+  #   }) do |args, context|
+  #     Bookings.create(args.fetch("hotel_id"), traveler: context.app[:traveler])
   #   end
   ToolContext = Data.define(:session, :signal, :emit, :app) do
     def initialize(session: nil, signal: nil, emit: nil, app: nil)

--- a/lib/mistri/tool_executor.rb
+++ b/lib/mistri/tool_executor.rb
@@ -37,14 +37,37 @@ module Mistri
     COMMITTED = Object.new.freeze
     private_constant :COMMITTED
 
+    PreparedContext = Class.new(ToolContext) do
+      def arguments_prepared? = true
+    end
+    private_constant :PreparedContext
+
     module_function
 
     def call(calls, tools_by_name, signal: nil, max_concurrency: 4, session: nil, emit: nil,
              app: nil)
+      call_with_outcomes(
+        calls,
+        tools_by_name,
+        signal:,
+        max_concurrency:,
+        session:,
+        emit:,
+        app:,
+        prepared_arguments: false
+      ).map { |call, result, seconds, _committed| [call, result, seconds] }
+    end
+
+    # Agent prepares model arguments before approval and execution. This
+    # lower-level form preserves that boundary and exposes commitment so hooks
+    # cannot run for queued calls that an abort prevented from starting.
+    def call_with_outcomes(calls, tools_by_name, signal: nil, max_concurrency: 4, session: nil,
+                           emit: nil, app: nil, prepared_arguments: false)
       return [] if calls.empty?
 
-      context = ToolContext.new(session: session, signal: signal, emit: thread_safe(emit, signal),
-                                app: app)
+      context_class = prepared_arguments ? PreparedContext : ToolContext
+      context = context_class.new(session: session, signal: signal,
+                                  emit: thread_safe(emit, signal), app: app)
       results = Array.new(calls.length)
       queue = Queue.new
       errors = Queue.new
@@ -58,9 +81,9 @@ module Mistri
 
       calls.each_with_index.map do |call, index|
         entry = results[index]
-        entry = [failure(OUTCOME_UNKNOWN), nil] if entry.equal?(COMMITTED)
-        value, seconds = entry || [failure(INTERRUPTED), nil]
-        [call, value, seconds]
+        entry = [failure(OUTCOME_UNKNOWN), nil, true] if entry.equal?(COMMITTED)
+        value, seconds, committed = entry || [failure(INTERRUPTED), nil, false]
+        [call, value, seconds, committed]
       end
     end
 
@@ -75,7 +98,7 @@ module Mistri
             break
           end
           if context.signal&.aborted?
-            results[index] = [failure(INTERRUPTED), nil]
+            results[index] = [failure(INTERRUPTED), nil, false]
             next
           end
 
@@ -88,12 +111,12 @@ module Mistri
 
     def run_one(call, index, results, tools_by_name, context)
       tool = tools_by_name[call.name]
-      return [failure("Error: unknown tool #{call.name.inspect}"), nil] unless tool
+      return [failure("Error: unknown tool #{call.name.inspect}"), nil, false] unless tool
 
-      return [failure(INTERRUPTED), nil] unless commit(call, context)
+      return [failure(INTERRUPTED), nil, false] unless commit(call, context)
 
       results[index] = COMMITTED
-      invoke_one(tool, call, context)
+      [*invoke_one(tool, call, context), true]
     end
 
     def invoke_one(tool, call, context)
@@ -115,7 +138,9 @@ module Mistri
     def invoke(tool, call, context)
       return tool.call(call.arguments, context) unless tool.timeout
 
-      Timeout.timeout(tool.timeout, InvocationTimeout) { tool.call(call.arguments, context) }
+      Timeout.timeout(tool.timeout, InvocationTimeout) do
+        tool.call(call.arguments, context)
+      end
     end
 
     def commit(call, context)

--- a/lib/mistri/tool_result.rb
+++ b/lib/mistri/tool_result.rb
@@ -5,8 +5,10 @@ module Mistri
   # fact. Both channels and the error bit persist with the tool message; only
   # content and provider-supported error signaling reach the model.
   #
-  #   Tool.define("edit_page", "Edits the page.") do |args|
-  #     page = apply(args)
+  #   Tool.define("edit_page", "Edits the page.", schema: -> {
+  #     object :changes, "Page changes", required: true
+  #   }) do |args|
+  #     page = apply(args.fetch("changes"))
   #     Mistri::ToolResult.new(content: "Updated.", ui: { "html" => page })
   #   end
   #

--- a/lib/mistri/tools.rb
+++ b/lib/mistri/tools.rb
@@ -28,10 +28,17 @@ module Mistri
       yield content
     end
 
-    # Absorb the drift real models produce: alias keys, stringly booleans,
-    # unknown keys dropped by simply never being read.
+    # Absorb the drift real models produce for edit_file only. Ambiguous
+    # aliases fail instead of letting hash insertion order choose an edit.
     def tolerate(args)
-      normalized = args.to_h { |key, value| [ALIASES.fetch(key.to_s, key.to_s), value] }
+      normalized = args.each_with_object({}) do |(key, value), copy|
+        canonical = ALIASES.fetch(key.to_s, key.to_s)
+        if copy.key?(canonical)
+          raise ArgumentError, "multiple arguments map to #{canonical.inspect}"
+        end
+
+        copy[canonical] = value
+      end
       case normalized["replace_all"]
       when "true", "1", 1 then normalized["replace_all"] = true
       when "false", "0", 0, nil then normalized["replace_all"] = false

--- a/lib/mistri/tools/edit_file.rb
+++ b/lib/mistri/tools/edit_file.rb
@@ -16,13 +16,13 @@ module Mistri
                   "It must match exactly one place; add surrounding lines to make it " \
                   "unique, or set replace_all to change every occurrence.",
                   eager_input_streaming: true,
+                  argument_normalizer: Tools.method(:tolerate),
                   schema: lambda {
                     string :path, "Document path", required: true
                     string :old_string, "Exact text to replace (whitespace matters)", required: true
                     string :new_string, "Replacement text", required: true
                     boolean :replace_all, "Replace every occurrence instead of exactly one"
                   }) do |args|
-        args = Tools.tolerate(args)
         with_document(workspace, args) do |content|
           result = Edit.replace(content, args["old_string"], args["new_string"],
                                 replace_all: args["replace_all"] == true)

--- a/lib/mistri/transport.rb
+++ b/lib/mistri/transport.rb
@@ -91,7 +91,7 @@ module Mistri
           end
           parsed
         end
-      rescue ResponseTooLargeError, ProviderError, JSON::ParserError
+      rescue ResponseTooLargeError, ResponseTooComplexError, ProviderError, JSON::ParserError
         teardown
         raise
       end
@@ -131,7 +131,7 @@ module Mistri
           read_either(response, &block)
         end
         response_headers
-      rescue ResponseTooLargeError, ProviderError
+      rescue ResponseTooLargeError, ResponseTooComplexError, ProviderError
         teardown
         raise
       rescue IOError, SocketError, SystemCallError, Timeout::Error, JSON::ParserError,
@@ -183,7 +183,7 @@ module Mistri
         # than let the next request read stale frames.
         teardown if aborted
         aborted ? :aborted : nil
-      rescue ResponseTooLargeError, ProviderError
+      rescue ResponseTooLargeError, ResponseTooComplexError, ProviderError
         teardown
         raise
       rescue IOError, SocketError, SystemCallError, Timeout::Error => e

--- a/test/integration/test_core_loop.rb
+++ b/test/integration/test_core_loop.rb
@@ -13,12 +13,35 @@ class TestCoreLoopIntegration < Minitest::Test
     agent = Mistri::Agent.new(provider: Mistri.provider(model),
                               tools: [founder_tool, hq_tool],
                               system: "Answer strictly from the tools.")
+    events = []
 
-    result = agent.run("Who founded the company and what city is HQ in? One sentence.")
+    result = agent.run("Who founded the company and what city is HQ in? One sentence.") do |event|
+      events << event
+    end
 
     assert_predicate result, :completed?
+    assert_equal :start, events.first.type, "the provider stream did not open with :start"
+    assert_predicate events.first.partial, :assistant?
+    assert_empty events.first.partial.content
+    assert_stream_boundaries(events)
+    assert_predicate events.last, :terminal?
     assert Integration.saw?(result.text, founder), "founder fact never flowed: #{result.text}"
     assert Integration.saw?(result.text, city), "city fact never flowed: #{result.text}"
+  end
+
+  def assert_stream_boundaries(events)
+    open = false
+    events.each do |event|
+      if event.type == :start
+        refute open, "a provider stream opened before its predecessor terminated"
+        open = true
+      elsif event.terminal?
+        assert open, "a provider terminal arrived without a matching :start"
+        open = false
+      end
+    end
+
+    refute open, "the final provider stream never terminated"
   end
 
   Integration.scenario(self, :ui_channel_reaches_host_not_model) do |model|
@@ -61,5 +84,52 @@ class TestCoreLoopIntegration < Minitest::Test
     refute_empty failures, "the live tool was never called"
     assert_predicate failures, :all?, "the live lifecycle lost its error fact"
     assert Integration.saw?(result.text, code), "the failed result never replayed: #{result.text}"
+  end
+
+  Integration.scenario(self, :invalid_tool_arguments_are_corrected_before_execution) do |model|
+    correction = Integration.codename
+    validated = []
+    handled = []
+    submit = Mistri::Tool.define(
+      "submit_code", "Submits one validation code.",
+      schema: -> { string :code, "Validation code", required: true },
+      argument_validator: lambda do |args, _schema|
+        validated << args.fetch("code")
+        args["code"] == correction ? [] : ["$.code must be exactly #{correction}"]
+      end
+    ) do |args|
+      handled << args.fetch("code")
+      "Accepted #{args.fetch("code")}."
+    end
+    errors = []
+    calls = []
+    agent = Mistri::Agent.new(
+      provider: Mistri.provider(model), tools: [submit],
+      budget: Mistri::Budget.new(turns: 8),
+      system: "First call submit_code with code exactly wrong. When it returns an argument " \
+              "error, call it once more with the exact correction it gives you, then report " \
+              "the accepted code."
+    )
+
+    result = agent.run("Exercise the validation correction path.") do |event|
+      errors << event.tool_error if event.type == :tool_result
+      calls << event.tool_call if event.type == :toolcall_end
+    end
+
+    assert_operator validated.length, :>=, 2, "the model never exercised the rejected path"
+    refute_equal correction, validated.first, "the first call skipped validation correction"
+    refute_empty handled, "the corrected call never reached the handler"
+    assert_equal [correction], handled.uniq, "invalid arguments reached the handler"
+    assert errors.first, "the rejection lost its error type"
+    refute errors.last, "the accepted call stayed mislabeled as an error"
+    assert_equal handled.length, errors.count(false), "a valid handler outcome was mislabeled"
+    assert Integration.saw?(result.text, correction), "the corrected result never landed"
+    if model.start_with?("gemini-3")
+      ids = calls.map(&:provider_call_id)
+
+      assert ids.all? { |id| id.is_a?(String) && !id.empty? },
+             "Gemini 3 function-call IDs were not preserved"
+      assert_equal ids.uniq, ids, "Gemini 3 reused a provider function-call ID"
+    end
   end
 end

--- a/test/integration/test_structured_output.rb
+++ b/test/integration/test_structured_output.rb
@@ -39,4 +39,27 @@ class TestStructuredOutputIntegration < Minitest::Test
     assert_equal degrees, result.output["temperature_c"],
                  "the answer must carry the tool's exact reading"
   end
+
+  Integration.scenario(self, :scalar_and_tuple_tasks_survive_provider_schema_differences) do |model|
+    scalar = Integration.codename
+    scalar_result = Mistri::Agent.new(provider: Mistri.provider(model)).task(
+      "Return the exact JSON string #{scalar.inspect}.",
+      schema: { type: "string", enum: [scalar] }
+    )
+
+    tuple_value = Integration.codename
+    tuple_schema = {
+      type: "array",
+      prefixItems: [{ type: "string", enum: [tuple_value] },
+                    { type: "integer", enum: [37] }],
+      items: false
+    }
+    tuple_result = Mistri::Agent.new(provider: Mistri.provider(model)).task(
+      "Return a JSON array containing exactly #{tuple_value.inspect} and 37.",
+      schema: tuple_schema
+    )
+
+    assert_equal scalar, scalar_result.output
+    assert_equal [tuple_value, 37], tuple_result.output
+  end
 end

--- a/test/support/mcp_stub_server.rb
+++ b/test/support/mcp_stub_server.rb
@@ -16,7 +16,7 @@ module Mistri
       def initialize(tools: {}, sse: true, session: nil, page_size: nil,
                      require_token: nil, expire_after: nil, protocol: "2025-11-25",
                      drop_after: nil, malformed_after: nil, empty_after: nil,
-                     next_cursor: nil, trailing_after: nil)
+                     next_cursor: nil, trailing_after: nil, trailing_record: nil)
         @tools = tools
         @sse = sse
         @session = session
@@ -28,6 +28,7 @@ module Mistri
         @malformed_after = malformed_after
         @empty_after = empty_after
         @trailing_after = trailing_after
+        @trailing_record = trailing_record
         @trailed = false
         @next_cursor = next_cursor
         @dropped = false
@@ -128,7 +129,8 @@ module Mistri
         @stub.chunk(socket, "data: #{JSON.generate(payload)}\n\n")
         if method == @trailing_after && !@trailed
           @trailed = true
-          @stub.chunk(socket, "data: #{"x" * 2000}")
+          trailing = @trailing_record ? "#{JSON.generate(@trailing_record)}\n\n" : "x" * 2000
+          @stub.chunk(socket, "data: #{trailing}")
         end
         @stub.finish_sse(socket)
       end

--- a/test/test_agent.rb
+++ b/test/test_agent.rb
@@ -10,7 +10,10 @@ class TestAgent < Minitest::Test
                                                                            "b" => 3 } }] },
                                              { text: "The sum is 5." }
                                            ])
-    add = Mistri::Tool.define("add", "Add two numbers.") { |args| (args["a"] + args["b"]).to_s }
+    add = Mistri::Tool.define("add", "Add two numbers.", schema: lambda {
+      integer :a, "First number", required: true
+      integer :b, "Second number", required: true
+    }) { |args| (args["a"] + args["b"]).to_s }
     agent = Mistri::Agent.new(provider:, tools: [add])
 
     message = agent.run("What is 2 plus 3?")
@@ -66,6 +69,18 @@ class TestAgent < Minitest::Test
     assert_predicate tool_result, :tool?
     assert_equal Mistri::ToolExecutor::INTERRUPTED, tool_result.text
     assert_predicate tool_result, :tool_error?
+  end
+
+  def test_a_length_limited_turn_never_executes_its_tool_calls
+    turn = { tool_calls: [{ name: "danger", arguments: {} }], stop_reason: :length }
+    provider = Mistri::Providers::Fake.new(turns: [turn])
+    danger = Mistri::Tool.define("danger", "Must not run.") { flunk "executed after truncation" }
+    agent = Mistri::Agent.new(provider:, tools: [danger])
+
+    message = agent.run("go")
+
+    assert_equal :length, message.stop_reason
+    assert_equal Mistri::ToolExecutor::INTERRUPTED, agent.session.messages.last.text
   end
 
   def test_a_budget_stops_the_run_between_turns

--- a/test/test_agent_approval.rb
+++ b/test/test_agent_approval.rb
@@ -97,7 +97,8 @@ class TestAgentApproval < Minitest::Test
   def test_conditional_gating_only_parks_the_risky_calls
     sent = []
     tool = Mistri::Tool.define("pay", "Pay an amount.",
-                               needs_approval: ->(args) { args["amount"].to_i > 100 }) do |args|
+                               needs_approval: ->(args) { args["amount"].to_i > 100 },
+                               schema: -> { integer :amount, "Amount", required: true }) do |args|
       sent << args["amount"]
       "paid"
     end

--- a/test/test_agent_task.rb
+++ b/test/test_agent_task.rb
@@ -10,6 +10,20 @@ class TestAgentTask < Minitest::Test
                            "temperature" => { type: "number" } },
              required: %w[city temperature] }.freeze
 
+  class NativeFallbackFake < Mistri::Providers::Fake
+    attr_reader :native_schemas
+
+    def initialize(**)
+      super
+      @native_schemas = []
+    end
+
+    def native_output_schema(schema)
+      @native_schemas << schema
+      nil
+    end
+  end
+
   def test_a_valid_answer_returns_its_parsed_output
     provider = Mistri::Providers::Fake.new(turns: [
                                              { text: '{"city":"Lahore","temperature":31.5}' }
@@ -27,8 +41,18 @@ class TestAgentTask < Minitest::Test
     Mistri::Agent.new(provider:).task("weather", schema: SCHEMA)
 
     request = provider.requests.last
+    expected = {
+      "type" => "object",
+      "properties" => {
+        "city" => { "type" => "string" },
+        "temperature" => { "type" => "number" }
+      },
+      "required" => %w[city temperature],
+      "additionalProperties" => false
+    }
 
-    assert_equal SCHEMA, request[:options][:output_schema]
+    assert_equal expected, request[:options][:output_schema]
+    assert_predicate request[:options][:output_schema], :frozen?
     assert_includes request[:messages].first.text, "matching this schema"
   end
 
@@ -91,5 +115,77 @@ class TestAgentTask < Minitest::Test
     assert_predicate result, :completed?
     assert_equal "not json", result.text
     assert_equal SCHEMA, provider.requests.last[:options][:output_schema]
+  end
+
+  def test_plain_run_does_not_apply_task_capability_fallback
+    provider = NativeFallbackFake.new(turns: [{ text: "not json" }])
+
+    Mistri::Agent.new(provider:).run("go", output_schema: SCHEMA)
+
+    assert_empty provider.native_schemas
+    assert_same SCHEMA, provider.requests.last[:options][:output_schema]
+  end
+
+  def test_task_falls_back_to_prompt_and_local_correction_without_native_schema
+    provider = NativeFallbackFake.new(turns: [
+                                        { text: '{"city":"Lahore"}' },
+                                        { text: '{"city":"Lahore","temperature":31}' }
+                                      ])
+
+    result = Mistri::Agent.new(provider:).task("weather", schema: SCHEMA)
+    output_schemas = provider.requests.map { |request| request[:options][:output_schema] }
+
+    assert_equal 31, result.output["temperature"]
+    assert_equal [nil, nil], output_schemas
+    assert_equal 2, provider.native_schemas.length
+    assert_same provider.native_schemas.first, provider.native_schemas.last
+    assert_includes provider.requests.first[:messages].first.text, "matching this schema"
+  end
+
+  def test_oversized_task_output_is_rejected_before_json_parsing
+    oversized = "x" * ((8 * 1024 * 1024) + 1)
+    parsed = nil
+    parse_called = false
+    trace = TracePoint.new(:call) do |event|
+      json_parse = event.defined_class == JSON.singleton_class && event.method_id == :parse
+      parse_called = true if json_parse
+    end
+
+    trace.enable { parsed = Mistri::TaskOutput.parse(oversized) }
+
+    refute parse_called
+    assert_equal ["the answer exceeds the output byte limit"],
+                 Mistri::TaskOutput.errors(parsed, SCHEMA)
+  end
+
+  def test_overwide_task_output_is_rejected_before_json_parsing
+    overwide = "[#{Array.new(20_002, "0").join(",")}]"
+    parsed = nil
+    parse_called = false
+    trace = TracePoint.new(:call) do |event|
+      json_parse = event.defined_class == JSON.singleton_class && event.method_id == :parse
+      parse_called = true if json_parse
+    end
+
+    trace.enable { parsed = Mistri::TaskOutput.parse(overwide) }
+
+    refute parse_called
+    assert_equal ["the answer exceeds the output complexity limit"],
+                 Mistri::TaskOutput.errors(parsed, SCHEMA)
+  end
+
+  def test_task_rejects_assertions_local_validation_cannot_guarantee
+    provider = Mistri::Providers::Fake.new(turns: [{ text: '{"code":"ABC"}' }])
+    schema = {
+      type: "object",
+      properties: { code: { type: "string", pattern: "^[a-z]+$" } }
+    }
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Agent.new(provider:).task("extract", schema: schema)
+    end
+
+    assert_match(/task output schema uses assertions Mistri cannot validate/, error.message)
+    assert_empty provider.requests
   end
 end

--- a/test/test_anthropic_assembler.rb
+++ b/test/test_anthropic_assembler.rb
@@ -63,6 +63,122 @@ class TestAnthropicAssembler < Minitest::Test
     assert_equal :tool_use, message.stop_reason
   end
 
+  def test_completed_tool_arguments_preserve_non_object_json_and_omission
+    { "null" => nil, "false" => false, "7" => 7, '"text"' => "text",
+      '[1,{"x":true}]' => [1, { "x" => true }] }.each do |json, expected|
+      message = tool_call_with(json)
+
+      if expected.nil?
+        assert_nil message.tool_calls.first.arguments
+      else
+        assert_equal expected, message.tool_calls.first.arguments
+      end
+
+      assert_nil message.tool_calls.first.arguments_error
+    end
+
+    assert_equal({}, tool_call_with(nil).tool_calls.first.arguments)
+  end
+
+  def test_fragmented_tool_arguments_release_the_buffer_after_the_aggregate_limit
+    assembler = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")
+    deltas = []
+    emit = ->(event) { deltas << event.delta if event.type == :toolcall_delta }
+    assembler.feed({ "type" => "content_block_start", "index" => 0,
+                     "content_block" => { "type" => "tool_use", "id" => "too-large",
+                                          "name" => "inspect" } }, &emit)
+    chunk = "x" * (tool_argument_limit / 2)
+    fragments = ['{"blob":"', chunk, chunk, "ignored-after-overflow"]
+    fragments.each do |fragment|
+      assembler.feed({ "type" => "content_block_delta", "index" => 0,
+                       "delta" => { "type" => "input_json_delta",
+                                    "partial_json" => fragment } }, &emit)
+    end
+
+    builder = assembler.instance_variable_get(:@current)
+
+    assert_empty builder.json, "the retained bytes are released once the cap is crossed"
+    assert_equal fragments.map(&:bytesize), deltas.map(&:bytesize),
+                 "resource accounting must not hide raw stream deltas"
+    assert_equal fragments.first, deltas.first
+    assert_equal fragments.last, deltas.last
+
+    assembler.feed({ "type" => "content_block_stop", "index" => 0 }, &emit)
+    assembler.feed({ "type" => "message_delta", "delta" => { "stop_reason" => "tool_use" },
+                     "usage" => {} })
+    assembler.feed({ "type" => "message_stop" })
+    call = assembler.finish.tool_calls.first
+
+    assert_nil call.arguments
+    assert_equal "too_large", call.arguments_error
+  end
+
+  def test_partial_argument_parsing_has_a_bounded_work_schedule
+    assembler = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")
+    assembler.feed({ "type" => "content_block_start", "index" => 0,
+                     "content_block" => { "type" => "tool_use", "id" => "bounded-preview",
+                                          "name" => "inspect" } })
+    previews = []
+    fragments = ['{"blob":"'] + Array.new(128) { "x" * 1024 }
+    fragments.each do |fragment|
+      assembler.feed({ "type" => "content_block_delta", "index" => 0,
+                       "delta" => { "type" => "input_json_delta",
+                                    "partial_json" => fragment } })
+      previews << assembler.instance_variable_get(:@current).argument_preview
+    end
+    builder = assembler.instance_variable_get(:@current)
+
+    assert_operator previews.map(&:object_id).uniq.length, :<=, 21
+    assert_operator builder.preview_bytes, :<=, 64 * 1024
+  end
+
+  def test_malformed_completed_tool_arguments_are_not_salvaged_from_partials
+    events = []
+    message = drive(events, tool_call_records('{"query":"ruby"'))
+    call = message.tool_calls.first
+    partial = events.find { |event| event.type == :toolcall_delta }.partial.tool_calls.first
+
+    assert_equal({ "query" => "ruby" }, partial.arguments,
+                 "the live preview may remain readable")
+    assert_nil call.arguments
+    assert_equal "invalid_json", call.arguments_error
+
+    whitespace = tool_call_with("   ").tool_calls.first
+
+    assert_nil whitespace.arguments
+    assert_equal "invalid_json", whitespace.arguments_error
+  end
+
+  def test_message_stop_never_promotes_an_unfinished_tool_block
+    records = tool_call_records('{"config":{"mode":"safe"}}')
+    records.delete_if { |record| record["type"] == "content_block_stop" }
+    events = []
+
+    message = drive(events, records)
+    call = message.tool_calls.first
+
+    assert_equal :error, message.stop_reason
+    assert_nil call.arguments
+    assert_equal "incomplete", call.arguments_error
+    assert_equal %i[toolcall_start toolcall_delta toolcall_end error], events.map(&:type)
+    preview = events.find { |event| event.type == :toolcall_delta }.partial.tool_calls.first
+
+    assert_predicate preview.arguments["config"], :frozen?
+  end
+
+  def test_a_truncated_text_block_closes_before_the_terminal_error
+    events = []
+    message = drive(events, [
+                      { "type" => "content_block_start", "index" => 0,
+                        "content_block" => { "type" => "text" } },
+                      { "type" => "content_block_delta", "index" => 0,
+                        "delta" => { "type" => "text_delta", "text" => "cut" } }
+                    ])
+
+    assert_equal "cut", message.text
+    assert_equal %i[text_start text_delta text_end error], events.map(&:type)
+  end
+
   def test_an_in_stream_error_ends_the_turn_in_band
     events = []
     message = drive(events, [
@@ -71,9 +187,69 @@ class TestAnthropicAssembler < Minitest::Test
                     ])
 
     assert_equal :error, message.stop_reason
-    assert_equal "Mistri::OverloadedError: Overloaded", message.error_message
+    assert_equal "Mistri::OverloadedError: overloaded_error: Overloaded", message.error_message
     assert_equal "OverloadedError", message.error["type"], "overloaded classifies as retryable"
     assert_predicate events.last, :error?
+  end
+
+  def test_wire_error_types_control_retryability
+    policy = Mistri::RetryPolicy.new
+    cases = {
+      "authentication_error" => ["AuthenticationError", false],
+      "invalid_request_error" => ["InvalidRequestError", false],
+      "permission_error" => ["InvalidRequestError", false],
+      "future_policy_error" => ["InvalidRequestError", false],
+      "rate_limit_error" => ["RateLimitError", true],
+      "api_error" => ["ServerError", true],
+      "timeout_error" => ["ProviderError", true],
+      "overloaded_error" => ["OverloadedError", true]
+    }
+
+    cases.each do |wire_type, (error_type, retryable)|
+      message = drive([], [{ "type" => "error",
+                             "error" => { "type" => wire_type, "message" => "no" } }])
+
+      assert_equal error_type, message.error["type"], wire_type
+      assert_equal retryable, policy.retryable?(message.error), wire_type
+    end
+  end
+
+  def test_fragmented_thinking_signatures_have_an_aggregate_ceiling
+    assembler = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")
+    assembler.feed({ "type" => "content_block_start", "index" => 0,
+                     "content_block" => { "type" => "thinking" } })
+    fragment = "s" * (tool_argument_limit / 2)
+    2.times do
+      assembler.feed({ "type" => "content_block_delta", "index" => 0,
+                       "delta" => { "type" => "signature_delta",
+                                    "signature" => fragment } })
+    end
+
+    error = assert_raises(Mistri::ResponseTooLargeError) do
+      assembler.feed({ "type" => "content_block_delta", "index" => 0,
+                       "delta" => { "type" => "signature_delta", "signature" => "x" } })
+    end
+
+    assert_equal :thinking_signature, error.kind
+  end
+
+  def test_interrupted_thinking_never_replays_a_partial_signature
+    message = drive([], [
+                      { "type" => "content_block_start", "index" => 0,
+                        "content_block" => { "type" => "thinking" } },
+                      { "type" => "content_block_delta", "index" => 0,
+                        "delta" => { "type" => "thinking_delta", "thinking" => "Plan" } },
+                      { "type" => "content_block_delta", "index" => 0,
+                        "delta" => { "type" => "signature_delta",
+                                     "signature" => "partial-secret" } }
+                    ])
+    thinking = message.content.first
+    replay = Mistri::Providers::Anthropic::Serializer.messages([message]).first
+
+    assert_nil thinking.signature
+    refute_predicate thinking, :redacted?
+    assert_equal [{ type: "text", text: "Plan" }], replay[:content]
+    refute(replay[:content].any? { |block| %w[thinking redacted_thinking].include?(block[:type]) })
   end
 
   def test_redacted_thinking_and_unknown_events_are_handled
@@ -236,6 +412,32 @@ class TestAnthropicAssembler < Minitest::Test
   end
 
   private
+
+  def tool_argument_limit
+    Mistri.const_get(:ToolArguments, false)::MAX_BYTES
+  end
+
+  def tool_call_with(json)
+    drive([], tool_call_records(json))
+  end
+
+  def tool_call_records(json)
+    records = [
+      { "type" => "content_block_start", "index" => 0,
+        "content_block" => { "type" => "tool_use", "id" => "toolu_args",
+                             "name" => "inspect" } }
+    ]
+    if json
+      records << { "type" => "content_block_delta", "index" => 0,
+                   "delta" => { "type" => "input_json_delta", "partial_json" => json } }
+    end
+    records + [
+      { "type" => "content_block_stop", "index" => 0 },
+      { "type" => "message_delta", "delta" => { "stop_reason" => "tool_use" },
+        "usage" => {} },
+      { "type" => "message_stop" }
+    ]
+  end
 
   def drive(events, records)
     assembler = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")

--- a/test/test_anthropic_replay.rb
+++ b/test/test_anthropic_replay.rb
@@ -11,7 +11,8 @@ class TestAnthropicReplay < Minitest::Test
     with_signature = Mistri::Content::Thinking.new(thinking: "kept", signature: "sig")
     no_signature = Mistri::Content::Thinking.new(thinking: "was mid-thought")
     empty = Mistri::Content::Thinking.new(thinking: "")
-    msg = Mistri::Message.assistant(content: [with_signature, no_signature, empty])
+    msg = Mistri::Message.assistant(content: [with_signature, no_signature, empty],
+                                    provider: :anthropic)
 
     blocks = SERIALIZER.message(msg)[:content]
 

--- a/test/test_anthropic_serializer.rb
+++ b/test/test_anthropic_serializer.rb
@@ -46,13 +46,32 @@ class TestAnthropicSerializer < Minitest::Test
     assert blocks.last[:is_error]
   end
 
+  def test_invalid_or_non_object_tool_arguments_replay_as_objects
+    invalid = Mistri::ToolCall.new(id: "bad", name: "inspect", arguments: nil,
+                                   arguments_error: "invalid_json")
+    scalar = Mistri::ToolCall.new(id: "scalar", name: "inspect", arguments: 7)
+
+    assert_equal({}, SERIALIZER.block(invalid)[:input])
+    assert_equal({}, SERIALIZER.block(scalar)[:input])
+  end
+
   def test_thinking_replays_with_signature_and_redacted_as_opaque_data
     thinking = Mistri::Content::Thinking.new(thinking: "why", signature: "sig")
     redacted = Mistri::Content::Thinking.new(thinking: "", signature: "opaque", redacted: true)
-    wire = SERIALIZER.message(Mistri::Message.assistant(content: [thinking, redacted]))
+    wire = SERIALIZER.message(Mistri::Message.assistant(content: [thinking, redacted],
+                                                        provider: :anthropic))
 
     assert_equal({ type: "thinking", thinking: "why", signature: "sig" }, wire[:content][0])
     assert_equal({ type: "redacted_thinking", data: "opaque" }, wire[:content][1])
+  end
+
+  def test_foreign_thinking_signatures_never_reach_the_messages_wire
+    thinking = Mistri::Content::Thinking.new(thinking: "why", signature: "foreign")
+    redacted = Mistri::Content::Thinking.new(thinking: "", signature: "opaque", redacted: true)
+    wire = SERIALIZER.message(Mistri::Message.assistant(content: [thinking, redacted],
+                                                        provider: :gemini))
+
+    assert_equal [{ type: "text", text: "why" }], wire[:content]
   end
 
   def test_cache_marks_the_system_tail_and_the_last_user_turn

--- a/test/test_background_mode.rb
+++ b/test/test_background_mode.rb
@@ -221,7 +221,10 @@ class TestBackgroundMode < Minitest::Test
 
   def test_a_dispatched_child_that_needs_approval_leaves_no_open_requests
     risky = Mistri::Tool.define("risky", "Needs a human sometimes.",
-                                needs_approval: ->(args) { args["danger"] == true }) { "did it" }
+                                needs_approval: ->(args) { args["danger"] == true },
+                                schema: -> { boolean :danger, "Whether it is dangerous" }) do
+      "did it"
+    end
     child_fake = fake({ tool_calls: [{ name: "risky", arguments: { "danger" => true } }] })
     dropper = drop_dispatcher
     spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [risky], dispatcher: dropper)
@@ -248,8 +251,8 @@ class TestBackgroundMode < Minitest::Test
     dispatched = Mistri::SubAgent.spawner(provider: fake,
                                           dispatcher: Mistri::Dispatchers::Inline.new)
 
-    refute bare.input_schema[:properties].key?("mode")
-    assert dispatched.input_schema[:properties].key?("mode")
-    assert dispatched.input_schema[:properties].key?("workspace")
+    refute bare.input_schema["properties"].key?("mode")
+    assert dispatched.input_schema["properties"].key?("mode")
+    assert dispatched.input_schema["properties"].key?("workspace")
   end
 end

--- a/test/test_console.rb
+++ b/test/test_console.rb
@@ -54,6 +54,31 @@ class TestConsole < Minitest::Test
     assert_match(/Looking it up\./, output)
   end
 
+  def test_read_agent_preserves_non_object_and_invalid_tool_arguments
+    store = Mistri::Stores::Memory.new
+    parent = Mistri::Session.new(store:)
+    worker = link(parent, store, "Setter")
+    worker.append_message(
+      Mistri::Message.assistant(tool_calls: [
+                                  Mistri::ToolCall.new(id: "null", name: "null_call",
+                                                       arguments: nil),
+                                  Mistri::ToolCall.new(id: "false", name: "false_call",
+                                                       arguments: false),
+                                  Mistri::ToolCall.new(id: "bad", name: "bad_call", arguments: nil,
+                                                       arguments_error: "invalid_json")
+                                ])
+    )
+
+    output = Mistri::Console.read_agent.call({ "agent" => "Setter" }, context_for(parent))
+
+    assert_includes output, "null_call(null)"
+    assert_includes output, "false_call(false)"
+    assert_includes output,
+                    'bad_call({"arguments":null,"arguments_error":"invalid_json"})'
+    refute_includes output, "null_call({})"
+    refute_includes output, "false_call({})"
+  end
+
   def test_list_agents_shows_every_worker_with_status
     _store, parent, = setup_family
     output = Mistri::Console.list_agents.call({}, context_for(parent))

--- a/test/test_content.rb
+++ b/test/test_content.rb
@@ -32,13 +32,258 @@ class TestContent < Minitest::Test
     assert_predicate image.data, :frozen?
   end
 
-  def test_tool_call_owns_its_arguments
-    args = { "q" => "ruby" }
-    call = Mistri::ToolCall.new(id: "c1", name: "search", arguments: args)
-    args["q"] = "changed"
+  def test_replay_signatures_are_owned_by_their_content_blocks
+    text_signature = +"message-id"
+    thinking_signature = +"opaque-state"
+    text = Mistri::Content::Text.new(text: "done", signature: text_signature)
+    thinking = Mistri::Content::Thinking.new(thinking: "why", signature: thinking_signature)
 
-    assert_equal "ruby", call.arguments["q"]
-    assert_raises(FrozenError) { call.arguments["q"] = "nope" }
+    text_signature << " changed"
+    thinking_signature << " changed"
+
+    assert_equal "message-id", text.signature
+    assert_equal "opaque-state", thinking.signature
+    assert_predicate text.signature, :frozen?
+    assert_predicate thinking.signature, :frozen?
+  end
+
+  def test_tool_call_owns_its_arguments
+    query = +"ruby"
+    nested = [{ "q" => query }]
+    args = { config: nested }
+    call = Mistri::ToolCall.new(id: "c1", name: "search", arguments: args)
+    query << " changed"
+    nested << { "q" => "other" }
+    args[:config] = []
+
+    assert_equal({ "config" => [{ "q" => "ruby" }] }, call.arguments)
+    assert_predicate call.arguments, :frozen?
+    assert_predicate call.arguments["config"], :frozen?
+    assert_predicate call.arguments.dig("config", 0, "q"), :frozen?
+    assert_raises(FrozenError) { call.arguments["config"] << "nope" }
+  end
+
+  def test_tool_call_owns_its_pairing_strings
+    id = +"c1"
+    name = +"search"
+    signature = +"provider-state"
+    provider_call_id = +"provider-call"
+    call = Mistri::ToolCall.new(id:, name:, signature:, provider_call_id:, arguments: {})
+
+    id << " changed"
+    name << " changed"
+    signature << " changed"
+    provider_call_id << " changed"
+
+    assert_equal %w[c1 search provider-state provider-call],
+                 [call.id, call.name, call.signature, call.provider_call_id]
+    assert_predicate call.id, :frozen?
+    assert_predicate call.name, :frozen?
+    assert_predicate call.signature, :frozen?
+    assert_predicate call.provider_call_id, :frozen?
+  end
+
+  def test_partial_argument_previews_are_deeply_frozen_only_once
+    counting_hash = Class.new(Hash) do
+      attr_reader :walks
+
+      def each(...)
+        @walks = (@walks || 0) + 1
+        super
+      end
+    end
+    nested = counting_hash.new
+    nested["items"] = [{ "value" => "partial" }]
+
+    arguments = Mistri.const_get(:ToolArguments, false)
+    first = arguments.freeze_partial(nested)
+    walks = nested.walks
+    second = arguments.freeze_partial(nested)
+
+    assert_predicate first, :frozen?
+    assert_predicate first["items"], :frozen?
+    assert_predicate first.dig("items", 0), :frozen?
+    assert_equal walks, nested.walks, "a cached frozen preview is O(1) to reuse"
+    assert_same first, second
+  end
+
+  def test_tool_call_preserves_every_json_top_level_and_explicit_null
+    [nil, false, 7, 2.5, "text", [1, { "x" => true }], { "x" => 1 }].each do |value|
+      call = Mistri::ToolCall.new(id: "c1", name: "inspect", arguments: value)
+      restored = Mistri::Content.from_h(JSON.parse(JSON.generate(call.to_h)))
+
+      value.nil? ? assert_nil(call.arguments) : assert_equal(value, call.arguments)
+
+      assert_equal call, restored
+      assert call.to_h.key?(:arguments), "arguments must survive even when null"
+    end
+
+    legacy = Mistri::Content.from_h(type: "tool_call", id: "old", name: "inspect")
+
+    assert_equal({}, legacy.arguments, "entries written before arguments existed stay compatible")
+  end
+
+  def test_tool_call_rejects_values_that_are_not_bounded_json
+    cycle = []
+    cycle << cycle
+    invalid_utf8 = "\xFF".b
+    too_deep = nil
+    65.times { too_deep = [too_deep] }
+    too_large = Array.new(10_000)
+    cases = [[{ a: 1, "a" => 2 }, "duplicate_key"],
+             [{ 1 => "value" }, "invalid_key"],
+             [cycle, "cyclic_value"],
+             [Object.new, "non_json_value"],
+             [Float::INFINITY, "non_finite_number"],
+             [invalid_utf8, "invalid_encoding"],
+             [too_deep, "too_deep"],
+             [too_large, "too_large"]]
+
+    cases.each do |value, code|
+      call = Mistri::ToolCall.new(id: "c1", name: "inspect", arguments: value)
+
+      assert_nil call.arguments
+      assert_equal code, call.arguments_error
+      assert_equal({ type: :tool_call, id: "c1", name: "inspect", arguments: nil,
+                     arguments_error: code }, call.to_h)
+    end
+  end
+
+  def test_oversized_arrays_are_copied_incrementally
+    hostile = Class.new(Array) do
+      def map(*) = raise("canonicalization preallocated from the hostile length")
+    end.new(10_001)
+
+    call = Mistri::ToolCall.new(id: "large", name: "inspect", arguments: hostile)
+
+    assert_nil call.arguments
+    assert_equal "too_large", call.arguments_error
+  end
+
+  def test_oversized_strings_are_rejected_before_they_are_copied
+    arguments = Mistri.const_get(:ToolArguments, false)
+    hostile = Class.new(String) do
+      def dup = raise("canonicalization copied a string beyond the byte limit")
+    end.new("x" * (arguments::MAX_BYTES + 1))
+
+    call = Mistri::ToolCall.new(id: "large", name: "inspect", arguments: hostile)
+
+    assert_nil call.arguments
+    assert_equal "too_large", call.arguments_error
+  end
+
+  def test_completed_argument_ceiling_counts_the_json_wire_shape
+    arguments = Mistri.const_get(:ToolArguments, false)
+    limit = arguments::MAX_BYTES
+    escaped = "\u0000" * ((limit / 6) + 1)
+    huge_integer = 1 << 28_000_000
+
+    escaped_call = Mistri::ToolCall.new(id: "escaped", name: "inspect",
+                                        arguments: { "value" => escaped })
+    integer_call = Mistri::ToolCall.new(id: "integer", name: "inspect",
+                                        arguments: { "value" => huge_integer })
+
+    assert_nil escaped_call.arguments
+    assert_equal "too_large", escaped_call.arguments_error
+    assert_nil integer_call.arguments
+    assert_equal "number_too_large", integer_call.arguments_error
+
+    value = { "x" => "\u0000" }
+
+    assert arguments.serialized_size_within_limit?(value, limit: 14)
+    refute arguments.serialized_size_within_limit?(value, limit: 13)
+
+    exact_values = [nil, true, false, -123_456_789, 1.25,
+                    "\u0000\b\t\n\f\r\\\"é", [1, "x"], { "a" => [false] }]
+    exact_values.each do |candidate|
+      bytes = JSON.generate(candidate).bytesize
+
+      assert arguments.serialized_size_within_limit?(candidate, limit: bytes)
+      refute arguments.serialized_size_within_limit?(candidate, limit: bytes - 1)
+    end
+  end
+
+  def test_programmatic_integer_tokens_obey_the_encoded_input_limit
+    arguments = Mistri.const_get(:ToolArguments, false)
+    huge_integer = 1 << ((arguments::MAX_NUMBER_BYTES + 1) * 4)
+
+    call = Mistri::ToolCall.new(id: "large", name: "inspect",
+                                arguments: { "value" => huge_integer })
+
+    assert_nil call.arguments
+    assert_equal "number_too_large", call.arguments_error
+  end
+
+  def test_encoded_json_width_is_bounded_before_parser_allocation
+    arguments = Mistri.const_get(:ToolArguments, false)
+    wide_array = "[#{Array.new(20_002, "0").join(",")}]"
+    wide_object = "{#{Array.new(10_001) { |index| "\"k#{index}\":0" }.join(",")}}"
+    parse_called = false
+    trace = TracePoint.new(:call) do |event|
+      json_parse = event.defined_class == JSON.singleton_class && event.method_id == :parse
+      parse_called = true if json_parse
+    end
+
+    errors = trace.enable do
+      [arguments.parse_json(wide_array).last, arguments.parse_json(wide_object).last]
+    end
+
+    assert_equal %w[too_many_nodes too_many_nodes], errors
+    refute parse_called
+
+    huge_number = "1" * (arguments::MAX_NUMBER_BYTES + 1)
+    parse_called = false
+    numeric_error = trace.enable { arguments.parse_json(huge_number).last }
+
+    assert_equal "number_too_large", numeric_error
+    refute parse_called
+
+    punctuation = JSON.generate(
+      "text" => "escaped \" quote, colon: braces {} and brackets []",
+      "values" => [1, 2]
+    )
+    parsed, error = arguments.parse_json(punctuation)
+
+    assert_nil error
+    assert_equal [1, 2], parsed["values"]
+  end
+
+  def test_tool_call_allows_shared_acyclic_values_and_exact_bounds
+    shared = ["value"]
+    at_depth = nil
+    64.times { at_depth = [at_depth] }
+    at_size = Array.new(9_999)
+
+    call = Mistri::ToolCall.new(id: "c1", name: "inspect",
+                                arguments: { "left" => shared, "right" => shared })
+
+    assert_nil call.arguments_error
+    assert_equal ["value"], call.arguments["left"]
+    refute_same call.arguments["left"], call.arguments["right"]
+    assert_nil Mistri::ToolCall.new(id: "depth", name: "inspect",
+                                    arguments: at_depth).arguments_error
+    assert_nil Mistri::ToolCall.new(id: "size", name: "inspect",
+                                    arguments: at_size).arguments_error
+  end
+
+  def test_persisted_argument_errors_are_closed_and_safe
+    call = Mistri::Content.from_h(type: "tool_call", id: "c1", name: "inspect",
+                                  arguments: { "secret" => "do not preserve" },
+                                  arguments_error: "future_internal_detail")
+
+    assert_nil call.arguments
+    assert_equal "invalid_arguments", call.arguments_error
+  end
+
+  def test_tool_call_with_reenters_the_argument_ownership_boundary
+    original = Mistri::ToolCall.new(id: "c1", name: "inspect", arguments: {})
+    nested = [{ key: +"value" }]
+
+    replaced = original.with(arguments: { payload: nested })
+    nested.first[:key] << " changed"
+
+    assert_equal({ "payload" => [{ "key" => "value" }] }, replaced.arguments)
+    assert_predicate replaced.arguments.dig("payload", 0), :frozen?
   end
 
   def test_wrap_coerces_strings_and_passes_blocks_through

--- a/test/test_errors.rb
+++ b/test/test_errors.rb
@@ -50,5 +50,7 @@ class TestErrors < Minitest::Test
     assert_equal :sse_record_nodes, error.kind
     assert_equal 10_000, error.limit
     assert_equal "sse record nodes exceeded the complexity limit (10000)", error.message
+    assert_equal({ "type" => "ResponseTooComplexError", "kind" => "sse_record_nodes",
+                   "limit" => 10_000 }, Mistri::ErrorData.for(error))
   end
 end

--- a/test/test_errors.rb
+++ b/test/test_errors.rb
@@ -6,7 +6,8 @@ class TestErrors < Minitest::Test
   def test_every_error_rescues_as_mistri_error
     [Mistri::ConfigurationError, Mistri::ProviderError, Mistri::AuthenticationError,
      Mistri::RateLimitError, Mistri::OverloadedError, Mistri::ServerError,
-     Mistri::ResponseTooLargeError, Mistri::AmbiguousDeliveryError,
+     Mistri::ResponseTooLargeError, Mistri::ResponseTooComplexError,
+     Mistri::AmbiguousDeliveryError,
      Mistri::InvalidRequestError, Mistri::SchemaError, Mistri::AbortError,
      Mistri::BudgetError].each do |klass|
       assert_operator klass, :<, Mistri::Error
@@ -40,6 +41,14 @@ class TestErrors < Minitest::Test
 
     assert_equal :json_body, error.kind
     assert_equal 1024, error.limit
-    assert_equal "json body exceeded max_record_bytes (1024 bytes)", error.message
+    assert_equal "json body exceeded the byte limit (1024 bytes)", error.message
+  end
+
+  def test_response_too_complex_error_carries_only_boundary_metadata
+    error = Mistri::ResponseTooComplexError.new(kind: :sse_record_nodes, limit: 10_000)
+
+    assert_equal :sse_record_nodes, error.kind
+    assert_equal 10_000, error.limit
+    assert_equal "sse record nodes exceeded the complexity limit (10000)", error.message
   end
 end

--- a/test/test_fake_provider.rb
+++ b/test/test_fake_provider.rb
@@ -89,6 +89,50 @@ class TestFakeProvider < Minitest::Test
     assert_equal html, htmls.last, "the final delta's partial already reads complete"
   end
 
+  def test_generated_tool_call_ids_are_unique_across_turns
+    turns = [
+      { tool_calls: [
+        { name: "first", arguments: {} },
+        { name: "second", arguments: {} }
+      ] },
+      { tool_calls: [{ name: "third", arguments: {} }] }
+    ]
+    provider = Mistri::Providers::Fake.new(turns:)
+
+    ids = [*provider.stream.tool_calls, *provider.stream.tool_calls].map(&:id)
+    fresh = Mistri::Providers::Fake.new(
+      turns: [{ tool_calls: [{ name: "fresh", arguments: {} }] }]
+    ).stream.tool_calls.first.id
+    sequences = ids.map { |id| id.split("_").last }
+
+    assert_equal 3, ids.uniq.length
+    assert_equal %w[1 2 3], sequences
+    refute_includes ids, fresh, "a fresh fake may resume the same durable session"
+  end
+
+  def test_tool_calls_preserve_non_object_arguments_and_omission
+    values = [nil, false, 7, "text", [1, { x: true }]]
+    turns = values.map { |value| { tool_calls: [{ name: "inspect", arguments: value }] } }
+    turns << { tool_calls: [{ name: "inspect" }] }
+    provider = Mistri::Providers::Fake.new(turns: turns)
+
+    calls = turns.map { provider.stream.tool_calls.first }
+
+    assert_equal [nil, false, 7, "text", [1, { "x" => true }], {}], calls.map(&:arguments)
+    assert(calls.all? { |call| call.arguments_error.nil? })
+  end
+
+  def test_tool_calls_can_script_a_malformed_provider_payload
+    turn = { tool_calls: [{ name: "inspect", arguments: { "secret" => "discard" },
+                            arguments_error: "invalid_json" }] }
+    provider = Mistri::Providers::Fake.new(turns: [turn])
+
+    call = provider.stream.tool_calls.first
+
+    assert_nil call.arguments
+    assert_equal "invalid_json", call.arguments_error
+  end
+
   private
 
   def deltas(events, type)

--- a/test/test_file_tools.rb
+++ b/test/test_file_tools.rb
@@ -39,6 +39,15 @@ class TestFileTools < Minitest::Test
     assert_equal "b\nb\n", @workspace.read("x.txt")
   end
 
+  def test_edit_file_rejects_ambiguous_aliases
+    error = assert_raises(ArgumentError) do
+      @tools["edit_file"].call({ "file" => "x.txt", "path" => "y.txt",
+                                 "oldText" => "a", "newText" => "b" })
+    end
+
+    assert_includes error.message, "map to \"path\""
+  end
+
   def test_edit_file_failures_come_back_in_band_with_the_near_miss
     reply = @tools["edit_file"].call({ "path" => "hero.html",
                                        "old_string" => "<h1>Welcom</h1>",

--- a/test/test_gemini_argument_integrity.rb
+++ b/test/test_gemini_argument_integrity.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "delegate"
+
+class TestGeminiArgumentIntegrity < Minitest::Test
+  class GeminiFake < SimpleDelegator
+    def stream(**, &)
+      super.with(provider: :gemini)
+    end
+  end
+
+  class VerdictGemini
+    attr_reader :requests
+
+    def initialize(message)
+      @message = message
+      @requests = 0
+    end
+
+    def model = "gemini-verdict"
+
+    def stream(**, &emit)
+      @requests += 1
+      emit&.call(Mistri::Event.new(type: :error, reason: @message.stop_reason,
+                                   message: @message, error_message: @message.error_message))
+      @message
+    end
+  end
+
+  def test_malformed_gemini_calls_retry_without_persisting_unreplayable_history
+    invalid_calls = [
+      { id: "bad-json", name: "write", arguments: {},
+        arguments_error: "invalid_json", signature: "signed" },
+      { id: "wrong-shape", name: "write", arguments: [], signature: "signed" }
+    ]
+
+    invalid_calls.each do |invalid|
+      fake = Mistri::Providers::Fake.new(turns: [
+                                           { tool_calls: [invalid] },
+                                           { text: "recovered" }
+                                         ])
+      provider = GeminiFake.new(fake)
+      retries = Mistri::RetryPolicy.new(attempts: 1, base: 0, max_delay: 0)
+      ran = false
+      tool = Mistri::Tool.define("write", "Writes.") do
+        ran = true
+        "written"
+      end
+      agent = Mistri::Agent.new(provider:, tools: [tool], retries:)
+
+      result = agent.run("go")
+
+      assert_predicate result, :completed?
+      refute ran
+      assert_equal 2, provider.requests.length
+      assert_equal provider.requests[0][:messages].map(&:to_h),
+                   provider.requests[1][:messages].map(&:to_h)
+      assert_empty agent.session.messages.flat_map(&:tool_calls)
+      assert_equal(1, agent.session.entries.count { |entry| entry["type"] == "retry" })
+    end
+  end
+
+  def test_malformed_call_metadata_cannot_reclassify_a_provider_verdict
+    call = Mistri::ToolCall.new(id: "bad", name: "write", arguments: {},
+                                arguments_error: "invalid_json", signature: "signed")
+    message = Mistri::Message.assistant(
+      content: ["blocked", call], provider: :gemini, model: "gemini-verdict",
+      usage: Mistri::Usage.zero, stop_reason: :error,
+      error_message: "generation stopped: SAFETY",
+      error: { "type" => "InvalidRequestError" }
+    )
+    provider = VerdictGemini.new(message)
+    tool = Mistri::Tool.define("write", "Writes.") { flunk "verdict call executed" }
+
+    result = Mistri::Agent.new(provider:, tools: [tool]).run("go")
+
+    assert_predicate result, :errored?
+    assert_equal 1, provider.requests
+    assert_equal "InvalidRequestError", result.message.error.fetch("type")
+    assert_empty result.message.tool_calls
+    assert_equal "blocked", result.text
+    assert_predicate result.message.content, :frozen?
+    assert_raises(FrozenError) { result.message.content << "mutated" }
+  end
+end

--- a/test/test_gemini_assembler.rb
+++ b/test/test_gemini_assembler.rb
@@ -32,7 +32,8 @@ class TestGeminiAssembler < Minitest::Test
     events = []
     message = drive(events, [
                       { "candidates" => [{ "content" => { "parts" => [
-                        { "functionCall" => { "name" => "search", "args" => { "q" => "ruby" } },
+                        { "functionCall" => { "id" => "call-remote", "name" => "search",
+                                              "args" => { "q" => "ruby" } },
                           "thoughtSignature" => "tsig123" }
                       ] } }] },
                       { "candidates" => [{ "finishReason" => "STOP" }] }
@@ -42,10 +43,46 @@ class TestGeminiAssembler < Minitest::Test
 
     assert_equal :tool_use, message.stop_reason
     assert_equal "search", call.name
+    assert_equal "call-remote", call.id
+    assert_equal "call-remote", call.provider_call_id
     assert_equal({ "q" => "ruby" }, call.arguments)
     assert_equal "tsig123", call.signature
     assert_equal %i[toolcall_start toolcall_delta toolcall_end],
                  events.select { |e| e.type.start_with?("toolcall") }.map(&:type)
+  end
+
+  def test_signed_parts_keep_their_wire_boundaries
+    message = drive([], [
+                      { "candidates" => [{ "content" => { "parts" => [
+                        { "text" => "A", "thoughtSignature" => "sig-a" },
+                        { "text" => "B", "thoughtSignature" => "sig-b" }
+                      ] } }] },
+                      { "candidates" => [{ "finishReason" => "STOP" }] }
+                    ])
+
+    assert_equal %w[A B], message.content.map(&:text)
+    assert_equal %w[sig-a sig-b], message.content.map(&:signature)
+  end
+
+  def test_missing_function_call_ids_receive_unique_internal_ids_only
+    first = function_call.tool_calls.first
+    second = function_call.tool_calls.first
+
+    refute_equal first.id, second.id
+    assert_nil first.provider_call_id
+    assert_nil second.provider_call_id
+  end
+
+  def test_function_calls_preserve_non_object_arguments_and_omission
+    [nil, false, 7, "text", [1, { "x" => true }]].each do |value|
+      call = function_call("args" => value).tool_calls.first
+
+      value.nil? ? assert_nil(call.arguments) : assert_equal(value, call.arguments)
+
+      assert_nil call.arguments_error
+    end
+
+    assert_equal({}, function_call.tool_calls.first.arguments)
   end
 
   def test_max_tokens_and_error_records_map_cleanly
@@ -62,6 +99,20 @@ class TestGeminiAssembler < Minitest::Test
     assert_equal :error, failed.stop_reason
     assert_equal "Mistri::ProviderError: internal | status 500", failed.error_message
     assert_equal 500, failed.error["status"], "the wire code rides as a status"
+  end
+
+  def test_max_tokens_outranks_a_function_call
+    message = drive([], [
+                      { "candidates" => [{
+                        "content" => { "parts" => [{
+                          "functionCall" => { "name" => "write", "args" => {} }
+                        }] },
+                        "finishReason" => "MAX_TOKENS"
+                      }] }
+                    ])
+
+    assert_equal :length, message.stop_reason
+    assert_equal 1, message.tool_calls.length
   end
 
   def test_usage_prices_from_the_catalog_and_unknown_models_stay_unknown
@@ -163,13 +214,23 @@ class TestGeminiAssembler < Minitest::Test
       refute policy.retryable?(message.error), "#{reason} is a verdict, never retried"
     end
 
-    %w[MALFORMED_FUNCTION_CALL TOO_MANY_TOOL_CALLS OTHER].each do |reason|
+    %w[MALFORMED_FUNCTION_CALL TOO_MANY_TOOL_CALLS OTHER MALFORMED_RESPONSE
+       FINISH_REASON_UNSPECIFIED].each do |reason|
       fumble = drive([], [{ "candidates" => [{ "finishReason" => reason }] }])
 
       assert_equal :error, fumble.stop_reason, "#{reason} must not read as a clean stop"
       assert_equal "ProviderError", fumble.error["type"], "#{reason} misclassified"
       assert policy.retryable?(fumble.error), "#{reason} accuses the input of nothing"
     end
+
+    missing_signature = drive([], [
+                                { "candidates" => [
+                                  { "finishReason" => "MISSING_THOUGHT_SIGNATURE" }
+                                ] }
+                              ])
+
+    assert_equal "InvalidRequestError", missing_signature.error["type"]
+    refute policy.retryable?(missing_signature.error)
   end
 
   def test_a_blocked_prompt_fails_fast_instead_of_reading_as_truncation
@@ -200,15 +261,26 @@ class TestGeminiAssembler < Minitest::Test
   end
 
   def test_a_stream_that_ends_without_a_finish_reason_is_an_error
-    message = drive([], [
+    events = []
+    message = drive(events, [
                       { "candidates" => [{ "content" => { "parts" => [{ "text" => "cut" }] } }] }
                     ])
 
     assert_equal :error, message.stop_reason
     assert_match(/finish reason/, message.error_message)
+    assert_equal %i[text_start text_delta text_end error], events.map(&:type)
   end
 
   private
+
+  def function_call(fields = {})
+    drive([], [
+            { "candidates" => [{ "content" => { "parts" => [
+              { "functionCall" => { "name" => "inspect" }.merge(fields) }
+            ] } }] },
+            { "candidates" => [{ "finishReason" => "STOP" }] }
+          ])
+  end
 
   def drive(events, records)
     assembler = Mistri::Providers::Gemini::Assembler.new(model: "gemini-2.5-flash")

--- a/test/test_gemini_live.rb
+++ b/test/test_gemini_live.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "securerandom"
 
 # Real API calls, opt-in: MISTRI_LIVE=1 bundle exec rake test
 class TestGeminiLive < Minitest::Test
@@ -74,6 +75,29 @@ class TestGeminiLive < Minitest::Test
     assert_kind_of Hash, config
     assert_equal "bar", config.dig("series", 0, "type")
     assert_equal [1, 2], config.dig("series", 0, "data")
+  ensure
+    provider&.close
+  end
+
+  def test_foreign_tool_history_projects_into_a_valid_gemini_continuation
+    provider = Mistri::Providers::Gemini.new(api_key: ENV.fetch("GEMINI_API_KEY"),
+                                             model: "gemini-3.5-flash")
+    fact = "Mistri-cross-provider-#{SecureRandom.hex(5)}"
+    call = Mistri::ToolCall.new(id: "openai-call-1", name: "lookup",
+                                arguments: { "record" => "one" },
+                                signature: "openai-item-1")
+    history = [
+      Mistri::Message.user("Look up the record."),
+      Mistri::Message.assistant(content: [call], provider: :openai,
+                                stop_reason: :tool_use),
+      Mistri::Message.tool(content: fact, tool_call_id: call.id, tool_name: call.name),
+      Mistri::Message.user("Repeat the exact historical lookup result and nothing else.")
+    ]
+
+    message = provider.stream(messages: history) { |_event| nil }
+
+    assert_equal :stop, message.stop_reason
+    assert_includes message.text, fact
   ensure
     provider&.close
   end

--- a/test/test_gemini_serializer.rb
+++ b/test/test_gemini_serializer.rb
@@ -12,12 +12,15 @@ class TestGeminiSerializer < Minitest::Test
 
     wire = SERIALIZER.tools([tool.spec])
 
-    assert_equal tool.input_schema, wire.first[:functionDeclarations].first[:parameters]
+    declaration = wire.first[:functionDeclarations].first
+
+    assert_equal tool.input_schema, declaration[:parametersJsonSchema]
+    refute declaration.key?(:parameters)
   end
 
   def test_a_gemini_turn_replays_with_signatures_and_merged_tool_results
     call = Mistri::ToolCall.new(id: "c1", name: "search", arguments: { "q" => "ruby" },
-                                signature: "tsig")
+                                signature: "tsig", provider_call_id: "c1")
     assistant = Mistri::Message.assistant(content: "Searching.", tool_calls: [call],
                                           provider: :gemini, stop_reason: :tool_use)
     history = [Mistri::Message.user("go"), assistant,
@@ -29,7 +32,9 @@ class TestGeminiSerializer < Minitest::Test
     call_part = contents[1][:parts].last
 
     assert_equal "tsig", call_part[:thoughtSignature]
-    assert_equal({ name: "search", args: { "q" => "ruby" } }, call_part[:functionCall])
+    assert_equal({ name: "search", args: { "q" => "ruby" }, id: "c1" },
+                 call_part[:functionCall])
+    assert_equal "c1", contents.last[:parts].first[:functionResponse][:id]
     assert_equal({ "result" => "found" },
                  contents.last[:parts].first[:functionResponse][:response])
   end
@@ -47,6 +52,39 @@ class TestGeminiSerializer < Minitest::Test
     assert_equal [{ text: "hi" }], parts
   end
 
+  def test_foreign_tool_exchanges_project_to_neutral_text
+    call = Mistri::ToolCall.new(id: "foreign-1", name: "lookup",
+                                arguments: { "q" => "ruby" }, signature: "openai-item")
+    assistant = Mistri::Message.assistant(content: [call], provider: :openai,
+                                          stop_reason: :tool_use)
+    result = Mistri::Message.tool(content: "found", tool_call_id: call.id,
+                                  tool_name: call.name)
+
+    contents = SERIALIZER.contents([Mistri::Message.user("go"), assistant, result])
+
+    assert_equal(%w[user model user], contents.map { |turn| turn[:role] })
+    refute contents[1][:parts].first.key?(:functionCall)
+    refute contents[2][:parts].first.key?(:functionResponse)
+    assert_includes contents[1][:parts].first[:text], '"q":"ruby"'
+    assert_includes contents[2][:parts].first[:text], "found"
+  end
+
+  def test_native_and_foreign_tool_results_never_share_a_wire_turn
+    gemini = Mistri::ToolCall.new(id: "gemini-1", name: "one", arguments: {})
+    foreign = Mistri::ToolCall.new(id: "foreign-1", name: "two", arguments: {})
+    history = [
+      Mistri::Message.assistant(content: [gemini], provider: :gemini),
+      Mistri::Message.assistant(content: [foreign], provider: :openai),
+      Mistri::Message.tool(content: "one", tool_call_id: gemini.id, tool_name: gemini.name),
+      Mistri::Message.tool(content: "two", tool_call_id: foreign.id, tool_name: foreign.name)
+    ]
+
+    contents = SERIALIZER.contents(history)
+
+    assert contents[-2][:parts].first.key?(:functionResponse)
+    assert contents[-1][:parts].first.key?(:text)
+  end
+
   def test_a_tool_result_without_a_tool_name_fails_loudly
     result = Mistri::Message.tool(content: "found", tool_call_id: "c1")
 
@@ -54,12 +92,54 @@ class TestGeminiSerializer < Minitest::Test
   end
 
   def test_failed_tool_results_use_the_documented_error_key
+    call = Mistri::ToolCall.new(id: "c1", name: "search", arguments: {})
     failed = Mistri::Message.tool(content: "unavailable", tool_call_id: "c1",
                                   tool_name: "search", tool_error: true)
+    assistant = Mistri::Message.assistant(content: [call], provider: :gemini)
 
-    response = SERIALIZER.contents([failed]).first[:parts].first[:functionResponse][:response]
+    response = SERIALIZER.contents([assistant, failed]).last[:parts]
+                         .first[:functionResponse][:response]
 
     assert_equal({ "error" => "unavailable" }, response)
+  end
+
+  def test_an_unknown_call_origin_projects_consistently_as_text
+    call = Mistri::ToolCall.new(id: "legacy", name: "lookup", arguments: {})
+    assistant = Mistri::Message.assistant(content: [call], provider: nil)
+    result = Mistri::Message.tool(content: "found", tool_call_id: call.id,
+                                  tool_name: call.name)
+
+    contents = SERIALIZER.contents([assistant, result])
+
+    assert contents.first[:parts].first.key?(:text)
+    assert contents.last[:parts].first.key?(:text)
+  end
+
+  def test_invalid_or_non_object_tool_arguments_replay_as_objects
+    invalid = Mistri::ToolCall.new(id: "bad", name: "inspect", arguments: nil,
+                                   arguments_error: "invalid_json", signature: "invalid-sig")
+    scalar = Mistri::ToolCall.new(id: "scalar", name: "inspect", arguments: 7,
+                                  signature: "scalar-sig")
+    message = Mistri::Message.assistant(content: [invalid, scalar], provider: :gemini)
+    parts = SERIALIZER.contents([message]).first[:parts]
+    arguments = parts.map { |part| part[:functionCall][:args] }
+
+    assert_equal [{}, {}], arguments
+    refute(parts.any? { |part| part.key?(:thoughtSignature) },
+           "a changed placeholder cannot retain the provider thought signature")
+  end
+
+  def test_a_legacy_call_without_a_wire_id_does_not_mutate_the_signed_part
+    call = Mistri::ToolCall.new(id: "internal", name: "inspect", arguments: {},
+                                signature: "signed")
+    history = [Mistri::Message.assistant(content: [call], provider: :gemini),
+               Mistri::Message.tool(content: "ok", tool_call_id: "internal",
+                                    tool_name: "inspect")]
+
+    contents = SERIALIZER.contents(history)
+
+    refute contents.first[:parts].first[:functionCall].key?(:id)
+    refute contents.last[:parts].first[:functionResponse].key?(:id)
   end
 
   def test_images_ride_as_inline_data

--- a/test/test_install_generator.rb
+++ b/test/test_install_generator.rb
@@ -38,5 +38,14 @@ if defined?(Mistri::Generators::InstallGenerator)
       assert_file "app/models/mistri_entry.rb", /class MistriEntry/
       assert_migration "db/migrate/create_mistri_entries.rb"
     end
+
+    def test_mysql_family_migrations_use_longtext_for_parallel_turns
+      generator = Mistri::Generators::InstallGenerator.allocate
+
+      %w[mysql2 trilogy].each do |adapter|
+        assert_equal ", size: :long", generator.send(:payload_size_for, adapter), adapter
+      end
+      assert_equal "", generator.send(:payload_size_for, "postgresql")
+    end
   end
 end

--- a/test/test_mcp_bridge.rb
+++ b/test/test_mcp_bridge.rb
@@ -29,6 +29,145 @@ class TestMcpBridge < Minitest::Test
                  tools.first.spec[:input_schema])
   end
 
+  def test_mcp_map_schemas_validate_without_an_adapter
+    listed = [{ "name" => "headers", "description" => "Accepts headers.",
+                "inputSchema" => {
+                  "type" => "object",
+                  "additionalProperties" => { "type" => "string" }
+                } }]
+    tool = Mistri::MCP.tools(Struct.new(:tools).new(listed)).first
+
+    assert_empty tool.argument_violations("authorization" => "redacted")
+    assert_equal ["$.attempts must be string, got integer"],
+                 tool.argument_violations("attempts" => 2)
+  end
+
+  def test_mcp_complete_validator_seam_is_explicit_and_names_bad_tools
+    listed = [{ "name" => "labels", "description" => "Accepts labels.",
+                "inputSchema" => {
+                  "type" => "object",
+                  "patternProperties" => { "^x-" => { "type" => "string" } },
+                  "additionalProperties" => false
+                } }]
+    client = Struct.new(:tools).new(listed)
+
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::MCP.tools(client) }
+
+    assert_match(/MCP tool "labels"/, error.message)
+    validated = []
+    tool = Mistri::MCP.tools(
+      client,
+      complete_argument_validator: lambda { |arguments, _schema|
+        validated << arguments
+        []
+      }
+    ).first
+
+    assert_empty tool.argument_violations("x-team" => "platform")
+    assert_equal [{ "x-team" => "platform" }], validated
+  end
+
+  def test_mcp_rejects_a_non_object_tool_schema
+    client = Struct.new(:tools).new(
+      [{ "name" => "disabled", "description" => "Disabled.", "inputSchema" => false }]
+    )
+
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::MCP.tools(client) }
+
+    assert_match(/MCP tool "disabled"/, error.message)
+    assert_match(/must declare type object/, error.message)
+  end
+
+  def test_mcp_distinguishes_an_omitted_schema_from_explicit_null
+    omitted = Struct.new(:tools).new([{ "name" => "ping", "description" => "Pings." }])
+    null = Struct.new(:tools).new(
+      [{ "name" => "broken", "description" => "Broken.", "inputSchema" => nil }]
+    )
+
+    tool = Mistri::MCP.tools(omitted).first
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::MCP.tools(null) }
+
+    assert_equal({ "type" => "object", "properties" => {},
+                   "additionalProperties" => false }, tool.input_schema)
+    assert_equal ["$.surprise is not allowed"], tool.argument_violations("surprise" => true)
+    assert_match(/MCP tool "broken"/, error.message)
+    assert_match(/inputSchema must be an object, not null/, error.message)
+  end
+
+  def test_mcp_requires_a_complete_validator_for_unimplemented_assertions
+    listed = [{ "name" => "bounded", "description" => "Checks a bounded value.",
+                "inputSchema" => {
+                  "type" => "object",
+                  "properties" => { "count" => { "type" => "integer", "minimum" => 1 } }
+                } }]
+    client = Struct.new(:tools).new(listed)
+
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::MCP.tools(client) }
+
+    assert_match(/MCP input schema uses assertions Mistri cannot validate/, error.message)
+    assert_match(/\$\.properties\.count\.minimum/, error.message)
+
+    tool = Mistri::MCP.tools(
+      client,
+      complete_argument_validator: ->(*) { [] }
+    ).first
+
+    assert_empty tool.argument_violations("count" => 1)
+  end
+
+  def test_mcp_does_not_promote_format_annotations_into_assertions
+    client = Struct.new(:tools).new(
+      [{ "name" => "notify", "description" => "Notifies.",
+         "inputSchema" => {
+           "type" => "object",
+           "properties" => { "email" => { "type" => "string", "format" => "email" } }
+         } }]
+    )
+
+    tool = Mistri::MCP.tools(client).first
+
+    assert_empty tool.argument_violations("email" => "host-policy-validates-if-needed")
+  end
+
+  def test_mcp_rejects_malformed_unimplemented_assertions_before_bridging
+    client = Struct.new(:tools).new(
+      [{ "name" => "broken_dependencies", "description" => "Broken.",
+         "inputSchema" => { "type" => "object", "dependentRequired" => [] } }]
+    )
+
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::MCP.tools(client) }
+
+    assert_match(/MCP tool "broken_dependencies"/, error.message)
+    assert_match(/dependentRequired must be an object/, error.message)
+  end
+
+  def test_mcp_allows_only_same_document_references_with_a_complete_validator
+    base = {
+      "type" => "object",
+      "$defs" => { "id" => { "type" => "string" } },
+      "properties" => { "id" => { "$ref" => "#/$defs/id" } }
+    }
+    complete = ->(*) { [] }
+    local = Struct.new(:tools).new(
+      [{ "name" => "local", "description" => "Local ref.", "inputSchema" => base }]
+    )
+    external_schema = base.merge(
+      "properties" => { "id" => { "$ref" => "https://example.com/id.json" } }
+    )
+    external = Struct.new(:tools).new(
+      [{ "name" => "external", "description" => "External ref.",
+         "inputSchema" => external_schema }]
+    )
+
+    assert Mistri::MCP.tools(local, complete_argument_validator: complete).first
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::MCP.tools(external, complete_argument_validator: complete)
+    end
+
+    assert_match(/MCP tool "external"/, error.message)
+    assert_match(/same-document reference beginning with #/, error.message)
+  end
+
   def test_answers_map_text_errors_images_and_structured_content
     text = { "content" => [{ "type" => "text", "text" => "found 3" },
                            { "type" => "text", "text" => "more" }] }

--- a/test/test_mcp_response_limits.rb
+++ b/test/test_mcp_response_limits.rb
@@ -49,6 +49,31 @@ class TestMcpResponseLimits < Minitest::Test
     end
   end
 
+  def test_a_structurally_complex_tool_response_is_ambiguous_and_resets_the_wire
+    arguments = Mistri.const_get(:ToolArguments, false)
+    cases = {
+      tokens: { "content" => Array.new(arguments::MAX_LEXICAL_TOKENS + 1, 0) },
+      numeric_token: { "content" => [1 << ((arguments::MAX_NUMBER_BYTES + 1) * 4)] }
+    }
+
+    cases.each do |label, outcome|
+      tools = { "complex" => { description: "Complex.", handler: ->(_) { outcome } } }
+      with_server(tools:, session: "sess") do |server|
+        client = remote_client(server)
+
+        error = assert_raises(Mistri::AmbiguousDeliveryError) do
+          client.call_tool("complex", {})
+        end
+
+        assert_instance_of Mistri::ResponseTooComplexError, error.cause, label
+        assert_equal 1, server.calls.length, label
+        client.connect
+
+        assert_equal 2, server.initializes, label
+      end
+    end
+  end
+
   def test_a_confirmed_tool_result_survives_an_oversized_trailing_sse_line
     with_server(trailing_after: "tools/call") do |server|
       client = remote_client(server, max_record_bytes: 512)
@@ -61,6 +86,22 @@ class TestMcpResponseLimits < Minitest::Test
       client.connect
 
       assert_equal 2, server.initializes, "the malformed stream forced a clean handshake"
+    end
+  end
+
+  def test_a_confirmed_tool_result_survives_a_complex_trailing_sse_record
+    arguments = Mistri.const_get(:ToolArguments, false)
+    trailing = { "noise" => Array.new(arguments::MAX_LEXICAL_TOKENS + 1, 0) }
+    with_server(trailing_after: "tools/call", trailing_record: trailing) do |server|
+      client = remote_client(server)
+
+      result = client.call_tool("echo", { "text" => "confirmed" })
+
+      assert_equal "echo: confirmed", result.dig("content", 0, "text")
+      assert_equal 1, server.calls.length
+      client.connect
+
+      assert_equal 2, server.initializes, "the complex stream forced a clean handshake"
     end
   end
 

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -224,6 +224,9 @@ class TestModels < Minitest::Test
     refute body.key?("service_tier"), "catalog pricing must not choose host policy"
     assert_equal "standard_only", standard_body["service_tier"]
     assert_equal({ "type" => "adaptive", "display" => "summarized" }, body["thinking"])
+    assert_equal :start, seen.first.type
+    assert_predicate seen.first.partial, :assistant?
+    assert_equal :anthropic, seen.first.partial.provider
   ensure
     automatic&.close
     standard&.close
@@ -242,13 +245,16 @@ class TestModels < Minitest::Test
     standard = Mistri::Providers::OpenAI.new(api_key: "test", origin: server.origin,
                                              catalog_pricing: true, service_tier: "default")
 
-    automatic.stream(messages: [Mistri::Message.user("hi")])
+    seen = []
+    automatic.stream(messages: [Mistri::Message.user("hi")]) { |event| seen << event }
     standard.stream(messages: [Mistri::Message.user("hi")])
     automatic_body, standard_body = server.requests.map { |request| JSON.parse(request[:body]) }
 
     assert_equal "gpt-5.5", automatic_body["model"], "the public provider default stays stable"
     refute automatic_body.key?("service_tier"), "catalog pricing must not choose host policy"
     assert_equal "default", standard_body["service_tier"]
+    assert_equal :start, seen.first.type
+    assert_equal :openai, seen.first.partial.provider
   ensure
     automatic&.close
     standard&.close
@@ -267,12 +273,15 @@ class TestModels < Minitest::Test
     priority = Mistri::Providers::Gemini.new(api_key: "test", origin: server.origin,
                                              catalog_pricing: true, service_tier: "priority")
 
-    automatic.stream(messages: [Mistri::Message.user("hi")])
+    seen = []
+    automatic.stream(messages: [Mistri::Message.user("hi")]) { |event| seen << event }
     priority.stream(messages: [Mistri::Message.user("hi")])
     automatic_body, priority_body = server.requests.map { |request| JSON.parse(request[:body]) }
 
     refute automatic_body.key?("serviceTier"), "catalog pricing must not choose host policy"
     assert_equal "priority", priority_body["serviceTier"]
+    assert_equal :start, seen.first.type
+    assert_equal :gemini, seen.first.partial.provider
   ensure
     automatic&.close
     priority&.close

--- a/test/test_openai_assembler.rb
+++ b/test/test_openai_assembler.rb
@@ -3,7 +3,7 @@
 require "json"
 require_relative "test_helper"
 
-class TestOpenAIAssembler < Minitest::Test
+class TestOpenAIAssembler < Minitest::Test # rubocop:disable Metrics/ClassLength -- one wire fold
   def test_folds_reasoning_text_and_usage_with_replay_signatures
     events = []
     reasoning_item = { "type" => "reasoning", "id" => "rs_1",
@@ -99,6 +99,126 @@ class TestOpenAIAssembler < Minitest::Test
     assert_equal({ "q" => "ru" }, mid.arguments)
   end
 
+  def test_completed_tool_arguments_preserve_non_object_json
+    { "null" => nil, "false" => false, "7" => 7, '"text"' => "text",
+      '[1,{"x":true}]' => [1, { "x" => true }] }.each do |json, expected|
+      call = tool_call_item("arguments" => json).tool_calls.first
+
+      expected.nil? ? assert_nil(call.arguments) : assert_equal(expected, call.arguments)
+
+      assert_nil call.arguments_error
+    end
+  end
+
+  def test_malformed_completed_tool_arguments_are_not_salvaged_from_partials
+    events = []
+    item = { "type" => "function_call", "id" => "fc_bad", "call_id" => "call_bad",
+             "name" => "inspect", "arguments" => '{"query":"ruby"' }
+    message = drive(events, [
+                      { "type" => "response.output_item.added", "item" => item },
+                      { "type" => "response.function_call_arguments.delta",
+                        "delta" => '{"query":"ruby"' },
+                      { "type" => "response.output_item.done", "item" => item },
+                      { "type" => "response.completed",
+                        "response" => { "status" => "completed" } }
+                    ])
+    partial = events.find { |event| event.type == :toolcall_delta }.partial.tool_calls.first
+    call = message.tool_calls.first
+
+    assert_equal({ "query" => "ruby" }, partial.arguments,
+                 "the live preview may remain readable")
+    assert_nil call.arguments
+    assert_equal "invalid_json", call.arguments_error
+
+    non_string = tool_call_item("arguments" => nil).tool_calls.first
+    missing = tool_call_item.tool_calls.first
+
+    assert_nil non_string.arguments
+    assert_equal "invalid_json", non_string.arguments_error
+    assert_nil missing.arguments
+    assert_equal "invalid_json", missing.arguments_error
+  end
+
+  def test_completed_tool_arguments_are_bounded_during_strict_parsing
+    nested = nil
+    66.times { nested = [nested] }
+    encoded = JSON.generate(nested, max_nesting: false)
+
+    call = tool_call_item("arguments" => encoded).tool_calls.first
+
+    assert_nil call.arguments
+    assert_equal "too_deep", call.arguments_error
+  end
+
+  def test_completed_item_supersedes_a_fragmented_argument_overflow
+    assembler = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.5")
+    deltas = []
+    emit = ->(event) { deltas << event.delta if event.type == :toolcall_delta }
+    item = { "type" => "function_call", "id" => "fc_large", "call_id" => "call_large",
+             "name" => "inspect" }
+    assembler.feed({ "type" => "response.output_item.added", "item" => item }, &emit)
+    chunk = "x" * (tool_argument_limit / 2)
+    fragments = ['{"blob":"', chunk, chunk, "ignored-after-overflow"]
+    fragments.each do |fragment|
+      assembler.feed({ "type" => "response.function_call_arguments.delta",
+                       "delta" => fragment }, &emit)
+    end
+
+    builder = assembler.instance_variable_get(:@current)
+
+    assert_empty builder.json, "the retained bytes are released once the cap is crossed"
+    assert_equal fragments.map(&:bytesize), deltas.map(&:bytesize),
+                 "resource accounting must not hide raw stream deltas"
+    assert_equal fragments.first, deltas.first
+    assert_equal fragments.last, deltas.last
+
+    assembler.feed({ "type" => "response.output_item.done",
+                     "item" => item.merge("arguments" => '{"mode":"safe"}') }, &emit)
+    assembler.feed({ "type" => "response.completed",
+                     "response" => { "status" => "completed" } })
+    call = assembler.finish.tool_calls.first
+
+    assert_equal({ "mode" => "safe" }, call.arguments)
+    assert_nil call.arguments_error
+  end
+
+  def test_missing_completed_arguments_preserve_a_stream_overflow
+    assembler = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.5")
+    item = { "type" => "function_call", "id" => "fc_large", "call_id" => "call_large",
+             "name" => "inspect" }
+    assembler.feed({ "type" => "response.output_item.added", "item" => item })
+    chunk = "x" * (tool_argument_limit / 2)
+    assembler.feed({ "type" => "response.function_call_arguments.delta",
+                     "delta" => '{"blob":"' })
+    2.times do
+      assembler.feed({ "type" => "response.function_call_arguments.delta", "delta" => chunk })
+    end
+    assembler.feed({ "type" => "response.output_item.done", "item" => item })
+    assembler.feed({ "type" => "response.completed",
+                     "response" => { "status" => "completed" } })
+    call = assembler.finish.tool_calls.first
+
+    assert_nil call.arguments
+    assert_equal "too_large", call.arguments_error
+  end
+
+  def test_partial_argument_parsing_has_a_bounded_work_schedule
+    assembler = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.5")
+    assembler.feed({ "type" => "response.output_item.added",
+                     "item" => { "type" => "function_call" } })
+    previews = []
+    fragments = ['{"blob":"'] + Array.new(128) { "x" * 1024 }
+    fragments.each do |fragment|
+      assembler.feed({ "type" => "response.function_call_arguments.delta",
+                       "delta" => fragment })
+      previews << assembler.instance_variable_get(:@current).argument_preview
+    end
+    builder = assembler.instance_variable_get(:@current)
+
+    assert_operator previews.map(&:object_id).uniq.length, :<=, 21
+    assert_operator builder.preview_bytes, :<=, 64 * 1024
+  end
+
   def test_a_content_filter_cut_fails_fast_instead_of_reading_complete
     message = drive([], [
                       { "type" => "response.incomplete",
@@ -135,6 +255,30 @@ class TestOpenAIAssembler < Minitest::Test
     assert_match(/server exploded/, failed.error_message)
   end
 
+  def test_unknown_incomplete_reasons_never_read_as_a_clean_stop
+    policy = Mistri::RetryPolicy.new
+    [nil, "future_reason"].each do |reason|
+      details = reason && { "reason" => reason }
+      message = drive([], [
+                        { "type" => "response.output_item.added",
+                          "item" => { "type" => "message", "id" => "msg_partial" } },
+                        { "type" => "response.output_text.delta", "delta" => "partial" },
+                        { "type" => "response.output_item.done",
+                          "item" => { "type" => "message", "id" => "msg_partial",
+                                      "content" => [{ "type" => "output_text",
+                                                      "text" => "partial" }] } },
+                        { "type" => "response.incomplete",
+                          "response" => { "status" => "incomplete",
+                                          "incomplete_details" => details } }
+                      ])
+
+      assert_equal :error, message.stop_reason, reason.inspect
+      assert_equal "partial", message.text, reason.inspect
+      assert_equal "TruncatedStream", message.error["type"], reason.inspect
+      assert policy.retryable?(message.error), "#{reason.inspect} should be retryable"
+    end
+  end
+
   # A failed response is the provider's verdict, not a dropped stream: its
   # code decides retryability, and it must never read as TruncatedStream.
   def test_failed_responses_classify_by_their_error_code
@@ -165,6 +309,30 @@ class TestOpenAIAssembler < Minitest::Test
                                          "error" => { "code" => "invalid_prompt" } } }])
 
     assert_includes terse.error_message, "the response failed"
+  end
+
+  def test_top_level_stream_errors_classify_by_their_error_code
+    policy = Mistri::RetryPolicy.new
+    cases = {
+      "rate_limit_exceeded" => ["RateLimitError", true],
+      "server_error" => ["ServerError", true],
+      "vector_store_timeout" => ["ProviderError", true],
+      "invalid_prompt" => ["InvalidRequestError", false],
+      "image_content_policy_violation" => ["InvalidRequestError", false],
+      "future_transient_error" => ["InvalidRequestError", false]
+    }
+
+    cases.each do |code, (type, retryable)|
+      message = drive([], [{ "type" => "error", "code" => code, "message" => "no" }])
+
+      assert_equal type, message.error["type"], code
+      assert_equal retryable, policy.retryable?(message.error), code
+    end
+
+    unknown = drive([], [{ "type" => "error", "message" => "unknown transport failure" }])
+
+    assert_equal "ProviderError", unknown.error["type"]
+    assert policy.retryable?(unknown.error)
   end
 
   def test_usage_prices_from_the_catalog_and_unknown_models_stay_unknown
@@ -270,13 +438,71 @@ class TestOpenAIAssembler < Minitest::Test
   end
 
   def test_a_stream_that_ends_without_a_terminal_event_is_an_error
-    message = drive([], [{ "type" => "response.output_text.delta", "delta" => "cut off" }])
+    events = []
+    message = drive(events, [
+                      { "type" => "response.output_item.added",
+                        "item" => { "type" => "message", "id" => "msg_cut" } },
+                      { "type" => "response.output_text.delta", "delta" => "cut off" }
+                    ])
 
     assert_equal :error, message.stop_reason
     assert_match(/terminal event/, message.error_message)
+    assert_equal "cut off", message.text
+    assert_equal %i[text_start text_delta text_end error], events.map(&:type)
+  end
+
+  def test_an_incomplete_stream_never_promotes_partial_arguments_to_a_final_call
+    events = []
+    message = drive(events, [
+                      { "type" => "response.output_item.added",
+                        "item" => { "type" => "function_call", "id" => "fc_cut",
+                                    "call_id" => "call_cut", "name" => "inspect" } },
+                      { "type" => "response.function_call_arguments.delta",
+                        "delta" => '{"config":{"mode":"partial"' }
+                    ])
+    call = message.tool_calls.first
+    preview = events.find { |event| event.type == :toolcall_delta }.partial.tool_calls.first
+
+    assert_equal :error, message.stop_reason
+    assert_nil call.arguments
+    assert_equal "incomplete", call.arguments_error
+    assert_predicate preview.arguments["config"], :frozen?
+    assert_equal %i[toolcall_start toolcall_delta toolcall_end error], events.map(&:type)
+  end
+
+  def test_a_terminal_response_without_a_finished_function_call_is_an_error
+    events = []
+    message = drive(events, [
+                      { "type" => "response.output_item.added",
+                        "item" => { "type" => "function_call", "id" => "fc_cut",
+                                    "call_id" => "call_cut", "name" => "inspect" } },
+                      { "type" => "response.function_call_arguments.delta", "delta" => "{}" },
+                      { "type" => "response.completed",
+                        "response" => { "status" => "completed" } }
+                    ])
+    call = message.tool_calls.first
+
+    assert_equal :error, message.stop_reason
+    assert_match(/output_item.done/, message.error_message)
+    assert_equal "incomplete", call.arguments_error
+    assert_equal %i[toolcall_start toolcall_delta toolcall_end error], events.map(&:type)
   end
 
   private
+
+  def tool_argument_limit
+    Mistri.const_get(:ToolArguments, false)::MAX_BYTES
+  end
+
+  def tool_call_item(fields = {})
+    item = { "type" => "function_call", "id" => "fc_args", "call_id" => "call_args",
+             "name" => "inspect" }.merge(fields)
+    drive([], [
+            { "type" => "response.output_item.added", "item" => item },
+            { "type" => "response.output_item.done", "item" => item },
+            { "type" => "response.completed", "response" => { "status" => "completed" } }
+          ])
+  end
 
   def drive(events, records)
     assembler = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.5")
@@ -284,4 +510,4 @@ class TestOpenAIAssembler < Minitest::Test
     records.each { |record| assembler.feed(record, &emit) }
     assembler.finish(&emit)
   end
-end
+end # rubocop:enable Metrics/ClassLength

--- a/test/test_openai_refusal.rb
+++ b/test/test_openai_refusal.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestOpenAIRefusal < Minitest::Test
+  def test_a_structured_output_refusal_is_a_non_retryable_provider_verdict
+    events = []
+    item = refusal_item("I cannot help with that.")
+    message = drive(events, [
+                      { "type" => "response.output_item.added", "item" => item },
+                      { "type" => "response.refusal.delta", "delta" => "I cannot" },
+                      { "type" => "response.output_item.done", "item" => item },
+                      { "type" => "response.completed",
+                        "response" => { "status" => "completed" } }
+                    ])
+
+    assert_equal :error, message.stop_reason
+    assert_equal "InvalidRequestError", message.error.fetch("type")
+    assert_includes message.error_message, "I cannot help with that."
+    refute Mistri::RetryPolicy.new.retryable?(message.error)
+    assert_equal "I cannot", message.text
+    assert_equal %i[text_start text_delta text_end error], events.map(&:type)
+  end
+
+  def test_a_completed_refusal_without_a_terminal_response_still_fails_fast
+    item = refusal_item("No.")
+    message = drive([], [
+                      { "type" => "response.output_item.added", "item" => item },
+                      { "type" => "response.output_item.done", "item" => item }
+                    ])
+
+    assert_equal :error, message.stop_reason
+    assert_equal "InvalidRequestError", message.error.fetch("type")
+    refute Mistri::RetryPolicy.new.retryable?(message.error)
+    assert_includes message.error_message, "No."
+  end
+
+  def test_a_refusal_delta_is_a_verdict_even_when_the_stream_drops
+    events = []
+    item = refusal_item("ignored without done")
+    message = drive(events, [
+                      { "type" => "response.output_item.added", "item" => item },
+                      { "type" => "response.refusal.delta", "delta" => "Cannot comply." }
+                    ])
+
+    assert_equal "InvalidRequestError", message.error.fetch("type")
+    assert_equal "Cannot comply.", message.text
+    assert_equal %i[text_start text_delta text_end error], events.map(&:type)
+    refute Mistri::RetryPolicy.new.retryable?(message.error)
+  end
+
+  def test_refusal_details_are_bounded_and_encoding_safe
+    item = refusal_item(("\u{1F642}" * 1024) + ("x" * 4096))
+    message = drive([], [
+                      { "type" => "response.output_item.added", "item" => item },
+                      { "type" => "response.output_item.done", "item" => item },
+                      { "type" => "response.completed",
+                        "response" => { "status" => "completed" } }
+                    ])
+
+    assert_predicate message.error_message, :valid_encoding?
+    assert_operator message.error_message.bytesize, :<=, 2200
+  end
+
+  private
+
+  def refusal_item(text)
+    { "type" => "message", "id" => "msg_refusal",
+      "content" => [{ "type" => "refusal", "refusal" => text }] }
+  end
+
+  def drive(events, records)
+    assembler = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.6")
+    records.each { |record| assembler.feed(record) { |event| events << event } }
+    assembler.finish { |event| events << event }
+  end
+end

--- a/test/test_openai_serializer.rb
+++ b/test/test_openai_serializer.rb
@@ -26,7 +26,7 @@ class TestOpenAISerializer < Minitest::Test
       ],
       tool_calls: [Mistri::ToolCall.new(id: "call_1", name: "search",
                                         arguments: { "q" => "ruby" }, signature: "fc_1")],
-      stop_reason: :tool_use
+      provider: :openai, stop_reason: :tool_use
     )
     history = [Mistri::Message.user("go"), assistant,
                Mistri::Message.tool(content: "found it", tool_call_id: "call_1")]
@@ -51,6 +51,18 @@ class TestOpenAISerializer < Minitest::Test
                  item)
   end
 
+  def test_invalid_or_non_object_tool_arguments_replay_as_objects
+    invalid = Mistri::ToolCall.new(id: "bad", name: "inspect", arguments: nil,
+                                   arguments_error: "invalid_json", signature: "fc_bad")
+    scalar = Mistri::ToolCall.new(id: "scalar", name: "inspect", arguments: 7)
+
+    invalid_item = SERIALIZER.function_call_item(invalid)
+
+    assert_equal "{}", invalid_item[:arguments]
+    refute invalid_item.key?(:id), "a changed placeholder cannot retain the provider item ID"
+    assert_equal "7", SERIALIZER.function_call_item(scalar)[:arguments]
+  end
+
   def test_a_reasoning_item_missing_encrypted_content_is_dropped
     bare = { "type" => "reasoning", "id" => "rs_1", "summary" => [] }
     thinking = Mistri::Content::Thinking.new(thinking: "", signature: JSON.generate(bare))
@@ -64,6 +76,19 @@ class TestOpenAISerializer < Minitest::Test
     items = SERIALIZER.input_items([Mistri::Message.assistant(content: [anthropic_thinking])])
 
     assert_empty items
+  end
+
+  def test_foreign_pairing_signatures_never_reach_the_responses_wire
+    call = Mistri::ToolCall.new(id: "gemini-call", name: "search", arguments: {},
+                                signature: "gemini-signature")
+    message = Mistri::Message.assistant(
+      content: [Mistri::Content::Text.new(text: "Searching.", signature: "gemini-text"), call],
+      provider: :gemini
+    )
+
+    items = SERIALIZER.input_items([message])
+
+    refute(items.any? { |item| item.key?(:id) })
   end
 
   def test_images_ride_as_data_urls

--- a/test/test_provider_schema_capabilities.rb
+++ b/test/test_provider_schema_capabilities.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Task schemas use native constrained decoding only when a provider can carry
+# the same contract; prompt and local validation cover every fallback.
+class TestProviderSchemaCapabilities < Minitest::Test
+  PROVIDERS = {
+    openai: -> { Mistri::Providers::OpenAI.new(api_key: "test") },
+    anthropic: -> { Mistri::Providers::Anthropic.new(api_key: "test") },
+    gemini: -> { Mistri::Providers::Gemini.new(api_key: "test") }
+  }.freeze
+
+  def test_provider_native_schema_capability_matrix
+    object = {
+      type: "object", properties: { value: { type: "string" } }, required: ["value"]
+    }
+    scalar = { type: "string", enum: %w[low high] }
+    tuple = {
+      type: "array", prefixItems: [{ type: "string" }, { type: "integer" }], items: false
+    }
+    titled = { type: "string", title: "Day", format: "date" }
+    nullable = { type: %w[string null] }
+
+    assert_capabilities object, openai: true, anthropic: true, gemini: true
+    assert_capabilities scalar, openai: false, anthropic: true, gemini: true
+    assert_capabilities tuple, openai: false, anthropic: false, gemini: true
+    assert_capabilities titled, openai: false, anthropic: false, gemini: true
+    assert_capabilities nullable, openai: false, anthropic: false, gemini: false
+  end
+
+  def test_all_providers_accept_homogeneous_primitive_and_object_arrays
+    string_array = {
+      type: "object",
+      properties: { values: { type: "array", items: { type: "string" } } },
+      required: ["values"]
+    }
+    object_array = {
+      type: "object",
+      properties: {
+        values: {
+          type: "array",
+          items: {
+            type: "object", properties: { value: { type: "string" } }, required: ["value"]
+          }
+        }
+      },
+      required: ["values"]
+    }
+
+    assert_capabilities string_array, openai: true, anthropic: true, gemini: true
+    assert_capabilities object_array, openai: true, anthropic: true, gemini: true
+  end
+
+  def test_explicit_provider_complexity_limits_fall_back_locally
+    refute_nil native(:openai, nested_objects(10))
+    assert_nil native(:openai, nested_objects(11))
+
+    refute_nil raw_capability(:openai, wide_object(5000))
+    assert_nil raw_capability(:openai, wide_object(5001))
+
+    refute_nil native(:openai, enum_schema((1..1000).map(&:to_s)))
+    assert_nil native(:openai, enum_schema((1..1001).map(&:to_s)))
+
+    refute_nil native(:openai, enum_schema(enum_strings(251, 15_000)))
+    assert_nil native(:openai, enum_schema(enum_strings(251, 15_001)))
+
+    refute_nil native(:openai, named_property(120_000))
+    assert_nil native(:openai, named_property(120_001))
+
+    refute_nil native(:anthropic, optional_properties(24))
+    assert_nil native(:anthropic, optional_properties(25))
+  end
+
+  def test_unknown_models_keep_structured_output_validation_local
+    canonical = Mistri::Schema.task_plan(
+      { type: "object", properties: { value: { type: "string" } }, required: ["value"] }
+    ).schema
+    providers = [
+      Mistri::Providers::OpenAI.new(api_key: "test", model: "gpt-future"),
+      Mistri::Providers::Anthropic.new(api_key: "test", model: "claude-future"),
+      Mistri::Providers::Gemini.new(api_key: "test", model: "gemini-future")
+    ]
+
+    providers.each { |provider| assert_nil provider.native_output_schema(canonical) }
+  ensure
+    providers&.each(&:close)
+  end
+
+  def test_openai_falls_back_instead_of_making_optional_fields_required
+    optional = {
+      type: "object", properties: { note: { type: "string" } }, required: []
+    }
+
+    assert_capabilities optional, openai: false, anthropic: true, gemini: true
+  end
+
+  def test_gemini_keeps_boolean_tuple_members
+    schema = {
+      type: "array", prefixItems: [true, { type: "boolean" }], items: false
+    }
+
+    assert_capabilities schema, openai: false, anthropic: false, gemini: true
+  end
+
+  def test_gemini_uses_only_its_documented_type_specific_keywords
+    assert_capabilities({ type: "string", format: "date" },
+                        openai: false, anthropic: false, gemini: true)
+    assert_capabilities({ type: "string", format: "uuid" },
+                        openai: false, anthropic: false, gemini: false)
+    assert_capabilities({ type: "integer", format: "date" },
+                        openai: false, anthropic: false, gemini: false)
+    assert_capabilities({ type: "boolean", enum: [true, false] },
+                        openai: false, anthropic: true, gemini: false)
+  end
+
+  def test_gemini_enum_members_match_the_declared_json_type
+    assert_capabilities({ type: "string", enum: ["valid", 1] },
+                        openai: false, anthropic: true, gemini: false)
+    assert_capabilities({ type: "number", enum: [1, 2.5] },
+                        openai: false, anthropic: true, gemini: true)
+    assert_capabilities({ type: "integer", enum: [1, 2.0] },
+                        openai: false, anthropic: true, gemini: true)
+    assert_capabilities({ type: "integer", enum: [1, 2.5] },
+                        openai: false, anthropic: true, gemini: false)
+  end
+
+  def test_native_objects_require_only_declared_properties
+    schema = {
+      type: "object", properties: { known: { type: "string" } },
+      required: %w[known missing]
+    }
+
+    assert_capabilities schema, openai: false, anthropic: false, gemini: false
+  end
+
+  def test_nil_fallback_is_not_restricted_again_by_provider_request_builders
+    history = [Mistri::Message.user("hello")]
+    providers = {
+      openai: PROVIDERS.fetch(:openai).call,
+      anthropic: PROVIDERS.fetch(:anthropic).call,
+      gemini: PROVIDERS.fetch(:gemini).call
+    }
+
+    openai = providers[:openai].send(:build_body, "gpt-5.6", history, nil, [],
+                                     output_schema: nil)
+    anthropic = providers[:anthropic].send(
+      :build_body, "claude-haiku-4-5-20251001", history, nil, [], output_schema: nil
+    )
+    gemini = providers[:gemini].send(:build_body, history, nil, [], output_schema: nil)
+
+    refute openai.key?(:text)
+    refute anthropic.key?(:output_config)
+    refute gemini.fetch(:generationConfig).key?(:responseJsonSchema)
+  end
+
+  def test_gemini_with_tools_keeps_task_validation_local
+    provider = PROVIDERS.fetch(:gemini).call
+    plan = Mistri::Schema.task_plan(
+      { type: "object", properties: { answer: { type: "string" } }, required: ["answer"] }
+    )
+    schema = provider.native_output_schema(plan.schema)
+    tool = {
+      name: "lookup", description: "Looks up.",
+      input_schema: { "type" => "object", "properties" => {} }
+    }
+
+    body = provider.send(:build_body, [Mistri::Message.user("hello")], nil, [tool],
+                         output_schema: schema)
+
+    refute body.fetch(:generationConfig).key?(:responseJsonSchema)
+  end
+
+  private
+
+  def nested_objects(levels)
+    levels.times.reduce({ type: "string" }) do |child, _|
+      { type: "object", properties: { value: child }, required: ["value"] }
+    end
+  end
+
+  def wide_object(count)
+    properties = count.times.to_h { |index| ["p#{index}", { "type" => "string" }] }
+    { "type" => "object", "properties" => properties,
+      "required" => properties.keys, "additionalProperties" => false }
+  end
+
+  def enum_schema(values)
+    { type: "object", properties: { value: { type: "string", enum: values } },
+      required: ["value"] }
+  end
+
+  def enum_strings(count, total)
+    base, extra = total.divmod(count)
+    Array.new(count) do |index|
+      length = base + (index < extra ? 1 : 0)
+      prefix = index.to_s
+      "#{prefix}#{"x" * (length - prefix.length)}"
+    end
+  end
+
+  def named_property(length)
+    name = "x" * length
+    { type: "object", properties: { name => { type: "string" } }, required: [name] }
+  end
+
+  def optional_properties(count)
+    { type: "object",
+      properties: count.times.to_h { |index| ["field_#{index}", { type: "string" }] },
+      required: [] }
+  end
+
+  def raw_capability(name, schema)
+    capabilities = Mistri::Providers.const_get(:SchemaCapabilities, false)
+    capabilities.derive(schema, name)
+  end
+
+  def native(name, schema)
+    canonical = Mistri::Schema.task_plan(schema).schema
+    PROVIDERS.fetch(name).call.native_output_schema(canonical)
+  end
+
+  def assert_capabilities(schema, expectations)
+    canonical = Mistri::Schema.task_plan(schema).schema
+    expectations.each do |name, supported|
+      native = PROVIDERS.fetch(name).call.native_output_schema(canonical)
+      if supported
+        assert_same canonical, native, name
+        assert_predicate native, :frozen?, name
+      else
+        assert_nil native, name
+      end
+    end
+  end
+end

--- a/test/test_provider_stream_protocol.rb
+++ b/test/test_provider_stream_protocol.rb
@@ -1,0 +1,294 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Malformed provider block lifecycles fail before a streamed fragment can
+# become an executable tool call or an unmatched host event.
+class TestProviderStreamProtocol < Minitest::Test
+  class ScriptedProvider
+    def initialize(message)
+      @message = message
+    end
+
+    def model = "protocol-test"
+    def prices_usage? = true
+
+    def stream(**)
+      if block_given?
+        yield Mistri::Event.new(type: :error, reason: @message.stop_reason,
+                                message: @message, error_message: @message.error_message)
+      end
+      @message
+    end
+  end
+
+  def test_openai_output_item_lifecycle_is_correlated_before_commit
+    function = { "type" => "function_call", "id" => "fc_1",
+                 "call_id" => "call_1", "name" => "write", "arguments" => "{}" }
+    message = { "type" => "message", "id" => "msg_1", "content" => [] }
+    cases = {
+      overlapping_start: [added(function), added(message)],
+      done_without_start: [done(function)],
+      changed_kind: [added(message), done(function)],
+      changed_id: [added(function), done(function.merge("id" => "fc_2"))],
+      changed_output_index: [added(function, output_index: 0),
+                             done(function, output_index: 1)],
+      mismatched_delta: [added(function),
+                         { "type" => "response.output_text.delta",
+                           "delta" => "not arguments" }],
+      changed_delta_item: [added(function),
+                           { "type" => "response.function_call_arguments.delta",
+                             "item_id" => "fc_2", "delta" => "{}" }]
+    }
+
+    cases.each do |label, records|
+      events = []
+      result = drive_openai(events, [*records, openai_terminal])
+
+      assert_protocol_error(result, events, label)
+    end
+  end
+
+  def test_anthropic_content_block_lifecycle_is_correlated_before_commit
+    start = anthropic_start
+    cases = {
+      overlapping_start: [start, anthropic_start(index: 1)],
+      mismatched_delta_kind: [start, anthropic_delta(0, "text_delta", "text" => "wrong")],
+      mismatched_delta_index: [start, anthropic_delta(1, "input_json_delta",
+                                                      "partial_json" => "{}")],
+      mismatched_stop_index: [start, { "type" => "content_block_stop", "index" => 1 }],
+      content_after_message_delta: [
+        { "type" => "message_delta", "delta" => { "stop_reason" => "tool_use" },
+          "usage" => {} },
+        start
+      ]
+    }
+
+    cases.each do |label, records|
+      events = []
+      result = drive_anthropic(events, [*records, *anthropic_terminal])
+
+      assert_protocol_error(result, events, label)
+    end
+  end
+
+  def test_unknown_anthropic_blocks_keep_their_wire_position_without_becoming_content
+    events = []
+    records = [
+      { "type" => "content_block_start", "index" => 0,
+        "content_block" => { "type" => "future_server_block" } },
+      { "type" => "content_block_delta", "index" => 0,
+        "delta" => { "type" => "input_json_delta", "partial_json" => "{}" } },
+      { "type" => "content_block_stop", "index" => 0 },
+      { "type" => "content_block_start", "index" => 1,
+        "content_block" => { "type" => "text" } },
+      { "type" => "content_block_delta", "index" => 1,
+        "delta" => { "type" => "text_delta", "text" => "kept" } },
+      { "type" => "content_block_stop", "index" => 1 },
+      { "type" => "message_delta", "delta" => { "stop_reason" => "end_turn" }, "usage" => {} },
+      { "type" => "message_stop" }
+    ]
+
+    result = drive_anthropic(events, records)
+
+    assert_equal "kept", result.text
+    assert_equal %i[text_start text_delta text_end done], events.map(&:type)
+  end
+
+  def test_misindexed_anthropic_arguments_never_reach_policy_or_persistence
+    message = drive_anthropic([], [
+                                anthropic_start,
+                                anthropic_delta(1, "input_json_delta",
+                                                "partial_json" => '{"amount":999}'),
+                                { "type" => "content_block_stop", "index" => 1 },
+                                *anthropic_terminal
+                              ])
+    touched = []
+    tool = Mistri::Tool.define(
+      "write", "Writes once.",
+      needs_approval: ->(*) { touched << :policy },
+      schema: -> { integer :amount, "Amount", required: true }
+    ) { touched << :handler }
+    agent = Mistri::Agent.new(provider: ScriptedProvider.new(message), tools: [tool],
+                              retries: false)
+
+    result = agent.run("write")
+
+    assert_predicate result, :errored?
+    assert_empty touched
+    assert_empty agent.session.messages.flat_map(&:tool_calls)
+    assert_empty agent.session.messages.select(&:tool?)
+  end
+
+  def test_anthropic_rejects_nonempty_tool_input_before_policy
+    start = anthropic_start
+    start["content_block"]["input"] = { "risk" => true }
+    message = drive_anthropic([], [start, *anthropic_terminal])
+    touched = []
+    tool = Mistri::Tool.define(
+      "write", "Writes once.",
+      needs_approval: lambda { |args|
+        touched << [:policy, args]
+        args["risk"]
+      },
+      input_schema: { type: "object" }
+    ) { touched << :handler }
+    agent = Mistri::Agent.new(provider: ScriptedProvider.new(message), tools: [tool],
+                              retries: false)
+
+    result = agent.run("write")
+
+    assert_predicate result, :errored?
+    assert_empty touched
+    assert_empty agent.session.messages.flat_map(&:tool_calls)
+    assert_empty agent.session.messages.select(&:tool?)
+  end
+
+  def test_terminal_records_fence_later_tool_content_for_every_provider
+    messages = {
+      anthropic: drive_anthropic([], [
+                                   { "type" => "message_stop" },
+                                   anthropic_start,
+                                   anthropic_delta(0, "input_json_delta",
+                                                   "partial_json" => '{"amount":999}'),
+                                   { "type" => "content_block_stop", "index" => 0 }
+                                 ]),
+      openai: drive_openai([], [
+                             openai_terminal,
+                             added(openai_function),
+                             done(openai_function)
+                           ]),
+      gemini: drive_gemini([], [
+                             { "candidates" => [{ "finishReason" => "STOP" }] },
+                             { "candidates" => [{ "content" => { "parts" => [{
+                               "functionCall" => { "name" => "write",
+                                                   "args" => { "amount" => 999 } }
+                             }] } }] }
+                           ])
+    }
+
+    messages.each do |provider_name, message|
+      touched = []
+      tool = Mistri::Tool.define(
+        "write", "Writes once.", needs_approval: ->(*) { touched << :policy },
+                                 schema: -> { integer :amount, "Amount", required: true }
+      ) { touched << :handler }
+      agent = Mistri::Agent.new(provider: ScriptedProvider.new(message), tools: [tool],
+                                retries: false)
+
+      result = agent.run("write")
+
+      assert_predicate result, :errored?, provider_name
+      assert_empty touched, provider_name
+      assert_empty agent.session.messages.flat_map(&:tool_calls), provider_name
+      assert_empty agent.session.messages.select(&:tool?), provider_name
+    end
+  end
+
+  def test_terminal_semantics_cannot_authorize_a_tool_call
+    messages = {}
+    %w[response.failed response.incomplete].each do |type|
+      messages[type] = drive_openai([], [
+                                      added(openai_function),
+                                      done(openai_function),
+                                      { "type" => type,
+                                        "response" => { "status" => "completed" } }
+                                    ])
+    end
+    function = { "functionCall" => {
+      "name" => "write", "args" => { "amount" => 999 }
+    } }
+    future_stop = {
+      "candidates" => [{ "content" => { "parts" => [function] },
+                         "finishReason" => "FUTURE_SAFETY_BLOCK" }]
+    }
+    messages["gemini_future_reason"] = drive_gemini([], [future_stop])
+
+    messages.each do |label, message|
+      assert_equal :error, message.stop_reason, label
+      assert message.tool_calls.all?(&:arguments_error?), "#{label} kept a usable call"
+      assert_message_cannot_run(message, label)
+    end
+  end
+
+  private
+
+  def added(item, output_index: nil)
+    { "type" => "response.output_item.added", "item" => item,
+      "output_index" => output_index }.compact
+  end
+
+  def done(item, output_index: nil)
+    { "type" => "response.output_item.done", "item" => item,
+      "output_index" => output_index }.compact
+  end
+
+  def openai_terminal
+    { "type" => "response.completed", "response" => { "status" => "completed" } }
+  end
+
+  def openai_function
+    { "type" => "function_call", "id" => "fc_1", "call_id" => "call_1",
+      "name" => "write", "arguments" => '{"amount":999}' }
+  end
+
+  def anthropic_start(index: 0)
+    { "type" => "content_block_start", "index" => index,
+      "content_block" => { "type" => "tool_use", "id" => "toolu_1", "name" => "write" } }
+  end
+
+  def anthropic_delta(index, type, fields)
+    { "type" => "content_block_delta", "index" => index,
+      "delta" => { "type" => type }.merge(fields) }
+  end
+
+  def anthropic_terminal
+    [{ "type" => "message_delta", "delta" => { "stop_reason" => "tool_use" }, "usage" => {} },
+     { "type" => "message_stop" }]
+  end
+
+  def drive_openai(events, records)
+    assembler = Mistri::Providers::OpenAI::Assembler.new(model: "gpt-5.5")
+    records.each { |record| assembler.feed(record) { |event| events << event } }
+    assembler.finish { |event| events << event }
+  end
+
+  def drive_anthropic(events, records)
+    assembler = Mistri::Providers::Anthropic::Assembler.new(model: "claude-opus-4-8")
+    records.each { |record| assembler.feed(record) { |event| events << event } }
+    assembler.finish { |event| events << event }
+  end
+
+  def drive_gemini(events, records)
+    assembler = Mistri::Providers::Gemini::Assembler.new(model: "gemini-2.5-flash")
+    records.each { |record| assembler.feed(record) { |event| events << event } }
+    assembler.finish { |event| events << event }
+  end
+
+  def assert_protocol_error(result, events, label)
+    assert_equal :error, result.stop_reason, label
+    assert result.tool_calls.none? { |call| !call.arguments_error? },
+           "#{label} kept a usable call"
+    assert_equal events.count { |event| event.type.to_s.end_with?("_start") },
+                 events.count { |event| event.type.to_s.end_with?("_end") }, label
+    assert_equal :error, events.last.type, label
+    assert Mistri::RetryPolicy.new.retryable?(result.error), "#{label} did not retry"
+  end
+
+  def assert_message_cannot_run(message, label)
+    touched = []
+    tool = Mistri::Tool.define(
+      "write", "Writes once.", needs_approval: ->(*) { touched << :policy },
+                               schema: -> { integer :amount, "Amount", required: true }
+    ) { touched << :handler }
+    agent = Mistri::Agent.new(provider: ScriptedProvider.new(message), tools: [tool],
+                              retries: false)
+
+    result = agent.run("write")
+
+    assert_predicate result, :errored?, label
+    assert_empty touched, label
+    assert_empty agent.session.messages.flat_map(&:tool_calls), label
+    assert_empty agent.session.messages.select(&:tool?), label
+  end
+end

--- a/test/test_schema_contract.rb
+++ b/test/test_schema_contract.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Dialect and completeness rules keep public schema promises honest.
+class TestSchemaContract < Minitest::Test
+  def test_json_schema_2020_12_rejects_legacy_tuple_items
+    schema = { type: "array", items: [{ type: "string" }] }
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Schema.validate_definition!(schema)
+    end
+
+    assert_match(/JSON Schema 2020-12/, error.message)
+    assert_match(/prefixItems/, error.message)
+  end
+
+  def test_a_declared_schema_dialect_must_be_json_schema_twenty_twenty_twelve
+    schema = { "$schema" => "http://json-schema.org/draft-07/schema#", type: "object" }
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Schema.validate_definition!(schema)
+    end
+
+    assert_equal "$.$schema must declare JSON Schema 2020-12", error.message
+  end
+
+  def test_schema_byte_limit_covers_json_escaping_and_large_integers
+    escaped = { description: "\0" * (2 * 1024 * 1024) }
+    integer = { default: 1 << 28_000_000 }
+
+    [escaped, integer].each do |schema|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::Schema.validate_definition!(schema)
+      end
+      assert_match(/exceeds the schema byte limit/, error.message)
+    end
+  end
+
+  def test_unsupported_independent_keywords_remain_provider_guidance
+    schema = { type: "string", pattern: "^x", minimum: 0.5, format: "custom" }
+
+    assert_same schema, Mistri::Schema.validate_definition!(schema)
+    assert_empty Mistri::Schema.violations("value", schema)
+    assert_equal ["$.pattern", "$.minimum"].sort,
+                 Mistri::Schema.unsupported_assertions(schema).sort
+    assert_equal "custom", Mistri::Schema.strict(schema).fetch("format")
+  end
+
+  def test_default_dialect_annotations_do_not_claim_validation_semantics
+    schema = {
+      type: "string",
+      format: "email",
+      contentSchema: { type: "number", minimum: 1 }
+    }
+    plan = Mistri::Schema.task_plan(schema)
+
+    assert_empty Mistri::Schema.unsupported_assertions(schema)
+    assert_empty plan.violations("not-an-email")
+
+    tool_schema = {
+      type: "object",
+      properties: {
+        payload: {
+          type: "string",
+          contentSchema: {
+            type: "object", patternProperties: { "^x" => { type: "integer" } },
+            additionalProperties: false
+          }
+        }
+      }
+    }
+
+    Mistri::Schema.tool_validator(tool_schema)
+  end
+
+  def test_recognized_json_schema_keywords_validate_their_shapes
+    invalid = {
+      { description: 1 } => /description must be a string/,
+      { deprecated: "yes" } => /deprecated must be a boolean/,
+      { format: 1 } => /format must be a string/,
+      { minimum: "one" } => /minimum must be a number/,
+      { maxLength: -1 } => /maxLength must be a non-negative integer/,
+      { multipleOf: 0 } => /multipleOf must be a number greater than zero/,
+      { dependentRequired: [] } => /dependentRequired must be an object/,
+      { dependentRequired: { kind: %w[value value] } } =>
+        /dependentRequired.kind must be an array of unique strings/,
+      { "$ref" => 1 } => /\$ref must be a URI-reference string/,
+      { "$anchor" => "not/a-name" } => /\$anchor must be a valid plain-name anchor/,
+      { "$vocabulary" => [] } => /\$vocabulary must map URI strings to booleans/,
+      { examples: {} } => /examples must be an array/
+    }
+
+    invalid.each do |schema, message|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::Schema.validate_definition!(schema)
+      end
+      assert_match message, error.message
+    end
+  end
+
+  def test_schema_identifiers_reject_nonempty_fragments
+    Mistri::Schema.validate_definition!({ "$id" => "record#", type: "string" })
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Schema.validate_definition!({ "$id" => "record#member", type: "string" })
+    end
+
+    assert_equal "$.$id must not contain a non-empty fragment", error.message
+  end
+
+  def test_vocabulary_keys_are_absolute_normalized_uris
+    valid = { "$vocabulary" => { "https://example.test/vocab" => false }, type: "string" }
+    Mistri::Schema.validate_definition!(valid)
+
+    ["relative-vocab", "HTTPS://EXAMPLE.TEST/vocab"].each do |uri|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::Schema.validate_definition!({ "$vocabulary" => { uri => false } })
+      end
+
+      assert_equal "$.$vocabulary must use absolute normalized URI keys", error.message
+    end
+  end
+
+  def test_task_mode_rejects_a_required_vocabulary_it_cannot_implement
+    required = {
+      "$vocabulary" => { "https://example.test/vocab" => true }, type: "string"
+    }
+    optional = {
+      "$vocabulary" => { "https://example.test/vocab" => false }, type: "string"
+    }
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Schema.task_plan(required)
+    end
+
+    assert_match(/task output schema uses assertions Mistri cannot validate/, error.message)
+    Mistri::Schema.task_plan(optional)
+  end
+
+  def test_tool_schemas_require_an_object_root
+    [false, true, { type: "string" }, { type: %w[object null] }].each do |schema|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::Schema.tool_validator(schema)
+      end
+
+      assert_equal "$ must declare type object for tool arguments", error.message
+    end
+  end
+
+  def test_open_pattern_properties_also_require_complete_validation
+    schema = {
+      type: "object",
+      patternProperties: { "^x-" => { type: "integer" } }
+    }
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Tool.define("patterned", "Patterned.", input_schema: schema) { "ran" }
+    end
+
+    assert_match(/non-empty pattern properties require a complete argument validator/,
+                 error.message)
+    tool = Mistri::Tool.define(
+      "patterned",
+      "Patterned.",
+      input_schema: schema,
+      complete_argument_validator: ->(*) { [] }
+    ) { "ran" }
+
+    assert_empty tool.argument_violations("x-count" => "host validates this")
+  end
+
+  def test_task_plan_rejects_assertions_local_validation_cannot_enforce
+    schema = {
+      type: "object",
+      properties: { code: { type: "string", pattern: "\\A[a-z]+\\z" } }
+    }
+
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::Schema.task_plan(schema) }
+
+    assert_match(/task output schema uses assertions Mistri cannot validate/, error.message)
+    assert_match(/\$\.properties\.code\.pattern/, error.message)
+  end
+
+  def test_strict_compiles_before_walking_a_cyclic_schema
+    schema = { type: "object" }
+    schema[:properties] = { child: schema }
+
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::Schema.strict(schema) }
+
+    assert_match(/contains a cycle/, error.message)
+  end
+
+  def test_task_plan_owns_one_strict_schema_for_provider_and_local_validation
+    source = {
+      type: "object",
+      properties: { code: { type: "string" } },
+      required: ["code"]
+    }
+    plan = Mistri::Schema.task_plan(source)
+    source[:properties][:code][:type] = "integer"
+
+    assert_predicate plan.schema, :frozen?
+    assert_predicate plan.schema.fetch("properties").fetch("code"), :frozen?
+    assert_equal "string", plan.schema.dig("properties", "code", "type")
+    refute plan.schema.fetch("additionalProperties")
+    assert_empty plan.violations("code" => "ok")
+    assert_equal ["$.extra is not allowed"],
+                 plan.violations("code" => "ok", "extra" => true)
+  end
+end

--- a/test/test_schema_validate.rb
+++ b/test/test_schema_validate.rb
@@ -34,8 +34,9 @@ class TestSchemaValidate < Minitest::Test
 
     assert_includes errors, "$.name is required"
     assert_includes errors, "$.tiers[0].price is required"
-    assert_includes errors, "$.tiers[0].label must be one of: basic, pro"
+    assert_includes errors, "$.tiers[0].label must match enum"
     assert_includes errors, "$.count must be integer, got string"
+    refute(errors.any? { |message| message.include?("basic") || message.include?("enterprise") })
   end
 
   def test_type_arrays_allow_null
@@ -50,10 +51,99 @@ class TestSchemaValidate < Minitest::Test
     schema = { type: "object", properties: { "price" => { type: "number" } } }
 
     assert_empty Mistri::Schema.violations({ "price" => 3 }, schema)
+    assert_empty Mistri::Schema.violations(1.0, { type: "integer" })
     refute_empty Mistri::Schema.violations(
       { "count" => 3.5 },
       { type: "object", properties: { "count" => { type: "integer" } } }
     )
+  end
+
+  def test_type_failures_name_each_json_runtime_type
+    schema = { type: "string" }
+
+    assert_equal ["$ must be string, got object"], Mistri::Schema.violations({}, schema)
+    assert_equal ["$ must be string, got boolean"], Mistri::Schema.violations(true, schema)
+    assert_equal ["$ must be string, got null"], Mistri::Schema.violations(nil, schema)
+    assert_empty Mistri::Schema.violations(true, { type: "boolean" })
+    assert_empty Mistri::Schema.violations(false, { type: "boolean" })
+  end
+
+  def test_non_json_numerics_do_not_satisfy_number_types
+    schema = { type: "number" }
+
+    [Float::NAN, Float::INFINITY, Rational(3, 2)].each do |value|
+      assert_equal ["$ must be valid JSON"],
+                   Mistri::Schema.violations(value, schema)
+    end
+  end
+
+  def test_boolean_schemas_work_at_any_supported_location
+    schema = {
+      type: "object",
+      properties: { "anything" => true, "forbidden" => false,
+                    "tail" => { type: "array", items: false } }
+    }
+    value = { "anything" => { "nested" => [1, true, nil] },
+              "forbidden" => "secret", "tail" => [1] }
+
+    assert_equal ["$.forbidden is not allowed", "$.tail[0] is not allowed"],
+                 Mistri::Schema.violations(value, schema)
+    assert_empty Mistri::Schema.violations("anything", true)
+    assert_equal ["$ is not allowed"], Mistri::Schema.violations("anything", false)
+  end
+
+  def test_true_schema_still_rejects_non_json_ruby_values
+    invalid_utf8 = "\xFF".b
+
+    assert_equal ["$ must be valid JSON"], Mistri::Schema.violations(Object.new, true)
+    assert_empty Mistri::Schema.violations({ symbol: "key" }, true)
+    assert_equal ["$ must be valid JSON"], Mistri::Schema.violations(invalid_utf8, true)
+  end
+
+  def test_instance_and_schema_cycles_fail_closed
+    value = {}
+    value["self"] = value
+    schema = { type: "object" }
+    schema[:properties] = { "self" => schema }
+
+    assert_equal ["$ must be valid JSON"], Mistri::Schema.violations(value, true)
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Schema.validate_definition!(schema)
+    end
+    assert_match(/contains a cycle/, error.message)
+  end
+
+  def test_type_unions_are_nonempty_and_contain_only_known_types
+    empty = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Schema.validate_definition!({ type: [] })
+    end
+    unknown = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Schema.violations("x", { type: %w[string mystery] })
+    end
+
+    assert_equal "$.type must be a primitive or non-empty union", empty.message
+    assert_equal "$.type contains an unknown JSON type", unknown.message
+  end
+
+  def test_enum_uses_json_value_equality
+    schema = { enum: [{ "enabled" => true, "limits" => { "daily" => 1 } }] }
+    reordered = { "limits" => { "daily" => 1.0 }, "enabled" => true }
+
+    assert_empty Mistri::Schema.violations(reordered, schema)
+    assert_equal ["$ must match enum"], Mistri::Schema.violations(1, { enum: [true] })
+  end
+
+  def test_items_begin_after_prefix_items
+    schema = {
+      type: "array",
+      prefixItems: [{ type: "string" }, true],
+      items: { type: "string" }
+    }
+
+    assert_empty Mistri::Schema.violations(["head", nil, "tail"], schema)
+    assert_equal ["$[0] must be string, got integer",
+                  "$[3] must be string, got integer"],
+                 Mistri::Schema.violations([7, nil, "tail", 4], schema)
   end
 
   def test_additional_properties_false_rejects_strays
@@ -61,6 +151,195 @@ class TestSchemaValidate < Minitest::Test
                additionalProperties: false }
 
     assert_equal ["$.b is not allowed"], Mistri::Schema.violations({ "a" => "x", "b" => 1 }, schema)
+  end
+
+  def test_paths_escape_and_bound_hostile_property_names
+    hostile = "line\n\"quote"
+    errors = Mistri::Schema.violations({ hostile => 1 },
+                                       { type: "object", additionalProperties: false })
+    long_errors = Mistri::Schema.violations({ "x" * 65_536 => 1 },
+                                            { type: "object", additionalProperties: false })
+
+    assert_equal ["$[\"line\\n\\\"quote\"] is not allowed"], errors
+    refute_includes errors.first, "\n"
+    assert_operator long_errors.first.bytesize, :<=, 280
+  end
+
+  def test_violations_stop_at_the_public_error_limit
+    schema = { type: "object", required: (1..20).map { |index| "key#{index}" } }
+    errors = Mistri::Schema.violations({}, schema)
+
+    assert_equal 8, errors.length
+    assert_equal "$.key1 is required", errors.first
+    assert_equal "$ additional violations omitted", errors.last
+  end
+
+  def test_validation_bounds_values_even_without_nested_assertions
+    errors = Mistri::Schema.violations(Array.new(10_001), { type: "array" })
+
+    assert_equal 1, errors.length
+    assert_match(/validation limit exceeded/, errors.first)
+
+    arguments = Mistri.const_get(:ToolArguments, false)
+    huge_integer = 1 << ((arguments::MAX_NUMBER_BYTES + 1) * 4)
+
+    assert_equal ["$ validation limit exceeded"],
+                 Mistri::Schema.violations(huge_integer, { type: "integer" })
+  end
+
+  def test_general_validation_does_not_guess_pattern_semantics
+    schema = {
+      type: "object",
+      properties: { "declared" => { type: "string" } },
+      patternProperties: { "^x-" => { type: "integer" } },
+      additionalProperties: false
+    }
+
+    assert_same schema, Mistri::Schema.validate_definition!(schema)
+    assert_equal ["$.declared must be string, got integer"],
+                 Mistri::Schema.violations(
+                   { "declared" => 1, "x-valid" => 2, "unknown" => 3 },
+                   schema
+                 )
+  end
+
+  def test_empty_pattern_properties_do_not_weaken_a_closed_object
+    schema = { type: "object", patternProperties: {}, additionalProperties: false }
+
+    assert_same schema, Mistri::Schema.validate_definition!(schema)
+    assert_equal ["$.unknown is not allowed"],
+                 Mistri::Schema.violations({ "unknown" => 1 }, schema)
+  end
+
+  def test_closed_pattern_properties_validate_the_interaction_shape
+    schema = { type: "object", patternProperties: [], additionalProperties: false }
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Schema.validate_definition!(schema)
+    end
+
+    assert_equal "$.patternProperties must be an object", error.message
+  end
+
+  def test_schema_valued_additional_properties_are_portable
+    additional = { type: "object", additionalProperties: { type: "string" } }
+
+    assert_same additional, Mistri::Schema.validate_definition!(additional)
+    assert_empty Mistri::Schema.violations({ "raw" => "value" }, additional)
+    assert_equal ["$.raw must be string, got integer"],
+                 Mistri::Schema.violations({ "raw" => 1 }, additional)
+  end
+
+  def test_malformed_supported_keyword_shapes_fail_at_definition
+    schemas = [
+      { type: nil },
+      { type: %w[string string] },
+      { enum: "x" },
+      { enum: [Float::NAN] },
+      { enum: [Object.new] },
+      { properties: [] },
+      { properties: { a: true, "a" => true } },
+      { required: "x" },
+      { required: %w[x x] },
+      { items: "x" },
+      { items: {}, prefixItems: "x" },
+      { additionalProperties: nil },
+      { 1 => true },
+      { description: "\xFF".b }
+    ]
+
+    schemas.each do |schema|
+      assert_raises(Mistri::ConfigurationError, schema.inspect) do
+        Mistri::Schema.validate_definition!(schema)
+      end
+    end
+  end
+
+  def test_schema_document_keywords_validate_their_subschemas
+    schema = {
+      "$schema" => Mistri::Schema::DIALECT,
+      "$defs" => { identifier: { type: :string } },
+      definitions: { legacy: true },
+      dependentSchemas: { kind: { required: ["value"] } },
+      allOf: [true],
+      anyOf: [{ not: false }],
+      oneOf: [{ if: true, then: true, else: false }],
+      contains: { type: "integer" },
+      propertyNames: { type: "string" },
+      unevaluatedProperties: true,
+      unevaluatedItems: false,
+      contentSchema: { type: "string" },
+      default: 1.5
+    }
+
+    assert_same schema, Mistri::Schema.validate_definition!(schema)
+
+    invalid = {
+      { "$defs" => [] } => "$.$defs must be an object",
+      { allOf: [] } => "$.allOf must be a non-empty array of schemas",
+      { not: [] } => "$.not must be a schema object or boolean",
+      { allOf: [{ required: %w[x x] }] } =>
+        "$.allOf[0].required must be an array of unique strings"
+    }
+    invalid.each do |definition, message|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::Schema.validate_definition!(definition)
+      end
+      assert_equal message, error.message
+    end
+  end
+
+  def test_schema_definitions_are_resource_bounded
+    too_deep = true
+    65.times { too_deep = { not: too_deep } }
+
+    definitions = {
+      too_deep => /exceeds the schema depth limit/,
+      { "x-extension" => Array.new(10_001, true) } => /exceeds the schema size limit/,
+      { description: "x" * (9 * 1024 * 1024) } => /exceeds the schema byte limit/
+    }
+
+    definitions.each do |definition, message|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::Schema.validate_definition!(definition)
+      end
+      assert_match message, error.message
+    end
+  end
+
+  def test_empty_enum_is_valid_and_rejects_every_instance
+    schema = { enum: [] }
+
+    assert_same schema, Mistri::Schema.validate_definition!(schema)
+    assert_equal ["$ must match enum"], Mistri::Schema.violations(nil, schema)
+  end
+
+  def test_schema_snapshot_matches_json_string_encoding
+    utf8 = "é".encode(Encoding::UTF_8)
+    utf16 = "é".encode(Encoding::UTF_16LE)
+    schema = {
+      type: "object",
+      properties: { utf16 => { enum: [utf16] } },
+      required: [utf16]
+    }
+
+    assert_empty Mistri::Schema.violations({ utf8 => utf8 }, schema)
+    collision = { properties: { utf8 => true, utf16 => true } }
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::Schema.validate_definition!(collision)
+    end
+  end
+
+  def test_definition_limits_cover_ignored_extensions
+    cyclic = { type: "object" }
+    cyclic["x-extension"] = cyclic
+
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::Schema.validate_definition!(cyclic)
+    end
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::Schema.validate_definition!(type: "string", minimum: Object.new)
+    end
   end
 
   def test_the_root_type_is_checked_first
@@ -112,5 +391,25 @@ class TestSchemaValidate < Minitest::Test
     assert_equal({ "type" => "object", "properties" => {},
                    "additionalProperties" => false, "required" => [] },
                  Mistri::Schema.strict(schema))
+  end
+
+  def test_strict_preserves_boolean_schemas
+    assert Mistri::Schema.strict(true)
+    refute Mistri::Schema.strict(false)
+    assert_equal({ "type" => "object", "properties" => { "value" => false },
+                   "additionalProperties" => false, "required" => [] },
+                 Mistri::Schema.strict({ type: "object", properties: { value: false } }))
+  end
+
+  def test_strict_closes_objects_inside_tuple_prefixes
+    schema = {
+      type: "array",
+      prefixItems: [{ type: "object", properties: { name: { type: "string" } } }],
+      items: false
+    }
+    strict = Mistri::Schema.strict(schema)
+
+    assert_same false, strict["items"]
+    assert_same false, strict.dig("prefixItems", 0, "additionalProperties")
   end
 end

--- a/test/test_session_approval_audit.rb
+++ b/test/test_session_approval_audit.rb
@@ -1,0 +1,453 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestSessionApprovalAudit < Minitest::Test # rubocop:disable Metrics/ClassLength -- one log grammar
+  def test_an_approval_request_must_follow_its_assistant_tool_call
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = Mistri::ToolCall.new(id: "write-1", name: "write", arguments: {})
+    session.append("approval_request", "call" => call.to_h)
+
+    assert_rejected_history(session, /without a prior assistant tool call/)
+  end
+
+  def test_legacy_request_is_accepted_when_it_exactly_mirrors_the_assistant_call
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = Mistri::ToolCall.new(id: "write-1", name: "write", arguments: { "value" => 7 },
+                                signature: "signed", provider_call_id: "remote-1")
+    session.append_message(Mistri::Message.assistant(
+                             tool_calls: [call], stop_reason: Mistri::StopReason::TOOL_USE
+                           ))
+    session.append("approval_request", "call" => call.to_h)
+    session.append("approval_decision", "call_id" => call.id, "approved" => true)
+    ran = []
+    tool = Mistri::Tool.define("write", "Write once.",
+                               needs_approval: true,
+                               schema: lambda {
+                                 integer :value, "Value", required: true
+                               }) do |arguments|
+      ran << arguments
+      "written"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "done" }])
+
+    result = Mistri::Agent.new(provider:, tools: [tool], session:).resume
+
+    assert_predicate result, :completed?
+    assert_equal [{ "value" => 7 }], ran
+    assert_equal 1, provider.requests.length
+  end
+
+  def test_malformed_persisted_messages_fail_before_an_approved_call_can_run
+    cases = {
+      bad_stop_reason: lambda do |message|
+        message["stop_reason"] = "bogus"
+      end,
+      unknown_content_block: lambda do |message|
+        message["content"] << { "type" => "future_block", "value" => "opaque" }
+      end
+    }
+
+    cases.each do |label, corrupt|
+      session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+      call = Mistri::ToolCall.new(id: "write-1", name: "write", arguments: {})
+      assistant = Mistri::Message.assistant(
+        tool_calls: [call], stop_reason: Mistri::StopReason::TOOL_USE
+      )
+      message = JSON.parse(JSON.generate(assistant.to_h))
+      corrupt.call(message)
+      raw_append(session, "message", "message" => message)
+      session.append("approval_request", "call" => call.to_h)
+      session.append("approval_decision", "call_id" => call.id, "approved" => true)
+
+      assert_rejected_history(session, /invalid persisted message/, label)
+    end
+  end
+
+  def test_approval_decisions_require_an_exact_boolean
+    session = approval_session
+    session.append("approval_decision", "call_id" => "write-1", "approved" => "false")
+
+    assert_rejected_history(session, /approved value is not true or false/)
+  end
+
+  def test_approval_requests_require_a_tool_use_assistant_turn
+    [nil, Mistri::StopReason::STOP, Mistri::StopReason::ERROR,
+     Mistri::StopReason::ABORTED, Mistri::StopReason::LENGTH,
+     Mistri::StopReason::BUDGET].each do |reason|
+      session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+      call = Mistri::ToolCall.new(id: "write-1", name: "write", arguments: {})
+      session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: reason))
+      session.append("approval_request", "call" => call.to_h)
+      session.append("approval_decision", "call_id" => call.id, "approved" => true)
+
+      assert_rejected_history(session, /did not stop for tool use/, reason.inspect)
+    end
+  end
+
+  def test_normalized_approvals_require_a_structurally_usable_source_call
+    sources = {
+      malformed: Mistri::ToolCall.new(id: "write-1", name: "write", arguments: nil,
+                                      arguments_error: "invalid_json"),
+      scalar: Mistri::ToolCall.new(id: "write-1", name: "write", arguments: 7),
+      over_limit: Mistri::ToolCall.new(id: "write-1", name: "write",
+                                       arguments: Array.new(10_000))
+    }
+
+    sources.each do |label, source|
+      %i[marker legacy].each do |shape|
+        session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+        session.append_message(Mistri::Message.assistant(
+                                 tool_calls: [source], stop_reason: :tool_use
+                               ))
+        prepared = Mistri::ToolCall.new(id: source.id, name: source.name, arguments: {})
+        data = { "call" => prepared.to_h }
+        if shape == :marker
+          data["prepared_from"] = "assistant"
+        else
+          data["source_call"] = source.to_h
+        end
+        session.append("approval_request", data)
+        session.append("approval_decision", "call_id" => source.id, "approved" => true)
+
+        assert_rejected_history(session, /could not have been normalized/, [label, shape])
+      end
+    end
+  end
+
+  def test_approval_decisions_must_follow_a_matching_request
+    cases = {
+      orphan: lambda do |session|
+        session.append("approval_decision", "call_id" => "other", "approved" => true)
+      end,
+      before_request: lambda do |session|
+        call = append_assistant_call(session, "write-1")
+        session.append("approval_decision", "call_id" => call.id, "approved" => true)
+        session.append("approval_request", "call" => call.to_h)
+      end
+    }
+
+    cases.each do |label, build|
+      session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+      build.call(session)
+
+      assert_rejected_history(session, /without a prior matching approval request/, label)
+    end
+  end
+
+  def test_approval_decision_ids_must_be_valid
+    invalid_utf8 = "\xFF".b.force_encoding(Encoding::UTF_8)
+    [nil, 7, "", " \t", invalid_utf8].each do |id|
+      session = approval_session
+      raw_append(session, "approval_decision", "call_id" => id, "approved" => true)
+
+      assert_rejected_history(session, /approval decision call IDs/)
+    end
+  end
+
+  def test_an_approval_request_can_have_only_one_decision
+    session = approval_session
+    session.append("approval_decision", "call_id" => "write-1", "approved" => true)
+    session.append("approval_decision", "call_id" => "write-1", "approved" => false)
+
+    assert_rejected_history(session, /duplicate approval decision/)
+  end
+
+  def test_a_settled_tool_call_cannot_be_reopened_or_decided_again
+    request_then_answer = approval_session
+    request_then_answer.append("approval_decision", "call_id" => "write-1",
+                                                    "approved" => true)
+    append_tool_result(request_then_answer)
+    request_then_answer.append("approval_decision", "call_id" => "write-1",
+                                                    "approved" => true)
+
+    assert_rejected_history(request_then_answer, /already answered tool call/)
+
+    answer_then_request = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = append_assistant_call(answer_then_request, "write-1")
+    append_tool_result(answer_then_request)
+    answer_then_request.append("approval_request", "call" => call.to_h)
+
+    assert_rejected_history(answer_then_request, /already answered tool call/)
+  end
+
+  def test_tool_results_require_a_unique_prior_call_with_the_same_name
+    cases = {
+      before_call: lambda do |session|
+        append_tool_result(session)
+        append_assistant_call(session, "write-1")
+      end,
+      unknown_call: lambda do |session|
+        append_assistant_call(session, "write-1")
+        append_tool_result(session, id: "other")
+      end,
+      wrong_name: lambda do |session|
+        append_assistant_call(session, "write-1")
+        append_tool_result(session, name: "delete")
+      end,
+      duplicate: lambda do |session|
+        append_assistant_call(session, "write-1")
+        2.times { append_tool_result(session) }
+      end
+    }
+    messages = {
+      before_call: /without a prior assistant tool call/,
+      unknown_call: /without a prior assistant tool call/,
+      wrong_name: /name does not match/,
+      duplicate: /duplicate tool result/
+    }
+
+    cases.each do |label, build|
+      session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+      build.call(session)
+
+      assert_rejected_history(session, messages.fetch(label), label)
+    end
+  end
+
+  def test_persisted_provider_call_ids_are_unique_within_an_assistant_turn
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    calls = %w[first second].map do |id|
+      Mistri::ToolCall.new(id:, name: "write", arguments: {},
+                           provider_call_id: "wire-duplicate")
+    end
+    session.append_message(Mistri::Message.assistant(
+                             tool_calls: calls, provider: :gemini,
+                             stop_reason: Mistri::StopReason::TOOL_USE
+                           ))
+
+    assert_rejected_history(session, /duplicate provider tool call ID/)
+  end
+
+  def test_direct_tool_results_preserve_assistant_call_order
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    calls = append_assistant_calls(session, %w[first second])
+    append_tool_result(session, id: calls.last.id, name: calls.last.name)
+    append_tool_result(session, id: calls.first.id, name: calls.first.name)
+
+    assert_rejected_history(session, /tool results out of assistant call order/)
+  end
+
+  def test_approval_requests_preserve_assistant_call_order
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    calls = append_assistant_calls(session, %w[first second])
+    session.append("approval_request", "call" => calls.last.to_h)
+    session.append("approval_request", "call" => calls.first.to_h)
+
+    assert_rejected_history(session, /approval requests out of assistant call order/)
+  end
+
+  def test_approved_tool_results_preserve_assistant_call_order
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    calls = append_assistant_calls(session, %w[first second])
+    calls.each { |call| session.append("approval_request", "call" => call.to_h) }
+    calls.reverse_each do |call|
+      session.append("approval_decision", "call_id" => call.id, "approved" => true)
+      append_tool_result(session, id: call.id, name: call.name)
+    end
+
+    assert_rejected_history(session, /approval tool results out of assistant call order/)
+  end
+
+  def test_direct_results_cannot_arrive_after_approval_settlement_begins
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    calls = append_assistant_calls(session, %w[direct approved])
+    session.append("approval_request", "call" => calls.last.to_h)
+    session.append("approval_decision", "call_id" => calls.last.id, "approved" => true)
+    append_tool_result(session, id: calls.last.id, name: calls.last.name)
+    append_tool_result(session, id: calls.first.id, name: calls.first.name)
+
+    assert_rejected_history(session, /direct tool result after approval settlement began/)
+  end
+
+  def test_legacy_gemini_approval_cannot_resume_before_an_answered_same_name_sibling
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    calls = %w[risk safe].map do |suffix|
+      Mistri::ToolCall.new(id: "write-#{suffix}", name: "write", arguments: {})
+    end
+    session.append_message(Mistri::Message.assistant(
+                             tool_calls: calls, provider: :gemini,
+                             stop_reason: Mistri::StopReason::TOOL_USE
+                           ))
+    append_tool_result(session, id: calls.last.id, name: calls.last.name)
+    session.append("approval_request", "call" => calls.first.to_h)
+    session.append("approval_decision", "call_id" => calls.first.id, "approved" => true)
+
+    assert_rejected_history(session, /ambiguous Gemini approval/)
+  end
+
+  def test_tool_result_ids_and_names_must_be_nonblank_utf8_strings
+    invalid_utf8 = "\xFF".b.force_encoding(Encoding::UTF_8)
+    fields = {
+      id: [nil, 7, "", " \t", invalid_utf8],
+      name: [nil, 7, "", " \t", invalid_utf8]
+    }
+
+    fields.each do |field, values|
+      values.each do |value|
+        session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+        append_assistant_call(session, "write-1")
+        data = { "tool_call_id" => "write-1", "tool_name" => "write" }
+        data[field == :id ? "tool_call_id" : "tool_name"] = value
+        raw_tool_result(session, data)
+
+        assert_rejected_history(session, /tool result/, [field, value.inspect])
+      end
+    end
+  end
+
+  def test_a_parked_call_cannot_be_answered_before_its_decision
+    session = approval_session
+    append_tool_result(session)
+
+    assert_rejected_history(session, /approval without a prior decision/)
+  end
+
+  def test_a_later_conversation_closes_unparked_calls_and_cannot_pass_a_parked_call
+    stale = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = append_assistant_call(stale, "write-1")
+    stale.append_message(Mistri::Message.user("continue after the crash"))
+    stale.append("approval_request", "call" => call.to_h)
+
+    assert_rejected_history(stale, /stale approval request/)
+
+    parked = approval_session
+    parked.append_message(Mistri::Message.user("continue without settling"))
+
+    assert_rejected_history(parked, /continues past an unsettled approval/)
+  end
+
+  def test_a_result_cannot_arrive_after_the_call_was_crash_healed
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    append_assistant_call(session, "write-1")
+    session.append_message(Mistri::Message.user("continue after the crash"))
+    append_tool_result(session)
+
+    assert_rejected_history(session, /late tool result for a crash-healed call/)
+  end
+
+  def test_non_message_appenders_do_not_close_the_approval_window
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = append_assistant_call(session, "write-1")
+    session.append("steer", "id" => "s1", "message" => Mistri::Message.user("wait").to_h)
+    session.append("custom_audit", "value" => 1)
+    session.append("approval_request", "call" => call.to_h)
+
+    call_ids = session.open_approvals.map { |approval| approval[:call].id }
+
+    assert_equal ["write-1"], call_ids
+  end
+
+  def test_an_open_approval_must_retain_its_assistant_call_across_compaction
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    session.append_message(Mistri::Message.user("old"))
+    call = append_assistant_call(session, "write-1")
+    session.append("approval_request", "call" => call.to_h)
+    session.append("compaction", "summary" => "summary", "kept_from" => 2,
+                                 "tokens_before" => 1)
+
+    assert_rejected_history(session, /assistant tool call was removed by compaction/)
+  end
+
+  def test_compaction_cannot_split_a_completed_tool_exchange
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    session.append_message(Mistri::Message.user("old"))
+    append_assistant_call(session, "write-1")
+    append_tool_result(session)
+    session.append("compaction", "summary" => "summary", "kept_from" => 2,
+                                 "tokens_before" => 1)
+
+    assert_rejected_history(session, /splits a tool call from its result/)
+  end
+
+  def test_the_public_decision_api_rejects_a_second_decision_without_writing_it
+    session = approval_session
+    session.approve("write-1")
+    before = session.entries.length
+
+    error = assert_raises(Mistri::ConfigurationError) { session.deny("write-1") }
+
+    assert_match(/already been decided/, error.message)
+    assert_equal before, session.entries.length
+    assert session.open_approvals.first[:decision]["approved"]
+  end
+
+  def test_open_approval_decisions_do_not_alias_the_store
+    session = approval_session
+    session.deny("write-1", note: "no")
+    exposed = session.open_approvals.first[:decision]
+
+    exposed["approved"] = true
+    exposed["note"].replace("changed")
+
+    durable = session.open_approvals.first[:decision]
+
+    refute durable["approved"]
+    assert_equal "no", durable["note"]
+  end
+
+  private
+
+  def approval_session
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = append_assistant_call(session, "write-1")
+    session.append("approval_request", "call" => call.to_h)
+    session
+  end
+
+  def append_assistant_call(session, id)
+    call = Mistri::ToolCall.new(id:, name: "write", arguments: {})
+    session.append_message(Mistri::Message.assistant(
+                             tool_calls: [call], stop_reason: Mistri::StopReason::TOOL_USE
+                           ))
+    call
+  end
+
+  def append_assistant_calls(session, names)
+    calls = names.map do |name|
+      Mistri::ToolCall.new(id: "#{name}-1", name:, arguments: {})
+    end
+    session.append_message(Mistri::Message.assistant(
+                             tool_calls: calls, stop_reason: Mistri::StopReason::TOOL_USE
+                           ))
+    calls
+  end
+
+  def append_tool_result(session, id: "write-1", name: "write")
+    session.append_message(Mistri::Message.tool(
+                             content: "written", tool_call_id: id, tool_name: name
+                           ))
+  end
+
+  def raw_tool_result(session, data)
+    message = {
+      "role" => "tool",
+      "content" => [{ "type" => "text", "text" => "written" }]
+    }.merge(data)
+    raw_append(session, "message", "message" => message)
+  end
+
+  def assert_rejected_history(session, message, label = nil)
+    ran = false
+    tool = Mistri::Tool.define("write", "Write once.", needs_approval: true) do
+      ran = true
+      "written"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "must not run" }])
+    before = session.entries.length
+    context = label&.to_s || "approval history"
+
+    error = assert_raises(Mistri::ConfigurationError, context) do
+      Mistri::Agent.new(provider:, tools: [tool], session:).resume
+    end
+
+    assert_match message, error.message, context
+    refute ran, context
+    assert_empty provider.requests, context
+    assert_equal before, session.entries.length, context
+  end
+
+  def raw_append(session, type, data)
+    session.store.append(session.id, { "type" => type }.merge(data))
+  end
+end # rubocop:enable Metrics/ClassLength

--- a/test/test_session_approval_audit.rb
+++ b/test/test_session_approval_audit.rb
@@ -71,6 +71,52 @@ class TestSessionApprovalAudit < Minitest::Test # rubocop:disable Metrics/ClassL
     assert_rejected_history(session, /approved value is not true or false/)
   end
 
+  def test_history_entries_and_approval_calls_must_be_objects
+    non_object_entry = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    non_object_entry.store.append(non_object_entry.id, "not an entry")
+
+    non_object_call = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    append_assistant_call(non_object_call, "write-1")
+    raw_append(non_object_call, "approval_request", "call" => "not a call")
+
+    assert_rejected_history(non_object_entry, /entry that is not an object/)
+    assert_rejected_history(non_object_call, /invalid approval request/)
+  end
+
+  def test_approval_provenance_shapes_fail_closed
+    cases = {
+      invalid_marker: lambda do |call|
+        { "call" => call.to_h, "prepared_from" => "future" }
+      end,
+      invalid_source: lambda do |call|
+        { "call" => call.to_h, "source_call" => "not a call" }
+      end,
+      mismatched_prepared_call: lambda do |call|
+        prepared = call.to_h.merge("name" => "delete")
+        { "call" => prepared, "prepared_from" => "assistant" }
+      end
+    }
+
+    cases.each do |label, attributes|
+      session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+      append_assistant_call(session, "write-1")
+      durable_call = session.entries.last.dig("message", "content", 0)
+      raw_append(session, "approval_request", attributes.call(durable_call))
+
+      assert_rejected_history(session, /approval|prepared/, label)
+    end
+  end
+
+  def test_compaction_boundaries_must_be_nonnegative_integers
+    [-1, "1"].each do |kept_from|
+      session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+      session.append("compaction", "summary" => "summary", "kept_from" => kept_from,
+                                   "tokens_before" => 1)
+
+      assert_rejected_history(session, /invalid compaction boundary/, kept_from.inspect)
+    end
+  end
+
   def test_approval_requests_require_a_tool_use_assistant_turn
     [nil, Mistri::StopReason::STOP, Mistri::StopReason::ERROR,
      Mistri::StopReason::ABORTED, Mistri::StopReason::LENGTH,

--- a/test/test_session_healing.rb
+++ b/test/test_session_healing.rb
@@ -90,4 +90,25 @@ class TestSessionHealing < Minitest::Test
     assert_predicate result, :completed?
     assert_includes agent.session.messages.select(&:tool?).map(&:text), "sent"
   end
+
+  def test_approval_reconstruction_preserves_null_and_argument_errors
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    null = { "type" => "tool_call", "id" => "null", "name" => "inspect",
+             "arguments" => nil }
+    bad = { "type" => "tool_call", "id" => "bad", "name" => "inspect",
+            "arguments" => nil, "arguments_error" => "invalid_json" }
+    session.append("message", "message" => {
+                     "role" => "assistant", "content" => [null, bad],
+                     "stop_reason" => "tool_use"
+                   })
+    session.append("approval_request", "call" => null)
+    session.append("approval_request", "call" => bad)
+
+    calls = session.open_approvals.map { |entry| entry[:call] }
+
+    assert_nil calls.first.arguments
+    assert_nil calls.first.arguments_error
+    assert_nil calls.last.arguments
+    assert_equal "invalid_json", calls.last.arguments_error
+  end
 end

--- a/test/test_spawn_types.rb
+++ b/test/test_spawn_types.rb
@@ -57,7 +57,8 @@ class TestSpawnTypes < Minitest::Test
     assert_equal "Parent done.", result.text, "the parent reads the refusal and continues"
     tool_message = session.messages.select(&:tool?).last
 
-    assert_match(/needs instructions/, tool_message.text)
+    assert_includes tool_message.text, "$.instructions is required"
+    assert_predicate tool_message, :tool_error?
     assert_empty session.children, "no child is born from a refused spawn"
   end
 
@@ -71,8 +72,8 @@ class TestSpawnTypes < Minitest::Test
 
     tool_message = session.messages.select(&:tool?).last
 
-    assert_match(/Unknown worker type "designer"/, tool_message.text)
-    assert_match(/general-purpose, researcher/, tool_message.text)
+    assert_includes tool_message.text, "$.type must match enum"
+    assert_predicate tool_message, :tool_error?
   end
 
   def test_a_type_with_placeholders_fails_at_construction

--- a/test/test_sse.rb
+++ b/test/test_sse.rb
@@ -88,4 +88,34 @@ class TestSSE < Minitest::Test
       assert_equal "max_record_bytes: must be a positive integer", error.message
     end
   end
+
+  def test_rejects_a_structurally_wide_record_before_json_parsing
+    arguments = Mistri.const_get(:ToolArguments, false)
+    line = "data: [#{Array.new(20_002, "0").join(",")}]"
+    parse_called = false
+    trace = TracePoint.new(:call) do |event|
+      json_parse = event.defined_class == JSON.singleton_class && event.method_id == :parse
+      parse_called = true if json_parse
+    end
+
+    error = assert_raises(Mistri::ResponseTooComplexError) do
+      trace.enable { Mistri::SSE.new.feed("#{line}\n") { flunk } }
+    end
+
+    assert_equal :sse_record_tokens, error.kind
+    assert_equal arguments::MAX_LEXICAL_TOKENS, error.limit
+    refute parse_called
+  end
+
+  def test_rejects_an_oversized_numeric_token_before_json_parsing
+    arguments = Mistri.const_get(:ToolArguments, false)
+    number = "1" * (arguments::MAX_NUMBER_BYTES + 1)
+
+    error = assert_raises(Mistri::ResponseTooComplexError) do
+      Mistri::SSE.new.feed("data: {\"value\":#{number}}\n") { flunk }
+    end
+
+    assert_equal :sse_numeric_token, error.kind
+    assert_equal arguments::MAX_NUMBER_BYTES, error.limit
+  end
 end

--- a/test/test_sse.rb
+++ b/test/test_sse.rb
@@ -118,4 +118,25 @@ class TestSSE < Minitest::Test
     assert_equal :sse_numeric_token, error.kind
     assert_equal arguments::MAX_NUMBER_BYTES, error.limit
   end
+
+  def test_rejects_an_excessively_deep_record_before_json_parsing
+    arguments = Mistri.const_get(:ToolArguments, false)
+    depth = arguments::MAX_DEPTH + 2
+    opening = "[" * depth
+    closing = "]" * depth
+    record = "#{opening}0#{closing}"
+    parse_called = false
+    trace = TracePoint.new(:call) do |event|
+      json_parse = event.defined_class == JSON.singleton_class && event.method_id == :parse
+      parse_called = true if json_parse
+    end
+
+    error = assert_raises(Mistri::ResponseTooComplexError) do
+      trace.enable { Mistri::SSE.new.feed("data: #{record}\n") { flunk } }
+    end
+
+    assert_equal :sse_record_depth, error.kind
+    assert_equal arguments::MAX_DEPTH, error.limit
+    refute parse_called
+  end
 end

--- a/test/test_stores.rb
+++ b/test/test_stores.rb
@@ -51,6 +51,22 @@ class TestStores < Minitest::Test
     end
   end
 
+  def test_memory_owns_appends_and_returns_independent_deep_snapshots
+    store = Mistri::Stores::Memory.new
+    source = { "nested" => { "approved" => false }, "items" => ["first"] }
+    store.append("s", source)
+
+    source["nested"]["approved"] = true
+    source["items"] << "source mutation"
+    first = store.load("s")
+
+    first.first["nested"]["approved"] = true
+    first.first["items"] << "loaded mutation"
+
+    assert_equal [{ "nested" => { "approved" => false }, "items" => ["first"] }],
+                 store.load("s")
+  end
+
   private
 
   def each_store

--- a/test/test_sub_agent.rb
+++ b/test/test_sub_agent.rb
@@ -84,8 +84,7 @@ class TestSubAgent < Minitest::Test
 
     answer = agent.session.messages.select(&:tool?).last.text
 
-    assert_includes answer, 'unknown tool "nope"'
-    assert_includes answer, "lookup"
+    assert_includes answer, "$.tools[0] must match enum"
   end
 
   def test_parallel_fan_out_runs_both_children
@@ -120,7 +119,8 @@ class TestSubAgent < Minitest::Test
 
   def test_a_runtime_suspended_child_is_denied_and_reported
     risky = Mistri::Tool.define("pay", "Pays.",
-                                needs_approval: ->(args) { args["amount"].to_i > 10 }) { "paid" }
+                                needs_approval: ->(args) { args["amount"].to_i > 10 },
+                                schema: -> { integer :amount, "Amount", required: true }) { "paid" }
     child_fake = fake({ tool_calls: [{ name: "pay", arguments: { "amount" => 50 } }] })
     worker = Mistri::SubAgent.new(name: "worker", description: "Works.",
                                   provider: child_fake, tools: [risky])
@@ -174,7 +174,8 @@ class TestSubAgent < Minitest::Test
     agent.run("go")
 
     assert_equal '{"year":1912}', agent.session.messages.select(&:tool?).last.text
-    assert_equal schema, child_fake.requests.first[:options][:output_schema]
+    assert_equal Mistri::Schema.strict(schema),
+                 child_fake.requests.first[:options][:output_schema]
   end
 
   def test_an_errored_child_reports_in_band
@@ -206,13 +207,12 @@ class TestSubAgent < Minitest::Test
 
     answer = agent.session.messages.select(&:tool?).last.text
 
-    assert_includes answer, "not allowed"
-    assert_includes answer, "claude-haiku-4-5-20251001"
+    assert_includes answer, "$.model must match enum"
   end
 
   def test_without_an_allowlist_the_spawner_offers_no_model_choice
     spawn = Mistri::SubAgent.spawner(provider: fake)
-    properties = spawn.spec[:input_schema][:properties]
+    properties = spawn.spec[:input_schema]["properties"]
 
     refute properties.key?("model"), "no allowlist means no model surface at all"
   end
@@ -263,10 +263,10 @@ class TestSubAgent < Minitest::Test
 
   def test_the_model_surface_names_the_default_child_model
     spawn = Mistri::SubAgent.spawner(provider: fake, models: ["claude-haiku-4-5-20251001"])
-    properties = spawn.spec[:input_schema][:properties]
+    properties = spawn.spec[:input_schema]["properties"]
 
     assert properties.key?("name"), "the worker name surface exists"
-    assert_includes properties["model"][:description], "fake-1",
+    assert_includes properties["model"]["description"], "fake-1",
                     "the default model is named, so the choice is informed"
   end
 

--- a/test/test_tool.rb
+++ b/test/test_tool.rb
@@ -3,13 +3,197 @@
 require "json"
 require_relative "test_helper"
 
-class TestTool < Minitest::Test
-  def test_a_raw_json_schema_passes_straight_through
-    raw = { type: "object", properties: { x: { type: "string" } } }
+class TestTool < Minitest::Test # rubocop:disable Metrics/ClassLength -- one public tool contract
+  def test_argument_violations_report_numeric_resource_limits_honestly
+    arguments = Mistri.const_get(:ToolArguments, false)
+    huge_integer = 1 << ((arguments::MAX_NUMBER_BYTES + 1) * 4)
+    tool = Mistri::Tool.define("measure", "Measures.", schema: lambda {
+      integer :value, "Value", required: true
+    }) { "ok" }
+
+    assert_equal ["$ validation limit exceeded"],
+                 tool.argument_violations({ "value" => huge_integer })
+  end
+
+  def test_empty_schema_is_deeply_frozen
+    assert_predicate Mistri::Tool::EMPTY_SCHEMA, :frozen?
+    assert_predicate Mistri::Tool::EMPTY_SCHEMA.fetch(:properties), :frozen?
+    assert_predicate Mistri::Tool::EMPTY_SCHEMA.fetch(:required), :frozen?
+    refute Mistri::Tool::EMPTY_SCHEMA.fetch(:additionalProperties)
+  end
+
+  def test_a_raw_json_schema_becomes_provider_equivalent_json
+    raw = { type: :object, properties: { x: { type: :string } } }
     tool = Mistri::Tool.define("echo", "Echoes.", input_schema: raw) { |args| args["x"] }
 
-    assert_equal(raw, tool.spec[:input_schema])
+    assert_equal({ "type" => "object",
+                   "properties" => { "x" => { "type" => "string" } } },
+                 tool.spec[:input_schema])
     assert_equal "hi", tool.call({ "x" => "hi" })
+  end
+
+  def test_a_tool_owns_one_immutable_provider_and_validation_schema
+    raw = { type: "object", properties: { value: { type: "string" } } }
+    tool = Mistri::Tool.define("echo", "Echoes.", input_schema: raw) { "ok" }
+
+    raw[:properties][:value][:type] = "number"
+
+    assert_equal "string", tool.input_schema.dig("properties", "value", "type")
+    assert_predicate tool.input_schema, :frozen?
+    assert_predicate tool.input_schema.dig("properties", "value"), :frozen?
+    assert_empty tool.argument_violations("value" => "text")
+  end
+
+  def test_raw_and_built_schemas_are_mutually_exclusive
+    error = assert_raises(ArgumentError) do
+      Mistri::Tool.define(
+        "ambiguous", "Ambiguous.", input_schema: { type: "object" }, schema: -> {}
+      ) { "ran" }
+    end
+
+    assert_equal "choose input_schema or schema, not both", error.message
+  end
+
+  def test_false_input_schema_never_becomes_an_open_default
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Tool.define("never", "Accepts nothing.", input_schema: false) { "ran" }
+    end
+
+    assert_equal "$ must declare type object for tool arguments", error.message
+  end
+
+  def test_complete_validation_authority_is_explicit
+    schema = {
+      type: "object",
+      patternProperties: { "^x-" => { type: "integer" } },
+      additionalProperties: false
+    }
+    supplemental = ->(*) { [] }
+
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::Tool.define("plain", "Plain.", input_schema: schema) { "ran" }
+    end
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::Tool.define(
+        "supplemental", "Supplemental.", input_schema: schema,
+                                         argument_validator: supplemental
+      ) { "ran" }
+    end
+
+    checked = []
+    tool = Mistri::Tool.define(
+      "complete", "Complete.",
+      input_schema: schema,
+      complete_argument_validator: lambda { |arguments, owned_schema|
+        checked << [arguments, owned_schema]
+        arguments.key?("x-count") ? [] : ["$.x-count is required by the host validator"]
+      }
+    ) { "ran" }
+
+    assert_empty tool.argument_violations("x-count" => 1)
+    assert_equal ["$.x-count is required by the host validator"], tool.argument_violations({})
+    assert_same tool.input_schema, checked.first.last
+  end
+
+  def test_public_argument_validation_gives_custom_rules_the_owned_core_value
+    observed = nil
+    tool = Mistri::Tool.define(
+      "inspect", "Inspects.",
+      input_schema: {
+        type: "object", properties: { value: { type: "integer" } },
+        required: ["value"], additionalProperties: false
+      },
+      argument_validator: lambda { |arguments, _schema|
+        observed = arguments
+        []
+      }
+    ) { "done" }
+
+    assert_empty tool.argument_violations(value: 1)
+    assert_equal({ "value" => 1 }, observed)
+    assert_predicate observed, :frozen?
+    assert_raises(FrozenError) { observed["value"] = 2 }
+  end
+
+  def test_tuple_items_use_json_schema_2020_12_prefix_items
+    legacy = {
+      type: "object",
+      properties: {
+        "pair" => { type: "array", items: [{ type: "string" }, { type: "integer" }] }
+      },
+      required: ["pair"]
+    }
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Tool.define("legacy_tuple", "Legacy tuple.", input_schema: legacy) { "ran" }
+    end
+    assert_equal "$.properties.pair.items must be a schema in JSON Schema 2020-12; " \
+                 "use prefixItems for tuples",
+                 error.message
+
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::Tool.define(
+        "legacy_complete", "Legacy tuple.",
+        input_schema: legacy, complete_argument_validator: ->(*) { [] }
+      ) { "ran" }
+    end
+
+    schema = {
+      type: "object",
+      properties: {
+        "pair" => {
+          type: "array", prefixItems: [{ type: "string" }, { type: "integer" }], items: false
+        }
+      },
+      required: ["pair"]
+    }
+    tool = Mistri::Tool.define("tuple", "Tuple.", input_schema: schema) { "ran" }
+
+    assert_empty tool.argument_violations("pair" => ["sku", 2])
+    assert_includes tool.argument_violations("pair" => [2, "sku"]),
+                    "$.pair[0] must be string, got integer"
+    assert_includes tool.argument_violations("pair" => ["sku", 2, true]),
+                    "$.pair[2] is not allowed"
+  end
+
+  def test_supplemental_and_complete_validators_are_mutually_exclusive
+    error = assert_raises(ArgumentError) do
+      Mistri::Tool.define(
+        "ambiguous", "Ambiguous.",
+        argument_validator: ->(*) { [] },
+        complete_argument_validator: ->(*) { [] }
+      ) do
+        "ran"
+      end
+    end
+
+    assert_match(/choose argument_validator or complete_argument_validator/, error.message)
+  end
+
+  def test_argument_hooks_must_be_callable
+    %i[argument_normalizer argument_validator complete_argument_validator].each do |option|
+      error = assert_raises(ArgumentError) do
+        Mistri::Tool.define("invalid_#{option}", "Invalid hook.", option => true) { "ran" }
+      end
+
+      assert_equal "#{option} must be callable", error.message
+    end
+  end
+
+  def test_custom_argument_validators_must_return_arrays_of_strings
+    validators = {
+      argument_validator: ->(*) {},
+      complete_argument_validator: ->(*) { [1] }
+    }
+
+    validators.each do |option, validator|
+      tool = Mistri::Tool.define("invalid_#{option}", "Invalid validator.",
+                                 option => validator) { "ran" }
+
+      error = assert_raises(TypeError) { tool.argument_violations({}) }
+
+      assert_equal "#{option} must return an Array of Strings", error.message
+    end
   end
 
   def test_the_schema_block_builds_provider_ready_json_schema
@@ -17,14 +201,18 @@ class TestTool < Minitest::Test
       string :city, "City name", required: true
       string :units, "Units", enum: %w[celsius fahrenheit]
       integer :days, "Forecast length"
+      array :alerts, "Alert codes", items: { type: "string" }, required: true, minItems: 1
     }) { |args| args["city"] }
 
     schema = tool.spec[:input_schema]
 
-    assert_equal "object", schema[:type]
-    assert_equal %w[city units days], schema[:properties].keys
-    assert_equal %w[celsius fahrenheit], schema[:properties]["units"][:enum]
-    assert_equal ["city"], schema[:required]
+    assert_equal "object", schema["type"]
+    assert_equal %w[city units days alerts], schema["properties"].keys
+    assert_equal %w[celsius fahrenheit], schema["properties"]["units"]["enum"]
+    assert_equal({ "type" => "array", "items" => { "type" => "string" },
+                   "description" => "Alert codes", "minItems" => 1 },
+                 schema["properties"]["alerts"])
+    assert_equal %w[city alerts], schema["required"]
   end
 
   def test_a_blockless_nested_object_is_freeform
@@ -34,12 +222,12 @@ class TestTool < Minitest::Test
     }) { |args| args["config"] }
 
     schema = tool.spec[:input_schema]
-    config = schema[:properties]["config"]
+    config = schema["properties"]["config"]
 
-    assert_equal({ type: "object", properties: {},
-                   description: "Provider-neutral chart configuration" }, config)
-    assert_equal ["config"], schema[:required]
-    assert_equal "string", schema.dig(:properties, "title", :type)
+    assert_equal({ "type" => "object", "properties" => {},
+                   "description" => "Provider-neutral chart configuration" }, config)
+    assert_equal ["config"], schema["required"]
+    assert_equal "string", schema.dig("properties", "title", "type")
     assert_empty Mistri::Schema.violations(
       { "config" => { "series" => [{ "type" => "bar", "data" => [1, 2] }] } },
       schema
@@ -58,15 +246,15 @@ class TestTool < Minitest::Test
 
     assert_equal(
       {
-        type: "object",
-        properties: {
-          "city" => { type: "string", description: "City name" },
-          "country" => { type: "string", description: "Country code" }
+        "type" => "object",
+        "properties" => {
+          "city" => { "type" => "string", "description" => "City name" },
+          "country" => { "type" => "string", "description" => "Country code" }
         },
-        required: ["city"],
-        description: "Place to locate"
+        "required" => ["city"],
+        "description" => "Place to locate"
       },
-      tool.spec[:input_schema][:properties]["location"]
+      tool.spec[:input_schema]["properties"]["location"]
     )
   end
 
@@ -83,12 +271,14 @@ class TestTool < Minitest::Test
   def test_results_serialize_by_type
     string_tool = Mistri::Tool.define("s", "d") { "text" }
     hash_tool = Mistri::Tool.define("h", "d") { { ok: true } }
+    nil_tool = Mistri::Tool.define("n", "d") { nil }
     image_tool = Mistri::Tool.define("i", "d") do
       Mistri::Content::Image.from_bytes("png!", mime_type: "image/png")
     end
 
     assert_equal "text", string_tool.call({})
     assert_equal({ "ok" => true }, JSON.parse(hash_tool.call({})))
+    assert_equal "", nil_tool.call({})
     assert_instance_of Mistri::Content::Image, image_tool.call({})
   end
 
@@ -113,7 +303,8 @@ class TestTool < Minitest::Test
   def test_a_no_argument_tool_gets_a_valid_object_schema
     tool = Mistri::Tool.define("now", "Current time.") { Time.now.to_s }
 
-    assert_equal({ type: "object", properties: {} }, tool.spec[:input_schema])
+    assert_equal({ "type" => "object", "properties" => {}, "required" => [],
+                   "additionalProperties" => false }, tool.spec[:input_schema])
   end
 
   def test_eager_streaming_shows_up_in_the_spec
@@ -214,4 +405,4 @@ class TestTool < Minitest::Test
     assert_operator durations.first, :>=, 0.0
     assert_kind_of Float, durations.first
   end
-end
+end # rubocop:enable Metrics/ClassLength

--- a/test/test_tool_abort_boundaries.rb
+++ b/test/test_tool_abort_boundaries.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestToolAbortBoundaries < Minitest::Test
+  def test_a_normalizer_abort_stops_before_the_validator
+    signal = Mistri::AbortSignal.new
+    phases = []
+    tool = Mistri::Tool.define(
+      "write", "Writes.",
+      argument_normalizer: lambda { |arguments|
+        phases << :normalizer
+        signal.abort!(:test)
+        arguments
+      },
+      argument_validator: lambda { |*|
+        phases << :validator
+        []
+      }
+    ) { flunk "handler ran" }
+    provider = two_call_fake("write", "write")
+    agent = Mistri::Agent.new(provider:, tools: [tool])
+
+    result = agent.run("go", signal:)
+
+    assert_predicate result, :aborted?
+    assert_equal [:normalizer], phases
+  end
+
+  def test_after_tool_skips_a_queued_call_that_never_committed
+    signal = Mistri::AbortSignal.new
+    rewritten = []
+    first = Mistri::Tool.define("first", "First.") do
+      signal.abort!(:test)
+      "done"
+    end
+    second = Mistri::Tool.define("second", "Second.") { flunk "queued handler ran" }
+    provider = two_call_fake("first", "second")
+    agent = Mistri::Agent.new(
+      provider:, tools: [first, second], max_concurrency: 1,
+      after_tool: lambda { |call, result, _context|
+        rewritten << call.name
+        result
+      }
+    )
+
+    result = agent.run("go", signal:)
+
+    assert_predicate result, :aborted?
+    assert_equal ["first"], rewritten
+    assert_equal ["done", Mistri::ToolExecutor::INTERRUPTED],
+                 agent.session.messages.select(&:tool?).map(&:text)
+  end
+
+  private
+
+  def two_call_fake(*names)
+    calls = names.map { |name| { name:, arguments: {} } }
+    Mistri::Providers::Fake.new(turns: [{ tool_calls: calls }])
+  end
+end

--- a/test/test_tool_argument_validation.rb
+++ b/test/test_tool_argument_validation.rb
@@ -1,0 +1,471 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Tool argument validation is the trust boundary before host policy and side
+# effects. Invalid calls answer the model in band while valid siblings proceed.
+class TestToolArgumentValidation < Minitest::Test
+  def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
+
+  def test_invalid_arguments_cannot_bypass_approval_or_reach_any_execution_hook
+    touched = []
+    approval = lambda do |args|
+      touched << :approval
+      args["total_usd"].to_i > 500
+    end
+    schema = -> { number :total_usd, "Order total", required: true }
+    tool = Mistri::Tool.define(
+      "purchase", "Purchase an order.", ends_turn: true,
+                                        needs_approval: approval, schema:
+    ) do
+      touched << :handler
+      "purchased"
+    end
+    provider = fake(
+      { tool_calls: [{ name: "purchase", arguments: { "total_usd" => "all" } }] },
+      { text: "I need to correct the amount." }
+    )
+    events = []
+    agent = Mistri::Agent.new(
+      provider:, tools: [tool],
+      before_tool: ->(*) { touched << :before },
+      after_tool: ->(*) { touched << :after }
+    )
+
+    result = agent.run("buy everything") { |event| events << event }
+
+    assert_predicate result, :completed?
+    refute_predicate result, :handed_off?
+    assert_empty touched
+    assert_empty agent.session.open_approvals
+    refute(events.any? { |event| event.type == :tool_started })
+    answer = agent.session.messages.find(&:tool?)
+
+    assert_predicate answer, :tool_error?
+    assert_includes answer.text, "must be number"
+  end
+
+  def test_a_schema_less_tool_rejects_undeclared_model_arguments
+    touched = []
+    tool = Mistri::Tool.define("ping", "Takes no arguments.", needs_approval: lambda { |*|
+      touched << :approval
+      false
+    }) do
+      touched << :handler
+      "pong"
+    end
+    provider = fake(
+      { tool_calls: [{ name: "ping", arguments: { "surprise" => 1 } }] },
+      { text: "corrected" }
+    )
+    agent = Mistri::Agent.new(provider:, tools: [tool])
+
+    result = agent.run("ping")
+
+    assert_predicate result, :completed?
+    assert_empty touched
+    answer = agent.session.messages.find(&:tool?)
+
+    assert_predicate answer, :tool_error?
+    assert_includes answer.text, "$.surprise is not allowed"
+  end
+
+  def test_programmatic_numeric_overflow_never_reaches_policy_or_the_handler
+    arguments = Mistri.const_get(:ToolArguments, false)
+    huge_integer = 1 << ((arguments::MAX_NUMBER_BYTES + 1) * 4)
+    touched = []
+    tool = Mistri::Tool.define(
+      "purchase", "Purchases.", needs_approval: ->(*) { touched << :policy },
+                                schema: -> { integer :amount, "Amount", required: true }
+    ) { touched << :handler }
+    provider = fake(
+      { tool_calls: [{ name: "purchase", arguments: { "amount" => huge_integer } }] },
+      { text: "arguments were rejected" }
+    )
+
+    agent = Mistri::Agent.new(provider:, tools: [tool])
+    result = agent.run("buy")
+
+    assert_predicate result, :completed?
+    assert_empty touched
+    answer = agent.session.messages.find(&:tool?)
+
+    assert_predicate answer, :tool_error?
+    assert_includes answer.text, "arguments were not valid bounded JSON"
+  end
+
+  def test_normalization_runs_once_before_approval_and_owns_its_result
+    normalized = 0
+    observations = []
+    normalizer = lambda do |args|
+      normalized += 1
+      observations << [args.frozen?, args["meta"].frozen?]
+      { "recipient" => args.fetch("to"), "meta" => args.fetch("meta") }
+    end
+    schema = lambda do
+      string :recipient, "Recipient", required: true
+      object :meta, "Metadata", required: true do
+        string :source, "Source", required: true
+      end
+    end
+    tool = Mistri::Tool.define(
+      "send", "Send a message.", needs_approval: true,
+                                 argument_normalizer: normalizer, schema:
+    ) do |args|
+      observations << [args.frozen?, args["meta"].frozen?]
+      "sent to #{args.fetch("recipient")}"
+    end
+    provider = fake(
+      { tool_calls: [{ name: "send",
+                       arguments: { "to" => "Ana", "meta" => { "source" => "model" } } }] },
+      { text: "done" }
+    )
+    agent = Mistri::Agent.new(provider:, tools: [tool])
+
+    pending = agent.run("send it").pending.first
+
+    assert_equal({ "recipient" => "Ana", "meta" => { "source" => "model" } },
+                 pending.arguments)
+    agent.session.approve(pending.id)
+    agent.resume
+
+    assert_equal 1, normalized
+    assert_equal [[true, true], [true, true]], observations
+  end
+
+  def test_resumed_approvals_use_current_tools_and_schemas_without_renormalizing
+    store = Mistri::Stores::Memory.new
+    session = Mistri::Session.new(store:)
+    normalizations = 0
+    normalizer = lambda do |args|
+      normalizations += 1
+      args
+    end
+    old_tools = [
+      Mistri::Tool.define(
+        "changed", "Changed later.", needs_approval: true,
+                                     argument_normalizer: normalizer,
+                                     schema: -> { string :amount, "Amount", required: true }
+      ) { "old" },
+      Mistri::Tool.define("removed", "Removed later.", needs_approval: true) { "old" }
+    ]
+    first = Mistri::Agent.new(
+      provider: fake({ tool_calls: [
+                       { id: "changed-1", name: "changed",
+                         arguments: { "amount" => "ten" } },
+                       { id: "removed-1", name: "removed", arguments: {} }
+                     ] }),
+      tools: old_tools, session:
+    )
+    pending = first.run("go").pending
+
+    assert_equal %w[changed-1 removed-1], pending.map(&:id)
+    pending.each { |call| session.approve(call.id) }
+
+    reject_normalization = ->(*) { flunk "a parked call was normalized twice" }
+    replacement = Mistri::Tool.define(
+      "changed", "Now requires a number.", needs_approval: true,
+                                           argument_normalizer: reject_normalization,
+                                           schema: -> { number :amount, "Amount", required: true }
+    ) { flunk "an invalid approved call executed" }
+    resumed = Mistri::Agent.new(
+      provider: fake({ text: "Please submit corrected calls." }), tools: [replacement],
+      session: Mistri::Session.new(store:, id: session.id)
+    )
+
+    result = resumed.resume
+
+    assert_predicate result, :completed?
+    assert_equal 1, normalizations
+    answers = resumed.session.messages.select(&:tool?)
+
+    assert_equal %w[changed removed], answers.map(&:tool_name)
+    assert answers.all?(&:tool_error?)
+    assert_includes answers.first.text, "must be number"
+    assert_includes answers.last.text, "Unknown tool"
+  end
+
+  def test_mixed_valid_and_invalid_calls_keep_model_order
+    ran = []
+    schema = -> { integer :count, "Count", required: true }
+    copy_arguments = lambda(&:merge)
+    tools = %w[first middle last].map do |name|
+      Mistri::Tool.define(name, "Runs.", argument_normalizer: copy_arguments, schema:) do
+        ran << name
+        name
+      end
+    end
+    provider = fake(
+      { tool_calls: [
+        { id: "first-1", name: "first", arguments: { "count" => 1 } },
+        { id: "middle-1", name: "middle", arguments: { "count" => "many" } },
+        { id: "last-1", name: "last", arguments: { "count" => 3 } }
+      ] },
+      { text: "done" }
+    )
+    agent = Mistri::Agent.new(provider:, tools:, max_concurrency: 1)
+
+    agent.run("go")
+
+    assert_equal %w[first last], ran
+    answers = agent.session.messages.select(&:tool?)
+
+    assert_equal %w[first middle last], answers.map(&:tool_name)
+    assert_equal ["first", true, "last"],
+                 [answers[0].text, answers[1].tool_error?, answers[2].text]
+  end
+
+  def test_custom_validator_supplements_core_and_errors_are_bounded
+    values = Array.new(20) { |index| "host rule #{index}" }
+    values[0] = "host rule 0: #{"x" * 2_000_000}"
+    tool = Mistri::Tool.define(
+      "custom", "Custom rules.", argument_validator: ->(_args, _schema) { values }
+    ) { flunk "custom-invalid arguments executed" }
+    provider = fake({ tool_calls: [{ name: "custom", arguments: {} }] },
+                    { text: "correcting" })
+    agent = Mistri::Agent.new(provider:, tools: [tool])
+
+    agent.run("go")
+
+    answer = agent.session.messages.find(&:tool?)
+
+    assert_predicate answer, :tool_error?
+    assert_operator answer.text.bytesize, :<=, 2048
+    assert_includes answer.text, "host rule 0"
+    refute_includes answer.text, "host rule 8"
+  end
+
+  def test_core_failure_skips_the_host_validator
+    validations = 0
+    tool = Mistri::Tool.define(
+      "typed", "Typed.",
+      argument_validator: lambda { |*|
+        validations += 1
+        []
+      },
+      schema: -> { integer :count, "Count", required: true }
+    ) { flunk "invalid arguments executed" }
+    provider = fake({ tool_calls: [{ name: "typed", arguments: { "count" => "one" } }] },
+                    { text: "correcting" })
+
+    Mistri::Agent.new(provider:, tools: [tool]).run("go")
+
+    assert_equal 0, validations
+  end
+end
+
+# Normalizer, host-validator, and remote-boundary failures all fail closed.
+class TestToolArgumentBoundaryFailures < Minitest::Test
+  def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
+
+  def test_invalid_normalizer_results_fail_before_policy
+    touched = []
+    cyclic = Mistri::Tool.define(
+      "cyclic", "Cyclic.",
+      argument_normalizer: lambda { |_args|
+        value = {}
+        value["self"] = value
+        value
+      }
+    ) { touched << :handler }
+    scalar = Mistri::Tool.define("scalar", "Scalar.",
+                                 argument_normalizer: ->(_args) { "not an object" }) do
+      touched << :handler
+    end
+    raises = Mistri::Tool.define("raises", "Raises.",
+                                 argument_normalizer: ->(*) { raise "normalizer secret" }) do
+      touched << :handler
+    end
+    provider = fake(
+      { tool_calls: [{ name: "cyclic", arguments: {} },
+                     { name: "scalar", arguments: {} },
+                     { name: "raises", arguments: {} }] },
+      { text: "host configuration needs attention" }
+    )
+    agent = Mistri::Agent.new(
+      provider:, tools: [cyclic, scalar, raises],
+      before_tool: ->(*) { touched << :before }
+    )
+
+    agent.run("go")
+
+    assert_empty touched
+    answers = agent.session.messages.select(&:tool?)
+
+    assert_equal %w[cyclic scalar raises], answers.map(&:tool_name)
+    assert answers.all?(&:tool_error?)
+    assert(answers.all? { |answer| answer.text.include?("argument normalizer") })
+    assert_includes answers[0].text, "TypeError"
+    assert_includes answers[1].text, "ArgumentError"
+    assert_includes answers[2].text, "RuntimeError"
+    refute_includes answers[2].text, "normalizer secret"
+  end
+
+  def test_host_validator_failures_are_closed_without_leaking_details
+    tools = [
+      Mistri::Tool.define("raises", "Raises.",
+                          argument_validator: ->(*) { raise "database password" }) do
+        flunk "validator failure executed"
+      end,
+      Mistri::Tool.define("bad_return", "Bad return.", argument_validator: ->(*) { "no" }) do
+        flunk "invalid validator return executed"
+      end
+    ]
+    provider = fake(
+      { tool_calls: [{ name: "raises", arguments: {} },
+                     { name: "bad_return", arguments: {} }] },
+      { text: "correcting" }
+    )
+    agent = Mistri::Agent.new(provider:, tools:)
+
+    agent.run("go")
+
+    answers = agent.session.messages.select(&:tool?)
+
+    assert answers.all?(&:tool_error?)
+    assert(answers.all? { |answer| answer.text.include?("argument validator") })
+    assert_includes answers[0].text, "RuntimeError"
+    assert_includes answers[1].text, "TypeError"
+    refute(answers.any? { |answer| answer.text.include?("database password") })
+  end
+
+  def test_edit_file_alias_collisions_never_reach_the_workspace
+    workspace = Mistri::Workspace::Memory.new
+    workspace.write("a.txt", "old")
+    workspace.write("b.txt", "old")
+    provider = fake(
+      { tool_calls: [{ name: "edit_file",
+                       arguments: { "file" => "a.txt", "path" => "b.txt",
+                                    "oldText" => "old", "newText" => "new" } }] },
+      { text: "I will choose one path." }
+    )
+    agent = Mistri::Agent.new(provider:, tools: [Mistri::Tools.edit_file(workspace)])
+
+    agent.run("edit it")
+
+    assert_equal "old", workspace.read("a.txt")
+    assert_equal "old", workspace.read("b.txt")
+    assert_predicate agent.session.messages.find(&:tool?), :tool_error?
+  end
+
+  def test_direct_tool_calls_are_trusted_but_still_apply_the_tool_normalizer
+    validations = 0
+    normalizations = 0
+    seen = nil
+    tool = Mistri::Tool.define(
+      "direct", "Direct.",
+      argument_normalizer: lambda { |args|
+        normalizations += 1
+        seen = args
+        { "name" => args.fetch("legacy_name") }
+      },
+      argument_validator: lambda { |*|
+        validations += 1
+        ["rejected"]
+      }
+    ) { |args| args.fetch("name") }
+
+    input = { "legacy_name" => "Ana" }
+
+    assert_equal "Ana", tool.call(input)
+    assert_same input, seen
+    refute_predicate seen, :frozen?
+    assert_equal 1, normalizations
+    assert_equal 0, validations
+  end
+
+  def test_non_object_and_malformed_arguments_fail_before_policy
+    touched = []
+    tool = Mistri::Tool.define("run", "Runs.", needs_approval: lambda { |_args|
+      touched << :approval
+    }) { touched << :handler }
+    provider = fake(
+      { tool_calls: [{ name: "run", arguments: [1, 2] },
+                     { name: "run", arguments: {}, arguments_error: "invalid_json" },
+                     { name: "run", arguments: {}, arguments_error: "too_large" }] },
+      { text: "correcting" }
+    )
+    agent = Mistri::Agent.new(provider:, tools: [tool],
+                              before_tool: ->(*) { touched << :before })
+
+    agent.run("go")
+
+    assert_empty touched
+    answers = agent.session.messages.select(&:tool?)
+
+    assert_equal 3, answers.length
+    assert answers.all?(&:tool_error?)
+    assert_includes answers.first.text, "JSON object"
+    assert_includes answers[1].text, "not valid JSON"
+    assert_includes answers.last.text, "bounded JSON"
+  end
+
+  def test_completed_arguments_have_an_aggregate_byte_ceiling
+    call = Mistri::ToolCall.new(
+      id: "large-1", name: "run", arguments: { "value" => "x" * (8 * 1024 * 1024) }
+    )
+
+    assert_nil call.arguments
+    assert_equal "too_large", call.arguments_error
+  end
+
+  def test_a_custom_provider_partial_is_reowned_before_policy
+    retained = { "nested" => { "count" => 1 } }
+    call = Mistri::ToolCall.new(id: "c1", name: "run", arguments: retained,
+                                canonicalize: false)
+    provider = Class.new do
+      define_method(:model) { "custom-1" }
+      define_method(:prices_usage?) { true }
+      define_method(:stream) do |**|
+        Mistri::Message.assistant(tool_calls: [call], stop_reason: Mistri::StopReason::TOOL_USE,
+                                  usage: Mistri::Usage.zero)
+      end
+    end.new
+    observed = nil
+    tool = Mistri::Tool.define("run", "Runs.", ends_turn: true, schema: lambda {
+      object :nested, required: true do
+        integer :count, required: true
+      end
+    }) do |args|
+      observed = args.dig("nested", "count")
+      "done"
+    end
+    agent = Mistri::Agent.new(provider:, tools: [tool], before_tool: lambda { |_call, _context|
+      retained["nested"]["count"] = "changed after validation"
+      nil
+    })
+
+    agent.run("go")
+
+    assert_equal 1, observed
+  end
+
+  def test_invalid_mcp_arguments_never_reach_the_remote_handler
+    client = Class.new do
+      attr_reader :tools, :calls
+
+      def initialize
+        @calls = []
+        @tools = [{ "name" => "charge", "description" => "Charges.",
+                    "inputSchema" => {
+                      "type" => "object",
+                      "properties" => { "amount" => { "type" => "number" } },
+                      "required" => ["amount"]
+                    } }]
+      end
+
+      def call_tool(name, arguments)
+        @calls << [name, arguments]
+        { "content" => [{ "type" => "text", "text" => "charged" }] }
+      end
+    end.new
+    provider = fake({ tool_calls: [{ name: "charge", arguments: { "amount" => "all" } }] },
+                    { text: "correcting" })
+    agent = Mistri::Agent.new(provider:, tools: Mistri::MCP.tools(client))
+
+    agent.run("charge it")
+
+    assert_empty client.calls
+    assert_predicate agent.session.messages.find(&:tool?), :tool_error?
+  end
+end

--- a/test/test_tool_call_identity.rb
+++ b/test/test_tool_call_identity.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "delegate"
+
+class TestToolCallIdentity < Minitest::Test
+  def test_approval_request_mirrors_do_not_duplicate_assistant_call_ids
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = Mistri::ToolCall.new(id: "c1", name: "send", arguments: {})
+    session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use))
+    session.append("approval_request", "call" => call.to_h)
+
+    assert_equal Set["c1"], session.tool_call_ids
+  end
+
+  def test_a_later_assistant_turn_cannot_reuse_a_persisted_call_id
+    ran = 0
+    tool = Mistri::Tool.define("write", "Write once.") do
+      ran += 1
+      "written"
+    end
+    turns = [tool_turn("same"), tool_turn("same"), tool_turn("corrected"), { text: "done" }]
+    provider = Mistri::Providers::Fake.new(turns:)
+    retries = Mistri::RetryPolicy.new(attempts: 1, base: 0, max_delay: 0)
+
+    agent = Mistri::Agent.new(provider:, tools: [tool], retries:)
+    result = agent.run("go")
+
+    assert_predicate result, :completed?
+    assert_equal 2, ran, "the rejected duplicate never reached the handler"
+    calls = agent.session.messages.flat_map(&:tool_calls)
+    retries_recorded = agent.session.entries.count { |entry| entry["type"] == "retry" }
+
+    assert_equal %w[same corrected], calls.map(&:id)
+    assert_equal 1, retries_recorded
+  end
+
+  def test_duplicate_ids_in_legacy_history_fail_before_a_run_writes_or_calls_a_provider
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    append_assistant_call(session, "same")
+    append_assistant_call(session, "same")
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "must not run" }])
+    before = session.entries.length
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Agent.new(provider:, session:).run("continue")
+    end
+
+    assert_match(/duplicate tool call ID/, error.message)
+    assert_equal before, session.entries.length
+    assert_empty provider.requests
+  end
+
+  def test_one_legacy_decision_cannot_execute_duplicate_approval_requests
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = Mistri::ToolCall.new(id: "write-1", name: "write", arguments: {})
+    session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use))
+    2.times { session.append("approval_request", "call" => call.to_h) }
+    session.append("approval_decision", "call_id" => call.id, "approved" => true)
+    ran = false
+    tool = Mistri::Tool.define("write", "Write once.", needs_approval: true) do
+      ran = true
+      "written"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "must not run" }])
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Agent.new(provider:, tools: [tool], session:).resume
+    end
+
+    assert_match(/duplicate approval request ID/, error.message)
+    refute ran
+    assert_empty provider.requests
+    assert_empty session.messages.select(&:tool?)
+  end
+
+  def test_an_approval_request_cannot_substitute_arguments_for_the_assistant_call
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = Mistri::ToolCall.new(id: "charge-1", name: "charge",
+                                arguments: { "amount" => 5 }, signature: "signed",
+                                provider_call_id: "remote-1")
+    session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use))
+    substituted = call.to_h.merge(arguments: { "amount" => 5000 })
+    session.append("approval_request", "call" => substituted)
+    session.append("approval_decision", "call_id" => call.id, "approved" => true)
+    ran = false
+    tool = Mistri::Tool.define("charge", "Charge.",
+                               needs_approval: true,
+                               schema: lambda {
+                                 integer :amount, "Amount", required: true
+                               }) do
+      ran = true
+      "charged"
+    end
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Agent.new(provider: Mistri::Providers::Fake.new, tools: [tool], session:).resume
+    end
+
+    assert_match(/does not match its assistant tool call/, error.message)
+    refute ran
+    assert_empty session.messages.select(&:tool?)
+  end
+
+  def test_a_normalized_approval_references_the_preceding_provider_call
+    normalizer = lambda do |arguments|
+      { "recipient" => arguments.fetch("to") }
+    end
+    tool = Mistri::Tool.define("send", "Send.",
+                               needs_approval: true,
+                               argument_normalizer: normalizer,
+                               schema: lambda {
+                                 string :recipient, "Recipient", required: true
+                               }) { "sent" }
+    turns = [{ tool_calls: [
+      { id: "send-1", name: "send", arguments: { "to" => "Ana" } }
+    ] }]
+    agent = Mistri::Agent.new(provider: Mistri::Providers::Fake.new(turns:), tools: [tool])
+
+    agent.run("go")
+
+    approval = agent.session.entries.find { |entry| entry["type"] == "approval_request" }
+    assistant = agent.session.entries.find do |entry|
+      entry.dig("message", "role") == "assistant"
+    end
+    provider_call = assistant.dig("message", "content", 0)
+
+    refute approval.key?("source_call")
+    assert_equal "assistant", approval["prepared_from"]
+    assert_equal "send-1", provider_call["id"]
+    assert_equal({ "recipient" => "Ana" }, approval.dig("call", "arguments"))
+    assert_equal Set["send-1"], agent.session.tool_call_ids
+  end
+
+  def test_approval_provenance_and_prepared_metadata_are_both_fail_closed
+    call = Mistri::ToolCall.new(id: "send-1", name: "send", arguments: { "to" => "Ana" },
+                                signature: "signed", provider_call_id: "remote-1")
+    cases = {
+      source_arguments: [call.to_h, call.to_h.merge(arguments: { "to" => "Mallory" })],
+      prepared_name: [call.to_h.merge(name: "delete"), call.to_h],
+      prepared_type: [call.to_h.merge(type: "text"), call.to_h]
+    }
+
+    cases.each do |label, (prepared, source)|
+      session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+      session.append_message(Mistri::Message.assistant(tool_calls: [call],
+                                                       stop_reason: :tool_use))
+      session.append("approval_request", "call" => prepared, "source_call" => source)
+
+      assert_raises(Mistri::ConfigurationError, label.to_s) { session.tool_call_ids }
+    end
+  end
+
+  def test_malformed_persisted_ids_are_rejected_without_rebuilding_messages
+    invalid_utf8 = "\xFF".b.force_encoding(Encoding::UTF_8)
+    [nil, 7, "", " \t", invalid_utf8].each do |id|
+      store = Mistri::Stores::Memory.new
+      session = Mistri::Session.new(store:)
+      store.append(session.id, raw_assistant_entry(id))
+
+      assert_raises(Mistri::ConfigurationError, "accepted #{id.inspect}") do
+        session.tool_call_ids
+      end
+    end
+  end
+
+  def test_malformed_persisted_names_and_signatures_fail_closed
+    invalid_utf8 = "\xFF".b.force_encoding(Encoding::UTF_8)
+    cases = [
+      [nil, nil], ["", nil], [7, nil], [invalid_utf8, nil],
+      ["write", ""], ["write", 7], ["write", invalid_utf8]
+    ]
+    cases.each do |name, signature|
+      store = Mistri::Stores::Memory.new
+      session = Mistri::Session.new(store:)
+      entry = raw_assistant_entry("c1")
+      call = entry.dig("message", "content", 0)
+      call["name"] = name
+      call["signature"] = signature unless signature.nil?
+      store.append(session.id, entry)
+
+      assert_raises(Mistri::ConfigurationError, "accepted #{[name, signature].inspect}") do
+        session.tool_call_ids
+      end
+    end
+  end
+
+  def test_invalid_provider_call_ids_reject_the_whole_live_attempt
+    ran = false
+    tool = Mistri::Tool.define("write", "Write once.") do
+      ran = true
+      "written"
+    end
+    turns = [{ tool_calls: [
+      { id: "internal", provider_call_id: " ", name: "write", arguments: {} }
+    ] }]
+    provider = Mistri::Providers::Fake.new(turns:)
+
+    agent = Mistri::Agent.new(provider:, tools: [tool], retries: nil)
+    result = agent.run("go")
+
+    assert_predicate result, :errored?
+    assert_match(/provider tool call IDs must not be blank/, result.message.error_message)
+    refute ran
+    assert_empty agent.session.messages.flat_map(&:tool_calls)
+  end
+
+  def test_invalid_signatures_reject_the_whole_live_attempt
+    cases = {
+      non_string: 7,
+      empty: "",
+      whitespace: " \t",
+      invalid_utf8: "\xFF".b,
+      non_utf8: "signed".encode(Encoding::UTF_16LE)
+    }
+    cases.each do |label, signature|
+      ran = false
+      tool = Mistri::Tool.define("write", "Write once.") do
+        ran = true
+        "written"
+      end
+      turns = [{ tool_calls: [
+        { id: "internal", signature:, name: "write", arguments: {} }
+      ] }]
+      provider = Mistri::Providers::Fake.new(turns:)
+      agent = Mistri::Agent.new(provider:, tools: [tool], retries: nil)
+
+      result = agent.run("go")
+
+      assert_predicate result, :errored?, label
+      assert_match(/tool call signatures must/, result.message.error_message, label)
+      refute ran, label
+      assert_empty agent.session.messages.flat_map(&:tool_calls), label
+    end
+  end
+
+  def test_the_identity_audit_reads_a_store_once
+    counter = Class.new(SimpleDelegator) do
+      def loads = @loads || 0
+
+      def load(id)
+        @loads = loads + 1
+        __getobj__.load(id)
+      end
+    end
+    store = counter.new(Mistri::Stores::Memory.new)
+    session = Mistri::Session.new(store:)
+    append_assistant_call(session, "c1")
+    before = store.loads
+
+    assert_equal Set["c1"], session.tool_call_ids
+    assert_equal 1, store.loads - before
+  end
+
+  private
+
+  def tool_turn(id)
+    { tool_calls: [{ id:, name: "write", arguments: {} }] }
+  end
+
+  def append_assistant_call(session, id)
+    call = Mistri::ToolCall.new(id:, name: "write", arguments: {})
+    session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use))
+    call
+  end
+
+  def raw_assistant_entry(id)
+    { "type" => "message", "message" => {
+      "role" => "assistant", "content" => [
+        { "type" => "tool_call", "id" => id, "name" => "write", "arguments" => {} }
+      ]
+    } }
+  end
+end

--- a/test/test_tool_call_identity.rb
+++ b/test/test_tool_call_identity.rb
@@ -186,23 +186,31 @@ class TestToolCallIdentity < Minitest::Test
   end
 
   def test_invalid_provider_call_ids_reject_the_whole_live_attempt
-    ran = false
-    tool = Mistri::Tool.define("write", "Write once.") do
-      ran = true
-      "written"
+    cases = {
+      non_string: [7, /must be strings/],
+      invalid_utf8: ["\xFF".b.force_encoding(Encoding::UTF_8), /must be valid UTF-8/],
+      blank: [" ", /must not be blank/]
+    }
+
+    cases.each do |label, (provider_call_id, message)|
+      ran = false
+      tool = Mistri::Tool.define("write", "Write once.") do
+        ran = true
+        "written"
+      end
+      turns = [{ tool_calls: [
+        { id: "internal", provider_call_id:, name: "write", arguments: {} }
+      ] }]
+      provider = Mistri::Providers::Fake.new(turns:)
+
+      agent = Mistri::Agent.new(provider:, tools: [tool], retries: nil)
+      result = agent.run("go")
+
+      assert_predicate result, :errored?, label
+      assert_match message, result.message.error_message, label
+      refute ran, label
+      assert_empty agent.session.messages.flat_map(&:tool_calls), label
     end
-    turns = [{ tool_calls: [
-      { id: "internal", provider_call_id: " ", name: "write", arguments: {} }
-    ] }]
-    provider = Mistri::Providers::Fake.new(turns:)
-
-    agent = Mistri::Agent.new(provider:, tools: [tool], retries: nil)
-    result = agent.run("go")
-
-    assert_predicate result, :errored?
-    assert_match(/provider tool call IDs must not be blank/, result.message.error_message)
-    refute ran
-    assert_empty agent.session.messages.flat_map(&:tool_calls)
   end
 
   def test_invalid_signatures_reject_the_whole_live_attempt

--- a/test/test_tool_call_lifecycle_boundary.rb
+++ b/test/test_tool_call_lifecycle_boundary.rb
@@ -1,0 +1,492 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Tool-call identity and abort are execution boundaries: neither malformed
+# provider metadata nor a late stop may reach policy or create an approval.
+class TestToolCallLifecycleBoundary < Minitest::Test # rubocop:disable Metrics/ClassLength -- one boundary matrix
+  class ScriptedProvider
+    attr_reader :requests
+
+    def initialize(*turns)
+      @turns = turns
+      @requests = []
+    end
+
+    def model = "custom-1"
+
+    def prices_usage? = true
+
+    def stream(messages: [], **)
+      @requests << messages
+      message = @turns.shift || raise(Mistri::ConfigurationError, "no scripted turn left")
+      type = message.stop_reason == Mistri::StopReason::ERROR ? :error : :done
+      if block_given?
+        yield Mistri::Event.new(type:, reason: message.stop_reason, message:,
+                                error_message: message.error_message)
+      end
+      message
+    end
+  end
+
+  def test_malformed_ids_fail_the_attempt_before_persistence_policy_or_execution
+    cases = {
+      missing: nil,
+      non_string: 7,
+      empty: "",
+      whitespace: " \n\t",
+      invalid_utf8: "\xFF".b,
+      non_utf8: "call".encode(Encoding::UTF_16LE)
+    }
+
+    cases.each do |label, id|
+      assert_malformed_id_rejected(label, id)
+    end
+  end
+
+  def test_malformed_names_fail_the_attempt_before_persistence_policy_or_execution
+    cases = {
+      missing: nil,
+      non_string: 7,
+      empty: "",
+      whitespace: " \n\t",
+      invalid_utf8: "\xFF".b,
+      non_utf8: "write".encode(Encoding::UTF_16LE)
+    }
+
+    cases.each do |label, name|
+      call = Mistri::ToolCall.new(id: "call", name:, arguments: {})
+
+      assert_malformed_call_rejected(label, call)
+    end
+  end
+
+  def test_duplicate_ids_retry_the_entire_attempt_and_run_only_a_clean_retry
+    state = duplicate_retry_scenario
+
+    result = state[:agent].run("go") { |event| state[:events] << event }
+
+    assert_clean_retry_execution(result, state)
+    assert_malformed_attempt_not_persisted(state)
+  end
+
+  def test_duplicate_provider_call_ids_fail_before_persistence_or_execution
+    calls = %w[first second].map do |id|
+      Mistri::ToolCall.new(id:, name: "write", arguments: {},
+                           provider_call_id: "wire-duplicate")
+    end
+    message = Mistri::Message.assistant(
+      tool_calls: calls, stop_reason: Mistri::StopReason::TOOL_USE
+    )
+    provider = ScriptedProvider.new(message)
+    ran = false
+    tool = Mistri::Tool.define("write", "Writes.") { ran = true }
+    agent = Mistri::Agent.new(provider:, tools: [tool], retries: false)
+
+    result = agent.run("go")
+
+    assert_predicate result, :errored?
+    refute ran
+    assert_empty agent.session.messages.flat_map(&:tool_calls)
+    assert_empty agent.session.messages.select(&:tool?)
+  end
+
+  def test_non_assistant_provider_messages_never_reach_tool_execution
+    %i[system user tool].each do |role|
+      call = Mistri::ToolCall.new(id: "call-1", name: "write", arguments: {})
+      message = Mistri::Message.new(
+        role:, content: [call], tool_call_id: ("source" if role == :tool),
+        tool_name: ("write" if role == :tool), stop_reason: Mistri::StopReason::TOOL_USE
+      )
+      provider = ScriptedProvider.new(message)
+      ran = false
+      tool = Mistri::Tool.define("write", "Writes.") { ran = true }
+      agent = Mistri::Agent.new(provider:, tools: [tool], retries: false)
+
+      result = agent.run("go")
+
+      assert_predicate result, :errored?, role
+      refute ran, role
+      assert_empty agent.session.messages.flat_map(&:tool_calls), role
+      assert_empty agent.session.messages.select(&:tool?), role
+    end
+  end
+
+  def test_incomplete_provider_calls_are_not_persisted_or_run
+    call = Mistri::ToolCall.new(id: "call-1", name: "write", arguments: nil,
+                                arguments_error: "incomplete")
+    message = Mistri::Message.assistant(
+      tool_calls: [call], stop_reason: Mistri::StopReason::ERROR,
+      error_message: "stream ended", error: { "type" => "TruncatedStream" }
+    )
+    provider = ScriptedProvider.new(message)
+    ran = false
+    tool = Mistri::Tool.define("write", "Writes.") { ran = true }
+    agent = Mistri::Agent.new(provider:, tools: [tool], retries: false)
+
+    result = agent.run("go")
+
+    assert_predicate result, :errored?
+    refute ran
+    assert_empty agent.session.messages.flat_map(&:tool_calls)
+    assert_empty agent.session.messages.select(&:tool?)
+    assert_equal "stream ended", result.message.error_message
+  end
+
+  def test_gemini_no_id_results_never_cross_a_same_name_approval_boundary
+    calls = [
+      Mistri::ToolCall.new(id: "risk", name: "write", arguments: { "risk" => true }),
+      Mistri::ToolCall.new(id: "safe", name: "write", arguments: { "risk" => false })
+    ]
+    turn = Mistri::Message.assistant(
+      tool_calls: calls, provider: :gemini, stop_reason: Mistri::StopReason::TOOL_USE
+    )
+    provider = ScriptedProvider.new(turn, text_turn("done"))
+    ran = []
+    tool = Mistri::Tool.define(
+      "write", "Writes.", needs_approval: ->(arguments) { arguments["risk"] },
+                          schema: -> { boolean :risk, "Risky", required: true }
+    ) do |arguments|
+      ran << arguments["risk"]
+      "written"
+    end
+    agent = Mistri::Agent.new(provider:, tools: [tool], max_concurrency: 1)
+
+    result = agent.run("go")
+    results = agent.session.messages.select(&:tool?)
+
+    assert_predicate result, :completed?
+    assert_equal [false], ran
+    assert_empty agent.session.open_approvals
+    assert_equal %w[risk safe], results.map(&:tool_call_id)
+    assert_predicate results.first, :tool_error?
+    assert_includes results.first.text, "retry those calls separately"
+  end
+
+  def test_gemini_no_id_calls_allow_a_final_same_name_approval
+    calls = [
+      Mistri::ToolCall.new(id: "safe", name: "write", arguments: { "risk" => false }),
+      Mistri::ToolCall.new(id: "risk", name: "write", arguments: { "risk" => true })
+    ]
+
+    state = exercise_allowed_gemini_approval(calls)
+
+    assert_equal [false, true], state[:ran]
+    assert_equal %w[safe risk], state[:results].map(&:tool_call_id)
+  end
+
+  def test_gemini_call_ids_allow_out_of_order_same_name_results
+    calls = [
+      Mistri::ToolCall.new(id: "risk", name: "write", arguments: { "risk" => true },
+                           provider_call_id: "wire-risk"),
+      Mistri::ToolCall.new(id: "safe", name: "write", arguments: { "risk" => false },
+                           provider_call_id: "wire-safe")
+    ]
+
+    state = exercise_allowed_gemini_approval(calls)
+
+    assert_equal [false, true], state[:ran]
+    assert_equal %w[safe risk], state[:results].map(&:tool_call_id)
+  end
+
+  def test_abort_during_each_pre_execution_phase_interrupts_every_call
+    %i[normalizer validator before_tool approval].each do |phase|
+      exercise_abort_phase(phase)
+    end
+  end
+
+  def test_abort_during_resume_validation_interrupts_approved_calls_without_another_turn
+    state = resume_abort_scenario
+    events = []
+
+    result = state[:agent].resume(signal: state[:signal]) { |event| events << event }
+
+    assert_resume_abort_outcome(result, state, events)
+  end
+
+  def test_abort_during_result_rewrite_interrupts_calls_waiting_to_park
+    signal = Mistri::AbortSignal.new
+    ran = []
+    free = Mistri::Tool.define("free", "Runs now.") do
+      ran << :free
+      "done"
+    end
+    gated = Mistri::Tool.define("gated", "Waits.", needs_approval: true) do
+      flunk "gated call ran"
+    end
+    calls = [{ name: "free", arguments: {} }, { name: "gated", arguments: {} }]
+    provider = Mistri::Providers::Fake.new(turns: [{ tool_calls: calls }])
+    after_tool = lambda do |*|
+      signal.abort!(:test)
+      nil
+    end
+    events = []
+    agent = Mistri::Agent.new(provider:, tools: [free, gated], max_concurrency: 1, after_tool:)
+
+    result = agent.run("go", signal:) { |event| events << event }
+
+    assert_post_execution_abort(result, agent, events, ran)
+  end
+
+  private
+
+  def exercise_allowed_gemini_approval(calls)
+    turn = Mistri::Message.assistant(
+      tool_calls: calls, provider: :gemini, stop_reason: Mistri::StopReason::TOOL_USE
+    )
+    provider = ScriptedProvider.new(turn, text_turn("done"))
+    ran = []
+    tool = Mistri::Tool.define(
+      "write", "Writes.", needs_approval: ->(arguments) { arguments["risk"] },
+                          schema: -> { boolean :risk, "Risky", required: true }
+    ) do |arguments|
+      ran << arguments["risk"]
+      "written"
+    end
+    agent = Mistri::Agent.new(provider:, tools: [tool], max_concurrency: 1)
+    pending = agent.run("go").pending
+
+    assert_equal ["risk"], pending.map(&:id)
+    agent.session.approve("risk")
+    result = agent.resume
+
+    assert_predicate result, :completed?
+    { ran:, results: agent.session.messages.select(&:tool?) }
+  end
+
+  def duplicate_retry_scenario
+    calls = [
+      Mistri::ToolCall.new(id: "duplicate", name: "pay", arguments: { "amount" => 1 }),
+      Mistri::ToolCall.new(id: "duplicate", name: "pay", arguments: { "amount" => 1_000 }),
+      Mistri::ToolCall.new(id: "discarded-sibling", name: "pay", arguments: { "amount" => 2 })
+    ]
+    clean = Mistri::ToolCall.new(id: "clean", name: "pay", arguments: { "amount" => 3 })
+    provider = ScriptedProvider.new(tool_turn(calls), tool_turn([clean]), text_turn("done"))
+    policies = []
+    ran = []
+    tool = Mistri::Tool.define(
+      "pay", "Pays.",
+      schema: -> { integer :amount, "Amount", required: true },
+      needs_approval: lambda { |args|
+        policies << args["amount"]
+        args["amount"] > 100
+      }
+    ) do |args|
+      ran << args["amount"]
+      "paid"
+    end
+    retries = Mistri::RetryPolicy.new(attempts: 1, base: 0.0)
+    events = []
+    agent = Mistri::Agent.new(provider:, tools: [tool], max_concurrency: 1, retries:)
+    { provider:, agent:, policies:, ran:, events: }
+  end
+
+  def resume_abort_scenario
+    signal = Mistri::AbortSignal.new
+    touched = []
+    validations = 0
+    validator = lambda do |*|
+      validations += 1
+      touched << :validator
+      signal.abort!(:test) if validations > 2
+      []
+    end
+    approval = lambda do |*|
+      touched << :approval
+      true
+    end
+    ran = []
+    tool = Mistri::Tool.define(
+      "write", "Writes.", argument_validator: validator, needs_approval: approval
+    ) do
+      ran << :handler
+      "wrote"
+    end
+    calls = [{ name: "write", arguments: {} }, { name: "write", arguments: {} }]
+    provider = Mistri::Providers::Fake.new(turns: [{ tool_calls: calls }])
+    agent = Mistri::Agent.new(
+      provider:, tools: [tool], before_tool: ->(*) { touched << :before }
+    )
+    pending = agent.run("go").pending
+    pending.each { |call| agent.session.approve(call.id) }
+    touched.clear
+    { agent:, provider:, ran:, signal:, touched: }
+  end
+
+  def assert_clean_retry_execution(result, state)
+    assert_predicate result, :completed?
+    assert_equal [3], state[:policies]
+    assert_equal [3], state[:ran]
+    assert_empty state[:agent].session.open_approvals
+    assert_equal ["clean"], state[:agent].session.messages.flat_map(&:tool_calls).map(&:id)
+    assert_equal ["clean"], state[:agent].session.messages.select(&:tool?).map(&:tool_call_id)
+    assert_equal 3, state[:provider].requests.length
+    assert_equal state[:provider].requests[0].map(&:to_h),
+                 state[:provider].requests[1].map(&:to_h),
+                 "a malformed attempt retries unchanged history"
+  end
+
+  def assert_malformed_attempt_not_persisted(state)
+    entries = state[:agent].session.entries
+    retry_entry = entries.find { |entry| entry["type"] == "retry" }
+    retry_count = entries.count { |entry| entry["type"] == "retry" }
+    retry_events = state[:events].count { |event| event.type == :retry }
+
+    assert_equal "ProviderError", retry_entry.dig("error", "type")
+    assert_equal 1, retry_count
+    assert_equal 1, retry_events
+    refute(state[:events].any? { |event| event.type == :error })
+    persisted = entries.inspect
+
+    refute_includes persisted, "duplicate"
+    refute_includes persisted, "discarded-sibling"
+  end
+
+  def assert_resume_abort_outcome(result, state, events)
+    assert_predicate result, :aborted?
+    assert_equal [:validator], state[:touched]
+    assert_empty state[:ran]
+    assert_equal 1, state[:provider].requests.length
+    assert_empty state[:agent].session.open_approvals
+    refute(events.any? { |event| event.type == :tool_started })
+    refute(events.any? { |event| event.type == :approval_needed })
+    answers = state[:agent].session.messages.select(&:tool?)
+
+    assert_equal [Mistri::ToolExecutor::INTERRUPTED] * 2, answers.map(&:text)
+    assert_equal [true, true], answers.map(&:tool_error?)
+  end
+
+  def assert_post_execution_abort(result, agent, events, ran)
+    assert_predicate result, :aborted?
+    assert_equal [:free], ran
+    assert_empty agent.session.open_approvals
+    refute(events.any? { |event| event.type == :approval_needed })
+    answers = agent.session.messages.select(&:tool?)
+
+    assert_equal %w[free gated], answers.map(&:tool_name)
+    assert_equal ["done", Mistri::ToolExecutor::INTERRUPTED], answers.map(&:text)
+    assert_equal [false, true], answers.map(&:tool_error?)
+  end
+
+  def exercise_abort_phase(phase)
+    signal = Mistri::AbortSignal.new
+    phase_calls = 0
+    aborting = lambda do |value = nil, *_rest|
+      phase_calls += 1
+      signal.abort!(:test)
+      value
+    end
+    options, before_tool = abort_configuration(phase, aborting)
+    ran = []
+    tool = Mistri::Tool.define("write", "Writes.", **options) do
+      ran << :handler
+      "wrote"
+    end
+    provider = two_call_fake
+    events = []
+    agent = Mistri::Agent.new(provider:, tools: [tool], before_tool:)
+
+    result = agent.run("go", signal:) { |event| events << event }
+
+    observed = { ran:, phase_calls: }
+
+    assert_abort_outcome(phase, result, agent, events, observed)
+  end
+
+  def assert_malformed_id_rejected(label, id)
+    call = Mistri::ToolCall.new(id:, name: "write", arguments: {})
+
+    assert_malformed_call_rejected(label, call)
+  end
+
+  def assert_malformed_call_rejected(label, call)
+    provider = ScriptedProvider.new(tool_turn([call]))
+    touched = []
+    normalizer = lambda do |args|
+      touched << :normalizer
+      args
+    end
+    validator = lambda do |*|
+      touched << :validator
+      []
+    end
+    approval = lambda do |*|
+      touched << :approval
+      true
+    end
+    tool = Mistri::Tool.define(
+      "write", "Writes.",
+      argument_normalizer: normalizer,
+      argument_validator: validator,
+      needs_approval: approval
+    ) { touched << :handler }
+    events = []
+    agent = Mistri::Agent.new(
+      provider:, tools: [tool], retries: false,
+      before_tool: ->(*) { touched << :before }
+    )
+
+    result = agent.run("go") { |event| events << event }
+    message = agent.session.messages.last
+
+    assert_predicate result, :errored?, label
+    assert_empty touched, label
+    assert_empty agent.session.open_approvals, label
+    assert_empty agent.session.messages.flat_map(&:tool_calls), label
+    assert_empty agent.session.messages.select(&:tool?), label
+    assert_equal Mistri::StopReason::ERROR, message.stop_reason, label
+    assert_equal "ProviderError", message.error["type"], label
+    assert_equal "The provider returned malformed tool-call metadata. No tools ran.",
+                 message.text, label
+    assert_equal [:error], events.select(&:terminal?).map(&:type), label
+    unsafe_event = events.any? do |event|
+      %i[tool_started tool_result approval_needed].include?(event.type)
+    end
+
+    refute unsafe_event, label
+  end
+
+  def abort_configuration(phase, aborting)
+    options = { needs_approval: true }
+    before_tool = nil
+    case phase
+    when :normalizer then options[:argument_normalizer] = aborting
+    when :validator then options[:argument_validator] = ->(*) { aborting.call([]) }
+    when :before_tool then before_tool = ->(*) { aborting.call(nil) }
+    when :approval then options[:needs_approval] = ->(*) { aborting.call(true) }
+    end
+    [options, before_tool]
+  end
+
+  def two_call_fake
+    calls = [{ name: "write", arguments: {} }, { name: "write", arguments: {} }]
+    Mistri::Providers::Fake.new(turns: [{ tool_calls: calls }])
+  end
+
+  def assert_abort_outcome(phase, result, agent, events, observed)
+    assert_predicate result, :aborted?, phase
+    assert_equal 1, observed[:phase_calls], phase
+    assert_empty observed[:ran], phase
+    assert_empty result.pending, phase
+    assert_empty agent.session.open_approvals, phase
+    refute(events.any? { |event| event.type == :tool_started }, phase)
+    refute(events.any? { |event| event.type == :approval_needed }, phase)
+    answers = agent.session.messages.select(&:tool?)
+
+    assert_equal 2, answers.length, phase
+    assert_equal [true, true], answers.map(&:tool_error?), phase
+    assert_equal [Mistri::ToolExecutor::INTERRUPTED] * 2, answers.map(&:text), phase
+  end
+
+  def tool_turn(calls)
+    Mistri::Message.assistant(tool_calls: calls, model: "custom-1", provider: :fake,
+                              usage: Mistri::Usage.zero,
+                              stop_reason: Mistri::StopReason::TOOL_USE)
+  end
+
+  def text_turn(text)
+    Mistri::Message.assistant(content: text, model: "custom-1", provider: :fake,
+                              usage: Mistri::Usage.zero,
+                              stop_reason: Mistri::StopReason::STOP)
+  end
+end # rubocop:enable Metrics/ClassLength

--- a/test/test_tool_extension.rb
+++ b/test/test_tool_extension.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestToolExtension < Minitest::Test
+  class DuckTool
+    attr_reader :name, :timeout
+
+    def initialize(log)
+      @name = "duck"
+      @timeout = nil
+      @log = log
+    end
+
+    def spec
+      { "name" => name, "description" => "Duck tool.",
+        "input_schema" => {
+          type: "object", properties: { count: { type: "integer" } }, required: ["count"]
+        } }
+    end
+
+    def call(arguments, _context)
+      @log << arguments.fetch("count")
+      "ok"
+    end
+
+    def needs_approval?(_arguments) = false
+
+    def ends_turn? = false
+  end
+
+  class SelfValidatingDuckTool < DuckTool
+    def prepared_argument_violations(_arguments) = []
+  end
+
+  def test_agent_execution_keeps_the_historical_call_override_extension_point
+    subclass = Class.new(Mistri::Tool) do
+      attr_reader :observed
+
+      def call(arguments, context = Mistri::ToolContext.new)
+        @observed = [arguments, context]
+        super
+      end
+    end
+    normalizations = 0
+    tool = subclass.new(
+      name: "wrapped", description: "Wrapped.",
+      argument_normalizer: lambda { |arguments|
+        normalizations += 1
+        arguments
+      }
+    ) { "ok" }
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [
+                                               { name: "wrapped", arguments: {} }
+                                             ] },
+                                             { text: "done" }
+                                           ])
+
+    agent = Mistri::Agent.new(provider:, tools: [tool])
+    result = agent.run("go")
+
+    assert_predicate result, :completed?
+    assert_equal 1, normalizations
+    assert_equal({}, tool.observed.first)
+    assert_predicate tool.observed.first, :frozen?
+    assert_predicate tool.observed.last, :arguments_prepared?
+  end
+
+  def test_direct_executor_calls_apply_a_tool_normalizer_once
+    observed = []
+    normalizations = 0
+    tool = Mistri::Tool.define(
+      "wrapped", "Wrapped.",
+      argument_normalizer: lambda { |arguments|
+        normalizations += 1
+        { "value" => arguments.fetch("alias") }
+      }
+    ) { |arguments| observed << arguments.fetch("value") }
+    call = Mistri::ToolCall.new(id: "call-1", name: "wrapped",
+                                arguments: { "alias" => "kept" })
+
+    results = Mistri::ToolExecutor.call([call], { "wrapped" => tool })
+
+    assert_equal 3, results.first.length
+    assert_equal 1, normalizations
+    assert_equal ["kept"], observed
+  end
+
+  def test_duck_typed_tools_keep_their_call_protocol_and_gain_core_validation
+    handled = []
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [
+                                               { name: "duck", arguments: { count: "two" } }
+                                             ] },
+                                             { tool_calls: [
+                                               { name: "duck", arguments: { count: 2 } }
+                                             ] },
+                                             { text: "done" }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [DuckTool.new(handled)])
+
+    result = agent.run("go")
+
+    assert_predicate result, :completed?
+    assert_equal [2], handled
+    answers = agent.session.messages.select(&:tool?)
+
+    assert_predicate answers.first, :tool_error?
+    refute_predicate answers.last, :tool_error?
+  end
+
+  def test_duck_validator_cannot_bypass_the_portable_core_contract
+    handled = []
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [
+                                               { name: "duck",
+                                                 arguments: { count: "two" } }
+                                             ] },
+                                             { text: "done" }
+                                           ])
+    tool = SelfValidatingDuckTool.new(handled)
+
+    agent = Mistri::Agent.new(provider:, tools: [tool])
+    result = agent.run("go")
+
+    assert_predicate result, :completed?
+    assert_empty handled
+    assert_predicate agent.session.messages.find(&:tool?), :tool_error?
+  end
+
+  def test_tool_subclass_cannot_override_the_agent_core_contract
+    subclass = Class.new(Mistri::Tool) do
+      def prepared_argument_violations(_arguments) = []
+    end
+    handled = []
+    tool = subclass.new(
+      name: "strict", description: "Strict.",
+      input_schema: {
+        type: "object", properties: { count: { type: "integer" } }, required: ["count"]
+      }
+    ) { |arguments| handled << arguments }
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [
+                                               { name: "strict",
+                                                 arguments: { count: "two" } }
+                                             ] },
+                                             { text: "done" }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [tool])
+
+    result = agent.run("go")
+
+    assert_predicate result, :completed?
+    assert_empty handled
+    assert_predicate agent.session.messages.find(&:tool?), :tool_error?
+  end
+end

--- a/test/test_tool_extension.rb
+++ b/test/test_tool_extension.rb
@@ -129,6 +129,24 @@ class TestToolExtension < Minitest::Test
     assert_predicate agent.session.messages.find(&:tool?), :tool_error?
   end
 
+  def test_duck_typed_tool_specs_must_be_objects_with_an_input_schema
+    cases = {
+      non_object: [nil, /spec must be a Hash/],
+      missing_schema: [{ name: "duck", description: "Duck tool." }, /needs input_schema/]
+    }
+
+    cases.each do |label, (spec, message)|
+      tool = DuckTool.new([])
+      tool.define_singleton_method(:spec) { spec }
+
+      error = assert_raises(Mistri::ConfigurationError, label.to_s) do
+        Mistri::Agent.new(provider: Mistri::Providers::Fake.new, tools: [tool])
+      end
+
+      assert_match message, error.message, label
+    end
+  end
+
   def test_tool_subclass_cannot_override_the_agent_core_contract
     subclass = Class.new(Mistri::Tool) do
       def prepared_argument_violations(_arguments) = []

--- a/test/test_tool_lifecycle.rb
+++ b/test/test_tool_lifecycle.rb
@@ -164,8 +164,10 @@ class TestToolLifecycle < Minitest::Test
              Mistri::ToolCall.new(id: "c2", name: "later", arguments: {})]
     events = []
 
-    results = Mistri::ToolExecutor.call(calls, { "exit" => tool, "later" => later },
-                                        max_concurrency: 1, emit: ->(event) { events << event })
+    results = Mistri::ToolExecutor.call_with_outcomes(
+      calls, { "exit" => tool, "later" => later },
+      max_concurrency: 1, emit: ->(event) { events << event }
+    )
 
     assert_equal [:tool_started], events.map(&:type)
     assert_predicate results[0][1], :error?
@@ -174,6 +176,8 @@ class TestToolLifecycle < Minitest::Test
     assert_equal Mistri::ToolExecutor::INTERRUPTED, results[1][1].content
     assert_nil results[0][2]
     assert_nil results[1][2]
+    assert results[0][3], "a committed call has an ambiguous outcome"
+    refute results[1][3], "a queued call never committed"
     refute later_ran
   end
 
@@ -232,13 +236,13 @@ class TestToolLifecycle < Minitest::Test
     run&.join
   end
 
-  def test_result_ordering_does_not_trust_provider_call_ids
+  def test_result_ordering_follows_the_provider_call_order
     first = Mistri::Tool.define("first", "First.") { "first result" }
     second = Mistri::Tool.define("second", "Second.") { "second result" }
     provider = Mistri::Providers::Fake.new(turns: [
-                                             { tool_calls: [{ id: "same", name: "first",
+                                             { tool_calls: [{ id: "first", name: "first",
                                                               arguments: {} },
-                                                            { id: "same", name: "second",
+                                                            { id: "second", name: "second",
                                                               arguments: {} }] },
                                              { text: "done" }
                                            ])

--- a/test/test_tool_result_ui.rb
+++ b/test/test_tool_result_ui.rb
@@ -73,13 +73,15 @@ class TestToolResultUi < Minitest::Test
     )
 
     anthropic = Mistri::Providers::Anthropic::Serializer.messages([legacy])
-    gemini = Mistri::Providers::Gemini::Serializer.contents([legacy])
+    call = Mistri::ToolCall.new(id: "c1", name: "lookup", arguments: {})
+    source = Mistri::Message.assistant(content: [call], provider: :gemini)
+    gemini = Mistri::Providers::Gemini::Serializer.contents([source, legacy])
     openai = Mistri::Providers::OpenAI::Serializer.input_items([legacy])
 
     refute_predicate legacy, :tool_error_known?
     refute anthropic.first[:content].first.key?(:is_error)
     assert_equal({ "result" => "old result" },
-                 gemini.first[:parts].first[:functionResponse][:response])
+                 gemini.last[:parts].first[:functionResponse][:response])
     assert_equal "old result", openai.first[:output]
   end
 


### PR DESCRIPTION
## Summary

- Deep-own and resource-bound completed tool arguments, preserving malformed JSON as typed invalidity instead of manufacturing an executable empty object.
- Compile a provider-neutral JSON Schema 2020-12 subset and enforce it before hooks, approval policy, handoff decisions, local handlers, or bridged MCP tools. Tool-owned normalization and supplemental or complete validators remain explicit host choices; core never coerces.
- Revalidate the exact approved arguments on resume and audit the durable call, result, approval, and provider-correlation history before any side effect can run.
- Derive native structured-output schemas only when the catalogued provider can represent them faithfully; otherwise retain prompt plus local validation.
- Fail closed on malformed provider stream lifecycles, terminal/status conflicts, unsafe Gemini result ordering, refusal and finish-reason verdicts, and oversized or structurally complex SSE records.

## Why

Provider-side schema guidance is not an authorization boundary. A model could previously send a type-confused value that changed an approval predicate, or a provider parser could collapse malformed arguments into `{}` before policy and execution. The gem now gives the declared tool schema one provider-neutral meaning at the exact boundary where model data becomes host authority.

This also makes the surrounding correlation contract trustworthy. Tool IDs, optional provider IDs, block ordering, approvals, and results are validated together so a malformed or legacy transcript cannot launder different arguments into a resumed side effect.

## Public impact

This is minor-release behavior:

- A schema-less `Tool` is a closed no-argument tool. Hosts that consume model fields must declare a schema.
- Supplied object schemas retain JSON Schema default-open behavior unless a raw schema sets `additionalProperties: false`.
- Invalid calls return bounded `ToolResult(error: true)` data the model can correct; no execution-start event or policy hook fires.
- Existing MySQL or Trilogy stores should migrate `payload` to `size: :long`; new generated migrations do so automatically.
- No runtime dependency was added.

The provider capability limits are based on primary documentation: [OpenAI structured-output limits](https://developers.openai.com/api/docs/guides/structured-outputs#objects-have-limitations-on-nesting-depth-and-size), [Anthropic schema complexity limits](https://platform.claude.com/docs/en/build-with-claude/structured-outputs#schema-complexity-limits), and [Gemini JSON Schema support](https://ai.google.dev/gemini-api/docs/structured-output?lang=rest#json-schema-support).

## Validation

- `mise exec -- bundle exec rake test`: 883 runs, 4,571 assertions, 0 failures or errors; 30 expected live/optional skips.
- Coverage: 98.24% lines and 88.10% branches.
- `mise exec -- bundle exec rubocop`: 185 files, no offenses.
- Gem build: 85 packaged files, zero runtime dependencies, isolated install and require on Ruby 3.2.9.
- Live matrix on Claude Haiku 4.5, GPT-5.6 Terra, and Gemini 2.5 Flash: tool flow and stream boundaries, invalid-argument correction, structured output, and JSONL approval resume all pass (12 scenarios, 114 assertions).
- Gemini 3.5 Flash invalid-argument correction passes with nonempty unique provider function-call IDs (1 scenario, 12 assertions).
- Live scalar/tuple fallback, nested freeform tool objects, and foreign-provider Gemini continuation also pass across their applicable provider matrix.
- Adversarial correctness, API, latency, public-gem, and security reviews report no unresolved blockers.

## Deliberately deferred

This does not claim exactly-once execution. A crash after handler commitment but before durable result persistence can still re-execute a side effect, and hosts must still serialize one active runner per session. Durable atomic claiming is the next synchronization feature rather than a mutex hidden inside this validation change.

Closes #1
