### PR TITLE
Tolerate legacy call ID reuse and bridge MCP assertions as guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   errors, and do not prevent valid siblings from running. Results settled in
   the same phase return in model-call order.
   Completed tool-call IDs, names, signatures, and provider correlation IDs must
-  be non-empty UTF-8 strings. Internal IDs are unique for the session, and
-  provider correlation IDs are unique within one assistant turn. A malformed
+  be non-empty UTF-8 strings. Live provider turns require IDs unique for the
+  session, and provider correlation IDs are unique within one assistant turn.
+  A persisted history may reuse an ID across turns once its earlier call was
+  answered, because earlier releases synthesized per-turn IDs ("call_1") for
+  Gemini and the Fake provider; those sessions load and resume unchanged, and
+  the compaction split check still covers every retired holder. Unanswered,
+  open-approval, or same-turn reuse still fails closed. A malformed
   call envelope or a non-assistant provider result rejects the whole provider
   attempt before persistence, policy, or execution. The normal provider retry
   contract retries unchanged history; exhaustion persists a pairable error with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   JSON Schema 2020-12 and require an object root; legacy array-form `items` is
   rejected in favor of `prefixItems`. A schema-less Tool is now a genuinely
   closed no-argument contract; hosts that accepted model fields without
-  declaring them must add an explicit schema. Supplied object schemas preserve
+  declaring them must add an explicit schema. The schema-less wire shape
+  changed with it, so provider prompt caches re-warm once per affected tool
+  set after upgrading. Supplied object schemas preserve
   JSON Schema's default-open semantics unless a raw schema explicitly sets
   `additionalProperties: false`; handlers should extract named fields instead
   of mass-assigning model input. MCP bridging enforces the portable subset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   declaring them must add an explicit schema. Supplied object schemas preserve
   JSON Schema's default-open semantics unless a raw schema explicitly sets
   `additionalProperties: false`; handlers should extract named fields instead
-  of mass-assigning model input. MCP bridging requires the complete validator
-  for every unimplemented standard constraint or applicator, rejects external
-  references and explicit `inputSchema: null`, and still defaults an omitted
-  schema to a no-argument object. Common map schemas work in core. Task mode
+  of mass-assigning model input. MCP bridging enforces the portable subset
+  locally and keeps unimplemented standard assertions as guidance for the
+  server, which the MCP spec obligates to validate its own tool inputs;
+  `strict_schemas: true` refuses such contracts outright, and a complete
+  validator still takes whole-contract authority. External references and
+  explicit `inputSchema: null` are rejected in every mode, an omitted schema
+  still defaults to a no-argument object, and non-empty `patternProperties`
+  still requires complete authority. Common map schemas work in core. Task mode
   rejects assertions and required vocabularies local validation cannot guarantee
   before making a provider request, then shares one deeply frozen strict schema
   between its prompt and compiled local validator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Completed tool-call IDs, names, signatures, and provider correlation IDs must
   be non-empty UTF-8 strings. Live provider turns require IDs unique for the
   session, and provider correlation IDs are unique within one assistant turn.
-  A persisted history may reuse an ID across turns once its earlier call was
-  answered, because earlier releases synthesized per-turn IDs ("call_1") for
-  Gemini and the Fake provider; those sessions load and resume unchanged, and
-  the compaction split check still covers every retired holder. Unanswered,
-  open-approval, or same-turn reuse still fails closed. A malformed
-  call envelope or a non-assistant provider result rejects the whole provider
-  attempt before persistence, policy, or execution. The normal provider retry
-  contract retries unchanged history; exhaustion persists a pairable error with
-  no tool calls. An abort during normalization, validation, policy, or approval
-  evaluation interrupts every uncommitted call and parks no approval. Custom
+  Persisted histories recognize only the `call_N` reuse without provider
+  correlation IDs that earlier releases synthesized for Gemini and the Fake
+  provider, after the prior occurrence was answered or crash-interrupted.
+  Replay, provider metadata, and compaction track each occurrence independently
+  while live IDs remain reserved for the full session. An unsettled reused-ID
+  approval that cannot distinguish its generation becomes an interrupted result
+  rather than executable stale authorization. Every other duplicate ID,
+  malformed call envelope, or non-assistant provider result rejects the whole
+  provider attempt before persistence, policy, or execution. The normal
+  provider retry contract retries unchanged history; exhaustion persists a
+  pairable error with no tool calls. An abort during normalization, validation,
+  policy, or approval evaluation interrupts every uncommitted call and parks no
+  approval. Custom
   providers that emitted missing, blank, non-string, non-UTF-8, or duplicate
   identifiers must correct their completed call contract. Each run or resume
   validates every persisted message and audits call identity in one control-state
@@ -62,7 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   boolean schemas, and boolean or schema-valued `additionalProperties`.
   `argument_validator:` adds domain rules without weakening core;
   `complete_argument_validator:` is separate explicit authority for every
-  non-empty `patternProperties` contract. Tool inputs use
+  argument-applicable non-empty `patternProperties` contract. Tool inputs use
   JSON Schema 2020-12 and require an object root; legacy array-form `items` is
   rejected in favor of `prefixItems`. A schema-less Tool is now a genuinely
   closed no-argument contract; hosts that accepted model fields without
@@ -71,15 +74,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   set after upgrading. Supplied object schemas preserve
   JSON Schema's default-open semantics unless a raw schema explicitly sets
   `additionalProperties: false`; handlers should extract named fields instead
-  of mass-assigning model input. MCP bridging enforces the portable subset
-  locally and keeps unimplemented standard assertions as guidance for the
-  server, which the MCP spec obligates to validate its own tool inputs;
-  `strict_schemas: true` refuses such contracts outright, and a complete
-  validator still takes whole-contract authority. External references and
+  of mass-assigning model input. MCP bridging enforces directly reachable
+  portable constraints locally and keeps unsupported applicator subtrees and
+  other unimplemented standard assertions as guidance for the server, which the
+  MCP spec obligates to validate its own tool inputs. A complete validator takes
+  explicit whole-contract authority when local policy depends on those
+  assertions. External references and
   explicit `inputSchema: null` are rejected in every mode, an omitted schema
-  still defaults to a no-argument object, and non-empty `patternProperties`
-  still requires complete authority. Common map schemas work in core. Task mode
-  rejects assertions and required vocabularies local validation cannot guarantee
+  still defaults to a no-argument object, and argument-applicable non-empty
+  `patternProperties` still requires complete authority. Common map schemas
+  work in core. Task mode rejects assertions local validation cannot guarantee
   before making a provider request, then shares one deeply frozen strict schema
   between its prompt and compiled local validator.
   Providers derive a native constraint only for schema shapes their documented

--- a/README.md
+++ b/README.md
@@ -296,8 +296,12 @@ The preceding assistant message remains the durable provider source. When a
 normalizer changes arguments, the approval stores the exact prepared call the
 human reviewed plus an explicit source marker. `resume` verifies pairing
 metadata and revalidates those approved arguments without rerunning a
-normalizer. Tool-call IDs are session-wide correlation keys; duplicate or
-malformed legacy histories fail before a handler or provider runs. Persisted
+normalizer. Tool-call IDs are session-wide correlation keys; live provider
+turns require session-unique IDs, while a persisted ID may recur across turns
+once its earlier call was answered, the per-turn shape earlier releases wrote
+for Gemini and the Fake provider. Unanswered, open-approval, or same-turn
+reuse and malformed legacy histories fail before a handler or provider runs.
+Persisted
 results must follow one matching call with the same name and settle in call
 order within each direct or approval phase; a compaction boundary cannot hide
 an open approval or split a completed call from its result.

--- a/README.md
+++ b/README.md
@@ -177,8 +177,9 @@ end
 Use `complete_argument_validator:` when a host validator implements the full
 schema. It has the same `(args, schema)` contract, still runs only after core
 passes, and is deliberately distinct from a supplemental validator. Any
-non-empty `patternProperties` requires this explicit authority because core
-cannot enforce a pattern's value schema even when unmatched keys remain open.
+argument-applicable non-empty `patternProperties` requires this explicit
+authority because core cannot enforce a pattern's value schema even when
+unmatched keys remain open.
 The two validator options are mutually exclusive.
 
 Validator errors are bounded before they reach a model; they should still
@@ -297,14 +298,15 @@ normalizer changes arguments, the approval stores the exact prepared call the
 human reviewed plus an explicit source marker. `resume` verifies pairing
 metadata and revalidates those approved arguments without rerunning a
 normalizer. Tool-call IDs are session-wide correlation keys; live provider
-turns require session-unique IDs, while a persisted ID may recur across turns
-once its earlier call was answered, the per-turn shape earlier releases wrote
-for Gemini and the Fake provider. Unanswered, open-approval, or same-turn
-reuse and malformed legacy histories fail before a handler or provider runs.
-Persisted
-results must follow one matching call with the same name and settle in call
-order within each direct or approval phase; a compaction boundary cannot hide
-an open approval or split a completed call from its result.
+turns require session-unique IDs. Replay recognizes only the `call_N` reuse
+without provider correlation IDs that earlier releases wrote for Gemini and
+the Fake provider, and only after the prior occurrence was answered or
+crash-interrupted. Every other duplicate and malformed legacy history fails
+before a handler or provider runs. A reused ID cannot carry stale approval
+forward: an unsettled approval that cannot identify its generation is replayed
+as interrupted. Persisted results must follow one matching call with the same
+name and settle in call order within each direct or approval phase; a compaction
+boundary cannot hide an open approval or split a completed call from its result.
 
 Only one Agent may actively call `run` or `resume` for a session at a time.
 Concurrent appenders such as approval decisions, steers, and worker reports are
@@ -583,11 +585,11 @@ agent = Mistri.agent("claude-opus-4-8", tools: tools)
 Common MCP map input schemas work with Mistri's portable validator through
 schema-valued `additionalProperties`. Standard assertions outside that subset
 (`minimum`, `pattern`, `anyOf`, same-document `$ref`, ...) bridge as guidance:
-Mistri enforces its portable subset locally and the server validates the full
-contract, which the MCP spec already requires of it. Two stricter stances are
-explicit host choices. `strict_schemas: true` refuses to bridge any tool whose
-contract core cannot enforce, and a complete validator takes whole-contract
-authority locally:
+Mistri enforces directly reachable portable constraints locally. Constraints
+inside an unsupported applicator such as `anyOf` remain server guidance as one
+unit, and the server validates the full contract, which the MCP spec already
+requires of it. When host policy must rely on assertions outside the portable
+subset, a complete validator takes explicit whole-contract authority locally:
 
 ```ruby
 tools = Mistri::MCP.tools(
@@ -596,12 +598,13 @@ tools = Mistri::MCP.tools(
 )
 ```
 
-Non-empty `patternProperties` always requires the complete validator, because
-which argument keys are even legal becomes a regex question core will not
-approximate. Omitted MCP `inputSchema` means a no-argument object. Explicit
-`null` and non-object roots are configuration errors. External references are
-rejected in every mode so validation never performs hidden network or file
-resolution.
+Argument-applicable non-empty `patternProperties` requires the complete
+validator because regex matching changes validation and can determine key
+legality in a closed schema. Core will not approximate it. Omitted MCP
+`inputSchema` means a no-argument object. Explicit `null` and non-object roots
+are configuration errors. Mistri currently compiles MCP inputs as JSON Schema
+2020-12 and rejects an explicit older dialect. External references are rejected
+in every mode so validation never performs hidden network or file resolution.
 
 Remote URLs are untrusted input. Mistri accepts public HTTPS destinations by
 default, rejects the whole DNS result when any answer is non-public, and pins an

--- a/README.md
+++ b/README.md
@@ -581,9 +581,13 @@ agent = Mistri.agent("claude-opus-4-8", tools: tools)
 ```
 
 Common MCP map input schemas work with Mistri's portable validator through
-schema-valued `additionalProperties`. Because a remote schema can guard approval
-policy, any standard assertion outside that subset requires the host's explicit,
-zero-coercion complete validator:
+schema-valued `additionalProperties`. Standard assertions outside that subset
+(`minimum`, `pattern`, `anyOf`, same-document `$ref`, ...) bridge as guidance:
+Mistri enforces its portable subset locally and the server validates the full
+contract, which the MCP spec already requires of it. Two stricter stances are
+explicit host choices. `strict_schemas: true` refuses to bridge any tool whose
+contract core cannot enforce, and a complete validator takes whole-contract
+authority locally:
 
 ```ruby
 tools = Mistri::MCP.tools(
@@ -592,10 +596,11 @@ tools = Mistri::MCP.tools(
 )
 ```
 
-Omitted MCP `inputSchema` means a no-argument object. Explicit `null` and
-non-object roots are configuration errors. Same-document `$ref` and
-`$dynamicRef` values are accepted only with a complete validator; external
-references are rejected so validation never performs hidden network or file
+Non-empty `patternProperties` always requires the complete validator, because
+which argument keys are even legal becomes a regex question core will not
+approximate. Omitted MCP `inputSchema` means a no-argument object. Explicit
+`null` and non-object roots are configuration errors. External references are
+rejected in every mode so validation never performs hidden network or file
 resolution.
 
 Remote URLs are untrusted input. Mistri accepts public HTTPS destinations by

--- a/lib/mistri/mcp.rb
+++ b/lib/mistri/mcp.rb
@@ -48,18 +48,23 @@ module Mistri
     # prefix namespaces local names ("linear__create_issue") against
     # collisions, and gates marks tools needing human approval
     # (gates: { "create_issue" => true }, or needs_approval: for all).
+    # strict_schemas: true refuses any tool whose schema carries assertions
+    # the portable validator cannot enforce, instead of bridging them as
+    # server-validated guidance.
     def tools(client, allow: nil, deny: [], prefix: nil, needs_approval: false, gates: {},
-              complete_argument_validator: nil)
+              complete_argument_validator: nil, strict_schemas: false)
       listed = client.tools
       listed = listed.select { |tool| allow.include?(tool["name"]) } if allow
       listed = listed.reject { |tool| deny.include?(tool["name"]) }
       listed.map do |tool|
         bridge(client, tool, prefix: prefix, gate: gates.fetch(tool["name"], needs_approval),
-                             complete_argument_validator: complete_argument_validator)
+                             complete_argument_validator: complete_argument_validator,
+                             strict_schemas: strict_schemas)
       end
     end
 
-    def bridge(client, spec, prefix: nil, gate: false, complete_argument_validator: nil)
+    def bridge(client, spec, prefix: nil, gate: false, complete_argument_validator: nil,
+               strict_schemas: false)
       remote = spec.fetch("name")
       local = prefix ? "#{prefix}__#{remote}" : remote
       if spec.key?("inputSchema") && spec["inputSchema"].nil?
@@ -68,7 +73,7 @@ module Mistri
 
       raw_schema = spec.fetch("inputSchema", EMPTY_INPUT_SCHEMA)
       input_schema = Schema.validate_mcp!(
-        raw_schema, complete: !complete_argument_validator.nil?
+        raw_schema, complete: !complete_argument_validator.nil?, strict: strict_schemas
       )
       Tool.define(local, spec["description"].to_s,
                   input_schema: input_schema,

--- a/lib/mistri/mcp.rb
+++ b/lib/mistri/mcp.rb
@@ -48,23 +48,18 @@ module Mistri
     # prefix namespaces local names ("linear__create_issue") against
     # collisions, and gates marks tools needing human approval
     # (gates: { "create_issue" => true }, or needs_approval: for all).
-    # strict_schemas: true refuses any tool whose schema carries assertions
-    # the portable validator cannot enforce, instead of bridging them as
-    # server-validated guidance.
     def tools(client, allow: nil, deny: [], prefix: nil, needs_approval: false, gates: {},
-              complete_argument_validator: nil, strict_schemas: false)
+              complete_argument_validator: nil)
       listed = client.tools
       listed = listed.select { |tool| allow.include?(tool["name"]) } if allow
       listed = listed.reject { |tool| deny.include?(tool["name"]) }
       listed.map do |tool|
         bridge(client, tool, prefix: prefix, gate: gates.fetch(tool["name"], needs_approval),
-                             complete_argument_validator: complete_argument_validator,
-                             strict_schemas: strict_schemas)
+                             complete_argument_validator: complete_argument_validator)
       end
     end
 
-    def bridge(client, spec, prefix: nil, gate: false, complete_argument_validator: nil,
-               strict_schemas: false)
+    def bridge(client, spec, prefix: nil, gate: false, complete_argument_validator: nil)
       remote = spec.fetch("name")
       local = prefix ? "#{prefix}__#{remote}" : remote
       if spec.key?("inputSchema") && spec["inputSchema"].nil?
@@ -73,7 +68,7 @@ module Mistri
 
       raw_schema = spec.fetch("inputSchema", EMPTY_INPUT_SCHEMA)
       input_schema = Schema.validate_mcp!(
-        raw_schema, complete: !complete_argument_validator.nil?, strict: strict_schemas
+        raw_schema, complete: !complete_argument_validator.nil?
       )
       Tool.define(local, spec["description"].to_s,
                   input_schema: input_schema,

--- a/lib/mistri/providers/gemini/serializer.rb
+++ b/lib/mistri/providers/gemini/serializer.rb
@@ -19,16 +19,15 @@ module Mistri
         module_function
 
         def contents(history)
-          origins = tool_call_origins(history)
-          wire_ids = provider_call_ids(history)
+          result_metadata = tool_result_metadata(history)
           groups = history.reject(&:system?).chunk_while do |a, b|
-            a.tool? && b.tool? && native_tool_result?(a, origins) ==
-              native_tool_result?(b, origins)
+            a.tool? && b.tool? && native_tool_result?(a, result_metadata) ==
+              native_tool_result?(b, result_metadata)
           end
           groups.filter_map do |group|
             if group.first.tool?
-              if native_tool_result?(group.first, origins)
-                tool_turn(group, wire_ids)
+              if native_tool_result?(group.first, result_metadata)
+                tool_turn(group, result_metadata)
               else
                 foreign_tool_turn(group)
               end
@@ -62,7 +61,7 @@ module Mistri
 
         # Gemini pairs a functionResponse to its call by NAME; a wrong name
         # silently mismatches, so a missing one fails loudly instead.
-        def tool_turn(group, wire_ids = {})
+        def tool_turn(group, result_metadata = {}.compare_by_identity)
           { role: "user", parts: group.map do |msg|
             unless msg.tool_name
               raise SchemaError, "Gemini tool results need tool_name to pair with their call"
@@ -70,7 +69,8 @@ module Mistri
 
             key = msg.tool_error? ? "error" : "result"
             response = { name: msg.tool_name, response: { key => result_text(msg) } }
-            response[:id] = wire_ids[msg.tool_call_id] if wire_ids[msg.tool_call_id]
+            wire_id = result_metadata.dig(msg, :provider_call_id)
+            response[:id] = wire_id if wire_id
             { functionResponse: response }
           end }
         end
@@ -135,26 +135,28 @@ module Mistri
                   "(call #{JSON.generate(block.id)}) with arguments: #{arguments}" }
         end
 
-        def native_tool_result?(message, origins)
-          origins[message.tool_call_id] == :gemini
+        def native_tool_result?(message, result_metadata)
+          result_metadata.dig(message, :provider) == :gemini
         end
 
-        def tool_call_origins(history)
-          history.each_with_object({}) do |message, origins|
-            next unless message.assistant?
-
-            message.tool_calls.each { |call| origins[call.id] = message.provider }
-          end
-        end
-
-        def provider_call_ids(history)
-          history.each_with_object({}) do |message, ids|
-            next unless message.assistant? && message.provider == :gemini
-
-            message.tool_calls.each do |call|
-              ids[call.id] = call.provider_call_id if call.provider_call_id
+        # Legacy histories may reuse call_N across turns. Correlating each
+        # result to the nearest preceding occurrence keeps a later Gemini call
+        # from rewriting an earlier foreign result's wire semantics.
+        def tool_result_metadata(history)
+          pending = Hash.new { |calls, id| calls[id] = [] }
+          metadata = {}.compare_by_identity
+          history.each do |message|
+            if message.assistant?
+              message.tool_calls.each do |call|
+                pending[call.id] << { provider: message.provider,
+                                      provider_call_id: call.provider_call_id }.freeze
+              end
+            elsif message.tool?
+              matched = pending[message.tool_call_id].pop
+              metadata[message] = matched if matched
             end
           end
+          metadata
         end
 
         def signed(part, signature, own)

--- a/lib/mistri/schema.rb
+++ b/lib/mistri/schema.rb
@@ -84,16 +84,14 @@ module Mistri
         Compiled.new(schema, tool: true, complete: complete)
       end
 
-      # MCP schemas get the same stance as host-authored tools: the portable
-      # subset is enforced locally and other standard assertions stay provider
-      # guidance, because the MCP spec already obligates the server to validate
-      # its own tool inputs. strict: true refuses any contract core cannot
-      # enforce; complete: true hands the whole contract to the host validator.
-      # External references are rejected in every mode.
-      def validate_mcp!(schema, complete: false, strict: false)
+      # MCP schemas get the same stance as host-authored tools: directly
+      # reachable portable constraints are enforced locally, while unsupported
+      # applicator subtrees stay server guidance. Complete validators own the
+      # whole local contract; external references are rejected in either mode.
+      def validate_mcp!(schema, complete: false)
         compiled = Compiled.new(schema, tool: true, complete: complete)
         AssertionContract.new(complete:, context: "MCP input schema",
-                              enforce: strict).call(compiled.schema)
+                              allow_guidance: true).call(compiled.schema)
         compiled.schema
       end
 
@@ -389,6 +387,7 @@ module Mistri
         validate_prefix_items(schema, path)
         validate_additional_properties(schema, path)
         validate_dependent_required(schema, path)
+        validate_dependencies(schema, path)
         SCHEMA_MAPS.each { |keyword| validate_schema_map(schema, keyword, path) }
         SCHEMA_ARRAYS.each { |keyword| validate_schema_array(schema, keyword, path) }
         SCHEMA_VALUES.each { |keyword| validate_schema_value(schema, keyword, path) }
@@ -546,6 +545,22 @@ module Mistri
         end
       end
 
+      def validate_dependencies(spec, path)
+        return unless spec.key?("dependencies")
+
+        dependencies = spec["dependencies"]
+        configuration!("#{path}.dependencies", "must be an object") unless dependencies.is_a?(Hash)
+        dependencies.each do |key, member|
+          member_path = ValidationSupport.child_path("#{path}.dependencies", key)
+          if member.is_a?(Array)
+            valid = member.all?(String) && member.uniq == member
+            configuration!(member_path, "must be a schema or array of unique strings") unless valid
+          else
+            walk_schema(member, member_path)
+          end
+        end
+      end
+
       def validate_schema_map(spec, keyword, path)
         return unless spec.key?(keyword)
 
@@ -626,9 +641,11 @@ module Mistri
         not if then else contains propertyNames unevaluatedProperties
         unevaluatedItems additionalProperties items
       ].freeze
+      REFERENCE_SCHEMA_VALUES = [*SCHEMA_VALUES, "contentSchema"].freeze
 
-      def call(schema)
+      def call(schema, references_only: false)
         @findings = []
+        @references_only = references_only
         walk(schema, "$")
         @findings.freeze
       end
@@ -642,20 +659,16 @@ module Mistri
         walk_maps(schema, path)
         walk_arrays(schema, path)
         walk_values(schema, path)
+        walk_dependencies(schema, path)
       end
 
       def record_assertions(schema, path)
-        ASSERTIONS.each do |keyword|
+        keywords = @references_only ? %w[$ref $dynamicRef] : ASSERTIONS
+        keywords.each do |keyword|
           next unless schema.key?(keyword)
           next if ignorable_empty_map?(schema, keyword)
 
           @findings << ["#{path}.#{keyword}".freeze, keyword, schema[keyword]].freeze
-        end
-        schema.fetch("$vocabulary", {}).each do |uri, required|
-          next unless required
-
-          vocabulary_path = ValidationSupport.child_path("#{path}.$vocabulary", uri)
-          @findings << [vocabulary_path.freeze, "$vocabulary", uri].freeze
         end
       end
 
@@ -684,29 +697,38 @@ module Mistri
       end
 
       def walk_values(schema, path)
-        SCHEMA_VALUES.each do |keyword|
+        values = @references_only ? REFERENCE_SCHEMA_VALUES : SCHEMA_VALUES
+        values.each do |keyword|
           member = schema[keyword]
           walk(member, "#{path}.#{keyword}") if member.is_a?(Hash)
+        end
+      end
+
+      def walk_dependencies(schema, path)
+        schema.fetch("dependencies", {}).each do |key, member|
+          next if member.is_a?(Array)
+
+          walk(member, ValidationSupport.child_path("#{path}.dependencies", key))
         end
       end
     end
     private_constant :AssertionScanner
 
-    # Unsupported assertions are safe as generation guidance, but not as a
-    # claimed validation boundary; enforce is the caller's stance on refusing
-    # them outright. External references are rejected in every mode so
-    # validation never implies hidden network or file resolution.
+    # Unsupported assertions are safe as MCP server guidance, but not as a
+    # claimed local validation boundary. External references are rejected in
+    # every mode so validation never implies hidden network or file resolution.
     class AssertionContract
-      def initialize(complete:, context:, enforce: true)
+      def initialize(complete:, context:, allow_guidance: false)
         @complete = complete
         @context = context
-        @enforce = enforce
+        @allow_guidance = allow_guidance
       end
 
       def call(schema)
         findings = AssertionScanner.new.call(schema)
-        reject_external_references(findings)
-        return if @complete || !@enforce || findings.empty?
+        references = AssertionScanner.new.call(schema, references_only: true)
+        reject_external_references(references)
+        return if @complete || @allow_guidance || findings.empty?
 
         paths = findings.first(3).map(&:first).join(", ")
         suffix = findings.length > 3 ? ", and #{findings.length - 3} more" : ""
@@ -718,12 +740,12 @@ module Mistri
 
       def reject_external_references(findings)
         finding = findings.find do |(_, keyword, value)|
-          %w[$ref $dynamicRef].include?(keyword) && !value.start_with?("#")
+          %w[$ref $dynamicRef].include?(keyword) && !value.empty? && !value.start_with?("#")
         end
         return unless finding
 
         raise ConfigurationError,
-              "#{finding.first} must be a same-document reference beginning with #"
+              "#{finding.first} must be empty or a same-document reference beginning with #"
       end
     end
     private_constant :AssertionContract
@@ -781,6 +803,11 @@ module Mistri
         end
         items = spec["items"]
         block.call(items, ValidationSupport.item_path(path)) if items.is_a?(Hash)
+        spec.fetch("dependencies", {}).each do |key, member|
+          next if member.is_a?(Array)
+
+          block.call(member, ValidationSupport.child_path("#{path}.dependencies", key))
+        end
       end
 
       def configuration!(path, problem)

--- a/lib/mistri/schema.rb
+++ b/lib/mistri/schema.rb
@@ -84,12 +84,16 @@ module Mistri
         Compiled.new(schema, tool: true, complete: complete)
       end
 
-      # MCP schemas are untrusted contracts. Core may preserve unsupported
-      # assertions as provider guidance for host-authored tools, but a remote
-      # schema needs an explicitly complete validator before policy can trust it.
-      def validate_mcp!(schema, complete: false)
+      # MCP schemas get the same stance as host-authored tools: the portable
+      # subset is enforced locally and other standard assertions stay provider
+      # guidance, because the MCP spec already obligates the server to validate
+      # its own tool inputs. strict: true refuses any contract core cannot
+      # enforce; complete: true hands the whole contract to the host validator.
+      # External references are rejected in every mode.
+      def validate_mcp!(schema, complete: false, strict: false)
         compiled = Compiled.new(schema, tool: true, complete: complete)
-        AssertionContract.new(complete:, context: "MCP input schema").call(compiled.schema)
+        AssertionContract.new(complete:, context: "MCP input schema",
+                              enforce: strict).call(compiled.schema)
         compiled.schema
       end
 
@@ -688,18 +692,21 @@ module Mistri
     end
     private_constant :AssertionScanner
 
-    # Unsupported assertions are safe as generation guidance for a local Tool,
-    # but not as a claimed validation or remote-policy boundary.
+    # Unsupported assertions are safe as generation guidance, but not as a
+    # claimed validation boundary; enforce is the caller's stance on refusing
+    # them outright. External references are rejected in every mode so
+    # validation never implies hidden network or file resolution.
     class AssertionContract
-      def initialize(complete:, context:)
+      def initialize(complete:, context:, enforce: true)
         @complete = complete
         @context = context
+        @enforce = enforce
       end
 
       def call(schema)
         findings = AssertionScanner.new.call(schema)
         reject_external_references(findings)
-        return if @complete || findings.empty?
+        return if @complete || !@enforce || findings.empty?
 
         paths = findings.first(3).map(&:first).join(", ")
         suffix = findings.length > 3 ? ", and #{findings.length - 3} more" : ""

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -190,10 +190,7 @@ module Mistri
       parsed_calls = message.tool_calls
       tool_calls_from(entry).each_with_index do |call, position|
         id = validated_persisted_call(call)
-        if reserved.include?(id)
-          raise ConfigurationError, "session contains a duplicate tool call ID"
-        end
-
+        retire_reused_call!(id, calls, reserved, audit)
         owned = id.dup.freeze
         source_call = parsed_calls.fetch(position)
         provider_id = source_call.provider_call_id
@@ -214,11 +211,28 @@ module Mistri
       end
     end
 
+    # Releases before the identity audit synthesized per-turn call IDs
+    # ("call_1") for Gemini and the Fake provider, so reuse across turns is
+    # the durable norm in legacy histories. Reuse is safe only once the prior
+    # holder was answered: an open, decided, or crash-interrupted holder makes
+    # result pairing and approval references ambiguous, and live turns still
+    # require session-unique IDs at the provider envelope.
+    def retire_reused_call!(id, calls, reserved, audit)
+      return unless reserved.include?(id)
+
+      prior = calls[id]
+      unless prior && prior[:status] == :answered
+        raise ConfigurationError, "session contains a duplicate tool call ID"
+      end
+
+      audit.fetch(:retired) << prior
+    end
+
     def audit_history(log)
       calls = {}
       unresolved = Set.new
       reserved = Set.new
-      audit = { calls:, unresolved:, reserved: }
+      audit = { calls:, unresolved:, reserved:, retired: [] }
       latest_compaction = nil
 
       log.each_with_index do |entry, index|
@@ -243,7 +257,7 @@ module Mistri
       end
 
       approvals = open_approval_states(calls)
-      validate_compaction!(calls, approvals, latest_compaction)
+      validate_compaction!(audit, approvals, latest_compaction)
       { tool_call_ids: reserved, approvals: }
     end
 
@@ -424,7 +438,7 @@ module Mistri
       end
     end
 
-    def validate_compaction!(calls, approvals, compaction)
+    def validate_compaction!(audit, approvals, compaction)
       return unless compaction
 
       kept_from = compaction["kept_from"]
@@ -435,7 +449,8 @@ module Mistri
         raise ConfigurationError, "session contains an open approval whose assistant tool call " \
                                   "was removed by compaction"
       end
-      split = calls.values.any? do |state|
+      states = audit.fetch(:calls).values + audit.fetch(:retired)
+      split = states.any? do |state|
         state[:result_index] && state[:source_index] < kept_from &&
           state[:result_index] >= kept_from
       end

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -58,6 +58,9 @@ module Mistri
     # What a run killed mid-tool answers in place of the result it never got.
     INTERRUPTED_RESULT = "[interrupted: the run stopped before this result was persisted; " \
                          "the tool may have executed, so verify its effects before retrying]"
+    LEGACY_CALL_ID = /\Acall_[1-9]\d*\z/
+    LEGACY_CALL_PROVIDERS = %i[fake gemini].freeze
+    private_constant :LEGACY_CALL_ID, :LEGACY_CALL_PROVIDERS
 
     # Replay messages paired with the entry index each came from, starting at
     # the latest compaction boundary. The synthetic summary message carries a
@@ -190,9 +193,9 @@ module Mistri
       parsed_calls = message.tool_calls
       tool_calls_from(entry).each_with_index do |call, position|
         id = validated_persisted_call(call)
-        retire_reused_call!(id, calls, reserved, audit)
-        owned = id.dup.freeze
         source_call = parsed_calls.fetch(position)
+        reused = reused_legacy_call(id, source_call, message.provider, calls, reserved)
+        owned = id.dup.freeze
         provider_id = source_call.provider_call_id
         if provider_id && batch[:provider_call_ids].key?(provider_id)
           raise ConfigurationError, "session contains a duplicate provider tool call ID"
@@ -203,36 +206,41 @@ module Mistri
                   source_provider: message.provider,
                   source_stop_reason: message.stop_reason,
                   source_index: index, source_position: position,
-                  batch:, status: :pending }
+                  batch:, status: :pending, reused: !reused.nil? }
         calls[owned] = state
         batch[:calls] << state
+        audit.fetch(:states) << state
         unresolved << owned
         reserved << owned
       end
     end
 
-    # Releases before the identity audit synthesized per-turn call IDs
-    # ("call_1") for Gemini and the Fake provider, so reuse across turns is
-    # the durable norm in legacy histories. Reuse is safe only once the prior
-    # holder was answered: an open, decided, or crash-interrupted holder makes
-    # result pairing and approval references ambiguous, and live turns still
-    # require session-unique IDs at the provider envelope.
-    def retire_reused_call!(id, calls, reserved, audit)
-      return unless reserved.include?(id)
+    # Gemini and Fake once synthesized call_N from a per-turn counter. Only
+    # that known shape without provider correlation IDs may repeat; widening
+    # the exception would turn the session correlation key back into a guess.
+    def reused_legacy_call(id, source_call, provider, calls, reserved)
+      return nil unless reserved.include?(id)
 
       prior = calls[id]
-      unless prior && prior[:status] == :answered
+      safe_status = prior && %i[answered interrupted].include?(prior[:status])
+      legacy_shape = LEGACY_CALL_ID.match?(id) && LEGACY_CALL_PROVIDERS.include?(provider) &&
+                     LEGACY_CALL_PROVIDERS.include?(prior&.fetch(:source_provider, nil)) &&
+                     source_call.provider_call_id.nil? &&
+                     prior&.fetch(:source_call)&.provider_call_id.nil?
+      unless safe_status && legacy_shape
         raise ConfigurationError, "session contains a duplicate tool call ID"
       end
 
-      audit.fetch(:retired) << prior
+      prior
     end
 
     def audit_history(log)
       calls = {}
       unresolved = Set.new
       reserved = Set.new
-      audit = { calls:, unresolved:, reserved:, retired: [] }
+      states = []
+      approval_ids = Set.new
+      audit = { calls:, unresolved:, reserved:, states:, approval_ids: }
       latest_compaction = nil
 
       log.each_with_index do |entry, index|
@@ -248,7 +256,7 @@ module Mistri
           close_unsettled_calls(calls, unresolved)
           record_assistant_calls(entry, message, index, audit) if message.assistant?
         elsif entry["type"] == "approval_request"
-          record_approval_call(entry, calls)
+          record_approval_call(entry, calls, audit)
         elsif entry["type"] == "approval_decision"
           record_approval_decision(entry, calls)
         elsif entry["type"] == "compaction"
@@ -256,7 +264,8 @@ module Mistri
         end
       end
 
-      approvals = open_approval_states(calls)
+      interrupt_ambiguous_reused_approvals!(states)
+      approvals = open_approval_states(states)
       validate_compaction!(audit, approvals, latest_compaction)
       { tool_call_ids: reserved, approvals: }
     end
@@ -326,6 +335,11 @@ module Mistri
     def close_unsettled_calls(calls, unresolved)
       unresolved.each do |id|
         state = calls.fetch(id)
+        if state[:ambiguous_approval] &&
+           %i[approval_requested decided].include?(state[:status])
+          state[:status] = :interrupted
+          next
+        end
         unless state[:status] == :pending
           raise ConfigurationError, "session continues past an unsettled approval"
         end
@@ -335,7 +349,7 @@ module Mistri
       unresolved.clear
     end
 
-    def record_approval_call(entry, calls)
+    def record_approval_call(entry, calls, audit)
       call = entry["call"]
       unless call.is_a?(Hash)
         raise ConfigurationError, "session contains an invalid approval request"
@@ -369,6 +383,8 @@ module Mistri
       state[:batch][:approval_phase_started] = true
       state[:status] = :approval_requested
       state[:approval] = { call:, decision: nil, source_index: state[:source_index] }
+      state[:ambiguous_approval] = state[:reused] && audit.fetch(:approval_ids).include?(id)
+      audit.fetch(:approval_ids) << id
     end
 
     def validate_approval_provenance!(entry, call, state)
@@ -432,8 +448,20 @@ module Mistri
       state[:status] = :decided
     end
 
-    def open_approval_states(calls)
-      calls.values.filter_map do |state|
+    # An old decision names only call_N. Once that ID has already participated
+    # in approval, a later unsettled approval cannot prove which generation a
+    # delayed decision intended, so replay it as interrupted rather than risk
+    # executing a side effect under stale authorization.
+    def interrupt_ambiguous_reused_approvals!(states)
+      states.each do |state|
+        if state[:ambiguous_approval] && %i[approval_requested decided].include?(state[:status])
+          state[:status] = :interrupted
+        end
+      end
+    end
+
+    def open_approval_states(states)
+      states.filter_map do |state|
         state[:approval] if %i[approval_requested decided].include?(state[:status])
       end
     end
@@ -449,8 +477,7 @@ module Mistri
         raise ConfigurationError, "session contains an open approval whose assistant tool call " \
                                   "was removed by compaction"
       end
-      states = audit.fetch(:calls).values + audit.fetch(:retired)
-      split = states.any? do |state|
+      split = audit.fetch(:states).any? do |state|
         state[:result_index] && state[:source_index] < kept_from &&
           state[:result_index] >= kept_from
       end
@@ -546,32 +573,99 @@ module Mistri
       compaction = log.reverse_each.find { |entry| entry["type"] == "compaction" }
       from = compaction ? compaction["kept_from"] : 0
       pairs = log.each_with_index.filter_map do |entry, index|
-        [Message.from_h(entry["message"]), index] if index >= from && entry["type"] == "message"
+        next unless index >= from && entry["type"] == "message"
+
+        [Message.from_h(entry["message"]), index]
       end
-      pairs = heal(pairs, parked_call_ids(log))
+      pairs = heal(pairs, replay_call_states(log, from:))
       compaction ? [[summary_message(compaction["summary"]), nil], *pairs] : pairs
     end
 
-    def heal(pairs, parked)
-      answered = pairs.map(&:first).select(&:tool?).to_set(&:tool_call_id)
+    # Replay only needs occurrence pairing, not the authorization audit. Keep
+    # it tolerant enough to render a rejected history while still ensuring a
+    # reused call_N cannot borrow an earlier result or approval.
+    def replay_call_states(log, from:)
+      replay = { active: {}, seen: Set.new, approval_ids: Set.new, states: [], from: }
+      log.each_with_index do |entry, index|
+        if entry["type"] == "message"
+          track_replay_message(entry, index, replay)
+        else
+          track_replay_control(entry, replay)
+        end
+      end
+      replay.fetch(:states).each do |state|
+        next unless state[:ambiguous_approval]
+        next unless %i[approval_requested decided].include?(state[:status])
+
+        state[:status] = :interrupted
+      end
+    end
+
+    def track_replay_message(entry, index, replay)
+      role = entry.dig("message", "role").to_s
+      if role == "assistant"
+        tool_calls_from(entry).each_with_index do |call, position|
+          id = call["id"]
+          state = { source_index: index, source_position: position, status: :pending,
+                    reused: replay.fetch(:seen).include?(id), approval: false }
+          replay.fetch(:states) << state if index >= replay.fetch(:from)
+          replay.fetch(:active)[id] = state
+          replay.fetch(:seen) << id
+        end
+      elsif role == "tool" &&
+            (state = replay.fetch(:active).delete(entry.dig("message", "tool_call_id")))
+        state[:status] = :answered
+        state[:result_index] = index
+      end
+    end
+
+    def track_replay_control(entry, replay)
+      if entry["type"] == "approval_request"
+        id = entry.dig("call", "id")
+        return unless (state = replay.fetch(:active)[id])
+
+        state[:status] = :approval_requested
+        state[:approval] = true
+        state[:ambiguous_approval] = state[:reused] && replay.fetch(:approval_ids).include?(id)
+        replay.fetch(:approval_ids) << id
+      elsif entry["type"] == "approval_decision"
+        state = replay.fetch(:active)[entry["call_id"]]
+        state[:status] = :decided if state&.dig(:status) == :approval_requested
+      end
+    end
+
+    def heal(pairs, states)
+      by_source = states.group_by { |state| state[:source_index] }
+      by_result = pairs.to_h { |message, index| [index, [message, index]] }
+      consumed = states.filter_map { |state| state[:result_index] }.to_set
       pairs.flat_map do |message, index|
-        dangling = if message.assistant?
-                     message.tool_calls.reject do |call|
-                       answered.include?(call.id) || parked.include?(call.id)
-                     end
-                   else
-                     []
-                   end
-        [[message, index]] + dangling.map do |call|
-          [Message.tool(content: INTERRUPTED_RESULT, tool_call_id: call.id,
-                        tool_name: call.name, tool_error: true), nil]
+        next [] if consumed.include?(index)
+
+        batch = by_source[index]
+        next [[message, index]] unless message.assistant? && batch
+
+        [[message, index], *healed_results(message, batch, by_result)]
+      end
+    end
+
+    def healed_results(message, states, by_result)
+      calls = message.tool_calls
+      [false, true].flat_map do |approval_phase|
+        states.select { |state| state[:approval] == approval_phase }
+              .sort_by { |state| state[:source_position] }
+              .filter_map do |state|
+          if state[:status] == :answered
+            by_result.fetch(state[:result_index])
+          elsif !approval_phase || state[:status] == :interrupted
+            interrupted_pair(calls.fetch(state[:source_position]))
+          end
         end
       end
     end
 
-    def parked_call_ids(log)
-      log.filter_map { |entry| entry.dig("call", "id") if entry["type"] == "approval_request" }
-         .to_set
+    def interrupted_pair(call)
+      [Message.tool(content: INTERRUPTED_RESULT, tool_call_id: call.id,
+                    tool_name: call.name, tool_error: true), nil]
     end
 
     def summary_message(summary)

--- a/test/test_gemini_live.rb
+++ b/test/test_gemini_live.rb
@@ -101,4 +101,46 @@ class TestGeminiLive < Minitest::Test
   ensure
     provider&.close
   end
+
+  def test_reused_legacy_ids_preserve_each_results_wire_origin
+    provider = Mistri::Providers::Gemini.new(api_key: ENV.fetch("GEMINI_API_KEY"))
+    lookup = { name: "lookup", description: "Looks up one record.",
+               input_schema: { type: "object", properties: { record: { type: "string" } },
+                               required: ["record"] } }
+    generated = provider.stream(
+      messages: [Mistri::Message.user("Call lookup with record two. No prose.")],
+      tools: [lookup]
+    ) { |_event| nil }
+
+    assert_equal :tool_use, generated.stop_reason
+
+    current = generated.tool_calls.fetch(0)
+    legacy_native = Mistri::ToolCall.new(id: "call_1", name: current.name,
+                                         arguments: current.arguments,
+                                         signature: current.signature)
+    foreign = Mistri::ToolCall.new(id: "call_1", name: "lookup", arguments: { "record" => "one" })
+    first_fact = "first-#{SecureRandom.hex(4)}"
+    second_fact = "second-#{SecureRandom.hex(4)}"
+    history = [
+      Mistri::Message.user("Look up record one."),
+      Mistri::Message.assistant(content: [foreign], provider: :fake,
+                                stop_reason: :tool_use),
+      Mistri::Message.tool(content: first_fact, tool_call_id: foreign.id,
+                           tool_name: foreign.name),
+      Mistri::Message.user("Now look up record two."),
+      Mistri::Message.assistant(content: [legacy_native], provider: :gemini,
+                                stop_reason: :tool_use),
+      Mistri::Message.tool(content: second_fact, tool_call_id: legacy_native.id,
+                           tool_name: legacy_native.name),
+      Mistri::Message.user("Return both exact lookup results, separated by one space.")
+    ]
+
+    message = provider.stream(messages: history, tools: [lookup]) { |_event| nil }
+
+    assert_equal :stop, message.stop_reason
+    assert_includes message.text, first_fact
+    assert_includes message.text, second_fact
+  ensure
+    provider&.close
+  end
 end

--- a/test/test_gemini_serializer.rb
+++ b/test/test_gemini_serializer.rb
@@ -85,6 +85,30 @@ class TestGeminiSerializer < Minitest::Test
     assert contents[-1][:parts].first.key?(:text)
   end
 
+  def test_reused_legacy_ids_keep_result_metadata_with_their_own_occurrence
+    foreign_call = Mistri::ToolCall.new(id: "call_1", name: "first", arguments: {})
+    gemini_call = Mistri::ToolCall.new(id: "call_1", name: "second", arguments: {})
+    foreign_result = Mistri::Message.tool(content: "foreign", tool_call_id: "call_1",
+                                          tool_name: "first")
+    gemini_result = Mistri::Message.tool(content: "native", tool_call_id: "call_1",
+                                         tool_name: "second")
+    history = [
+      Mistri::Message.assistant(content: [foreign_call], provider: :fake),
+      foreign_result,
+      Mistri::Message.assistant(content: [gemini_call], provider: :gemini),
+      gemini_result
+    ]
+
+    contents = SERIALIZER.contents(history)
+    first_response = contents[1][:parts].first
+    second_response = contents[3][:parts].first[:functionResponse]
+
+    assert first_response.key?(:text), "the earlier Fake result remains provider-neutral"
+    refute first_response.key?(:functionResponse)
+    refute second_response.key?(:id)
+    assert_equal "second", second_response[:name]
+  end
+
   def test_a_tool_result_without_a_tool_name_fails_loudly
     result = Mistri::Message.tool(content: "found", tool_call_id: "c1")
 

--- a/test/test_legacy_session_live.rb
+++ b/test/test_legacy_session_live.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "securerandom"
+
+# A literal pre-0.6 repeated-ID history must remain a valid continuation on
+# every provider, not merely pass Mistri's local audit.
+class TestLegacySessionLive < Minitest::Test
+  def setup
+    skip "set MISTRI_LIVE=1 for live tests" unless ENV["MISTRI_LIVE"] == "1"
+  end
+
+  def test_anthropic_accepts_a_legacy_repeated_id_continuation
+    skip "no ANTHROPIC_API_KEY" if ENV["ANTHROPIC_API_KEY"].to_s.empty?
+
+    with_provider(Mistri::Providers::Anthropic.new(
+                    api_key: ENV.fetch("ANTHROPIC_API_KEY")
+                  )) { |provider| assert_legacy_continuation(provider) }
+  end
+
+  def test_openai_accepts_a_legacy_repeated_id_continuation
+    skip "no OPENAI_API_KEY" if ENV["OPENAI_API_KEY"].to_s.empty?
+
+    with_provider(Mistri::Providers::OpenAI.new(
+                    api_key: ENV.fetch("OPENAI_API_KEY")
+                  )) { |provider| assert_legacy_continuation(provider) }
+  end
+
+  private
+
+  def with_provider(provider)
+    yield provider
+  ensure
+    provider.close
+  end
+
+  def assert_legacy_continuation(provider)
+    first = "first-#{SecureRandom.hex(4)}"
+    second = "second-#{SecureRandom.hex(4)}"
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    append_exchange(session, provider: :fake, result: first)
+    append_exchange(session, provider: :gemini, result: second)
+    session.append_message(Mistri::Message.user(
+                             "Return both exact historical tool results separated by one space."
+                           ))
+
+    message = provider.stream(messages: session.messages) { |_event| nil }
+
+    assert_equal :stop, message.stop_reason
+    assert_includes message.text, first
+    assert_includes message.text, second
+  end
+
+  def append_exchange(session, provider:, result:)
+    call = Mistri::ToolCall.new(id: "call_1", name: "lookup", arguments: {})
+    session.append_message(Mistri::Message.assistant(tool_calls: [call], provider:,
+                                                     stop_reason: :tool_use))
+    session.append_message(Mistri::Message.tool(content: result, tool_call_id: call.id,
+                                                tool_name: call.name))
+  end
+end

--- a/test/test_legacy_tool_call_identity.rb
+++ b/test/test_legacy_tool_call_identity.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Legacy compatibility is exact: old Gemini/Fake call_N histories remain
+# usable without weakening the unique correlation IDs every new turn reserves.
+class TestLegacyToolCallIdentity < Minitest::Test
+  def test_settled_ids_reuse_across_turns_and_the_session_still_runs
+    session = new_session
+    session.append_message(Mistri::Message.user("look twice"))
+    2.times { |round| append_answered_call(session, "call_1", result: "ok #{round}") }
+    ran = false
+    tool = Mistri::Tool.define("write", "Write.") do
+      ran = true
+      "written"
+    end
+    turns = [{ tool_calls: [{ id: "fresh-1", name: "write", arguments: {} }] }, { text: "done" }]
+    agent = Mistri::Agent.new(provider: Mistri::Providers::Fake.new(turns:), tools: [tool],
+                              session:)
+
+    assert_empty session.open_approvals
+    assert_equal Set["call_1"], session.tool_call_ids
+
+    result = agent.run("continue")
+
+    assert_predicate result, :completed?
+    assert ran, "a run on top of the legacy history executes normally"
+    assert_equal 3, session.messages.count(&:tool?)
+    assert_equal Set["call_1", "fresh-1"], session.tool_call_ids
+  end
+
+  def test_a_call_id_may_be_reused_after_its_approval_settled
+    session = new_session
+    call = append_legacy_call(session, "call_1")
+    session.append("approval_request", "call" => call.to_h)
+    session.append("approval_decision", "call_id" => call.id, "approved" => true)
+    append_result(session, call, "written")
+    append_answered_call(session, "call_1")
+
+    assert_empty session.open_approvals
+    assert_equal Set["call_1"], session.tool_call_ids
+  end
+
+  def test_only_the_known_wireless_gemini_and_fake_shape_may_reuse_ids
+    cases = [
+      ["custom", :gemini, nil],
+      ["call_1", :openai, nil],
+      ["call_1", nil, nil],
+      ["call_1", :gemini, "wire-1"]
+    ]
+    cases.each do |id, provider, wire_id|
+      session = new_session
+      append_answered_call(session, id, provider:, provider_call_id: wire_id)
+      append_answered_call(session, id, provider:, provider_call_id: wire_id && "wire-2")
+
+      error = assert_raises(Mistri::ConfigurationError) { session.tool_call_ids }
+
+      assert_match(/duplicate tool call ID/, error.message)
+    end
+  end
+
+  def test_replay_heals_the_later_occurrence_after_an_answered_id
+    session = new_session
+    append_answered_call(session, "call_1", result: "first")
+    append_legacy_call(session, "call_1")
+
+    results = session.messages.select(&:tool?)
+    healthy = results.filter_map { |message| message.text unless message.tool_error? }
+    interrupted = results.filter_map { |message| message.text if message.tool_error? }
+
+    assert_equal %w[first], healthy
+    assert_equal [Mistri::Session::INTERRUPTED_RESULT], interrupted
+    assert_equal Set["call_1"], session.tool_call_ids
+  end
+
+  def test_replay_heals_an_interrupted_occurrence_before_a_later_answer
+    session = new_session
+    append_legacy_call(session, "call_1")
+    session.append_message(Mistri::Message.user("continue after the crash"))
+    append_answered_call(session, "call_1", provider: :fake, result: "second")
+
+    results = session.messages.select(&:tool?)
+
+    assert_equal [Mistri::Session::INTERRUPTED_RESULT, "second"], results.map(&:text)
+    assert_predicate results.first, :tool_error?
+    refute_predicate results.last, :tool_error?
+    assert_equal Set["call_1"], session.tool_call_ids
+  end
+
+  def test_literal_v05_fake_to_gemini_history_keeps_result_origins_separate
+    session = new_session
+    append_v05_exchange(session, provider: "fake", name: "first", result: "foreign")
+    append_v05_exchange(session, provider: "gemini", name: "second", result: "native")
+
+    assert_equal Set["call_1"], session.tool_call_ids
+
+    contents = Mistri::Providers::Gemini::Serializer.contents(session.messages)
+    first_result = contents[1][:parts].first
+    second_result = contents[3][:parts].first
+
+    assert first_result.key?(:text)
+    refute first_result.key?(:functionResponse)
+    assert_equal "second", second_result.dig(:functionResponse, :name)
+    assert_equal({ "result" => "native" }, second_result.dig(:functionResponse, :response))
+  end
+
+  def test_a_stale_approval_cannot_authorize_a_reused_call
+    session = new_session
+    first = append_legacy_call(session, "call_1")
+    session.append("approval_request", "call" => first.to_h)
+    session.append("approval_decision", "call_id" => first.id, "approved" => true)
+    append_result(session, first, "first")
+    second = append_legacy_call(session, "call_1")
+    session.append("approval_request", "call" => second.to_h)
+    session.append("approval_decision", "call_id" => second.id, "approved" => true)
+    ran = false
+    tool = Mistri::Tool.define("write", "Write.", needs_approval: true) do
+      ran = true
+      "written"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { text: "I will verify first." },
+                                             { text: "The session remains usable." }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [tool], session:)
+
+    assert_empty session.open_approvals
+
+    result = agent.resume
+
+    assert_predicate result, :completed?
+    refute ran
+    interrupted = provider.requests.first[:messages].select(&:tool?).last
+
+    assert_equal Mistri::Session::INTERRUPTED_RESULT, interrupted.text
+    assert_predicate interrupted, :tool_error?
+    assert_predicate agent.run("continue"), :completed?
+  end
+
+  def test_same_turn_duplicate_ids_still_fail_closed
+    session = new_session
+    calls = Array.new(2) { Mistri::ToolCall.new(id: "call_1", name: "write", arguments: {}) }
+    session.append_message(Mistri::Message.assistant(tool_calls: calls, stop_reason: :tool_use,
+                                                     provider: :gemini))
+
+    error = assert_raises(Mistri::ConfigurationError) { session.tool_call_ids }
+
+    assert_match(/duplicate tool call ID/, error.message)
+  end
+
+  def test_compaction_cannot_split_an_earlier_occurrence_from_its_result
+    session = new_session
+    session.append_message(Mistri::Message.user("start"))
+    append_answered_call(session, "call_1")
+    append_answered_call(session, "call_1")
+    session.append("compaction", "summary" => "s", "kept_from" => 2)
+
+    error = assert_raises(Mistri::ConfigurationError) { session.tool_call_ids }
+
+    assert_match(/splits a tool call from its result/, error.message)
+  end
+
+  private
+
+  def new_session
+    Mistri::Session.new(store: Mistri::Stores::Memory.new)
+  end
+
+  def append_answered_call(session, id, provider: :gemini, provider_call_id: nil, result: "ok")
+    call = Mistri::ToolCall.new(id:, name: "write", arguments: {}, provider_call_id:)
+    session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use,
+                                                     provider:))
+    append_result(session, call, result)
+    call
+  end
+
+  def append_legacy_call(session, id, provider: :gemini)
+    call = Mistri::ToolCall.new(id:, name: "write", arguments: {})
+    session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use,
+                                                     provider:))
+    call
+  end
+
+  def append_result(session, call, content)
+    session.append_message(Mistri::Message.tool(content:, tool_call_id: call.id,
+                                                tool_name: call.name))
+  end
+
+  def append_v05_exchange(session, provider:, name:, result:)
+    session.append("message", "message" => {
+                     "role" => "assistant", "provider" => provider,
+                     "stop_reason" => "tool_use", "content" => [
+                       { "type" => "tool_call", "id" => "call_1", "name" => name,
+                         "arguments" => {} }
+                     ]
+                   })
+    session.append("message", "message" => {
+                     "role" => "tool", "tool_call_id" => "call_1", "tool_name" => name,
+                     "content" => [{ "type" => "text", "text" => result }]
+                   })
+  end
+end

--- a/test/test_mcp_bridge.rb
+++ b/test/test_mcp_bridge.rb
@@ -11,6 +11,24 @@ class TestMcpBridge < Minitest::Test
                             allow_non_public: Mistri::Test::ALLOW_LOOPBACK)
   end
 
+  def recording_client(listed)
+    Class.new do
+      def initialize(listed)
+        @listed = listed
+        @calls = []
+      end
+
+      attr_reader :calls
+
+      def tools = @listed
+
+      def call_tool(name, args)
+        @calls << [name, args]
+        { "content" => [{ "type" => "text", "text" => "within bounds" }] }
+      end
+    end.new(listed)
+  end
+
   def test_tools_map_with_prefix_filters_and_gates
     listed = [{ "name" => "create", "description" => "Creates.",
                 "inputSchema" => { "type" => "object",
@@ -94,7 +112,26 @@ class TestMcpBridge < Minitest::Test
     assert_match(/inputSchema must be an object, not null/, error.message)
   end
 
-  def test_mcp_requires_a_complete_validator_for_unimplemented_assertions
+  def test_mcp_bridges_unimplemented_assertions_as_server_validated_guidance
+    listed = [{ "name" => "bounded", "description" => "Checks a bounded value.",
+                "inputSchema" => {
+                  "type" => "object",
+                  "properties" => { "count" => { "type" => "integer", "minimum" => 1 } },
+                  "required" => ["count"]
+                } }]
+    client = recording_client(listed)
+
+    tool = Mistri::MCP.tools(client).first
+
+    assert_equal ["$.count must be integer, got string"],
+                 tool.argument_violations("count" => "one")
+    assert_empty tool.argument_violations("count" => 0),
+                 "minimum stays guidance for the server, which the MCP spec obligates to validate"
+    assert_equal "within bounds", tool.call({ "count" => 0 })
+    assert_equal [["bounded", { "count" => 0 }]], client.calls
+  end
+
+  def test_mcp_strict_schemas_refuses_unimplemented_assertions
     listed = [{ "name" => "bounded", "description" => "Checks a bounded value.",
                 "inputSchema" => {
                   "type" => "object",
@@ -102,17 +139,32 @@ class TestMcpBridge < Minitest::Test
                 } }]
     client = Struct.new(:tools).new(listed)
 
-    error = assert_raises(Mistri::ConfigurationError) { Mistri::MCP.tools(client) }
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::MCP.tools(client, strict_schemas: true)
+    end
 
     assert_match(/MCP input schema uses assertions Mistri cannot validate/, error.message)
     assert_match(/\$\.properties\.count\.minimum/, error.message)
 
     tool = Mistri::MCP.tools(
-      client,
-      complete_argument_validator: ->(*) { [] }
+      client, strict_schemas: true,
+              complete_argument_validator: ->(*) { [] }
     ).first
 
     assert_empty tool.argument_violations("count" => 1)
+  end
+
+  def test_mcp_pattern_properties_still_require_complete_authority_by_default
+    listed = [{ "name" => "labels", "description" => "Labels.",
+                "inputSchema" => {
+                  "type" => "object",
+                  "patternProperties" => { "^x-" => { "type" => "string" } }
+                } }]
+    client = Struct.new(:tools).new(listed)
+
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::MCP.tools(client) }
+
+    assert_match(/pattern properties require a complete argument validator/, error.message)
   end
 
   def test_mcp_does_not_promote_format_annotations_into_assertions
@@ -160,12 +212,17 @@ class TestMcpBridge < Minitest::Test
     )
 
     assert Mistri::MCP.tools(local, complete_argument_validator: complete).first
+    assert Mistri::MCP.tools(local).first, "same-document refs bridge as guidance by default"
     error = assert_raises(Mistri::ConfigurationError) do
       Mistri::MCP.tools(external, complete_argument_validator: complete)
     end
 
     assert_match(/MCP tool "external"/, error.message)
     assert_match(/same-document reference beginning with #/, error.message)
+
+    default_mode = assert_raises(Mistri::ConfigurationError) { Mistri::MCP.tools(external) }
+
+    assert_match(/same-document reference beginning with #/, default_mode.message)
   end
 
   def test_answers_map_text_errors_images_and_structured_content

--- a/test/test_mcp_bridge.rb
+++ b/test/test_mcp_bridge.rb
@@ -24,6 +24,11 @@ class TestMcpBridge < Minitest::Test
 
       def call_tool(name, args)
         @calls << [name, args]
+        if args["count"].is_a?(Integer) && args["count"] < 1
+          return { "isError" => true,
+                   "content" => [{ "type" => "text", "text" => "count must be positive" }] }
+        end
+
         { "content" => [{ "type" => "text", "text" => "within bounds" }] }
       end
     end.new(listed)
@@ -127,31 +132,29 @@ class TestMcpBridge < Minitest::Test
                  tool.argument_violations("count" => "one")
     assert_empty tool.argument_violations("count" => 0),
                  "minimum stays guidance for the server, which the MCP spec obligates to validate"
-    assert_equal "within bounds", tool.call({ "count" => 0 })
+    rejected = tool.call({ "count" => 0 })
+
+    assert_predicate rejected, :error?
+    assert_includes rejected.content, "count must be positive"
     assert_equal [["bounded", { "count" => 0 }]], client.calls
   end
 
-  def test_mcp_strict_schemas_refuses_unimplemented_assertions
-    listed = [{ "name" => "bounded", "description" => "Checks a bounded value.",
-                "inputSchema" => {
-                  "type" => "object",
-                  "properties" => { "count" => { "type" => "integer", "minimum" => 1 } }
-                } }]
-    client = Struct.new(:tools).new(listed)
+  def test_mcp_ignores_inline_vocabulary_declarations_for_instance_validation
+    schema = {
+      "$vocabulary" => { "https://example.com/vocab" => true },
+      "type" => "object"
+    }
+    client = Struct.new(:tools).new(
+      [{ "name" => "custom", "description" => "Custom.", "inputSchema" => schema }]
+    )
 
-    error = assert_raises(Mistri::ConfigurationError) do
-      Mistri::MCP.tools(client, strict_schemas: true)
-    end
+    tool = Mistri::MCP.tools(client).first
 
-    assert_match(/MCP input schema uses assertions Mistri cannot validate/, error.message)
-    assert_match(/\$\.properties\.count\.minimum/, error.message)
+    assert_empty tool.argument_violations({})
 
-    tool = Mistri::MCP.tools(
-      client, strict_schemas: true,
-              complete_argument_validator: ->(*) { [] }
-    ).first
+    schema["$vocabulary"]["https://example.com/vocab"] = false
 
-    assert_empty tool.argument_violations("count" => 1)
+    assert Mistri::MCP.tools(client).first
   end
 
   def test_mcp_pattern_properties_still_require_complete_authority_by_default
@@ -213,6 +216,16 @@ class TestMcpBridge < Minitest::Test
 
     assert Mistri::MCP.tools(local, complete_argument_validator: complete).first
     assert Mistri::MCP.tools(local).first, "same-document refs bridge as guidance by default"
+    %w[$ref $dynamicRef].each do |keyword|
+      empty_ref = base.merge("properties" => { "id" => { keyword => "" } })
+      empty_client = Struct.new(:tools).new(
+        [{ "name" => "empty", "description" => "Empty ref.", "inputSchema" => empty_ref }]
+      )
+
+      assert Mistri::MCP.tools(empty_client).first
+      assert Mistri::MCP.tools(empty_client,
+                               complete_argument_validator: complete).first
+    end
     error = assert_raises(Mistri::ConfigurationError) do
       Mistri::MCP.tools(external, complete_argument_validator: complete)
     end

--- a/test/test_mcp_schema_traversal.rb
+++ b/test/test_mcp_schema_traversal.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Remote schema guidance remains structurally bounded: nested contracts cannot
+# hide references or key-matching semantics from the bridge's safety checks.
+class TestMcpSchemaTraversal < Minitest::Test
+  def test_legacy_dependencies_shapes_are_validated
+    invalid = [
+      [[], /dependencies must be an object/],
+      [{ "kind" => %w[name name] }, /dependencies\.kind must be a schema or array/],
+      [{ "kind" => 7 }, /dependencies\.kind must be a schema object or boolean/]
+    ]
+
+    invalid.each do |dependencies, message|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::MCP.tools(client_for("dependencies" => dependencies))
+      end
+
+      assert_match message, error.message
+    end
+
+    assert Mistri::MCP.tools(client_for("dependencies" => { "kind" => [] })).first
+  end
+
+  def test_external_references_nested_under_legacy_dependencies_are_rejected
+    %w[$ref $dynamicRef].each do |keyword|
+      schema = { "dependencies" => {
+        "kind" => { keyword => "https://example.com/remote-schema" }
+      } }
+
+      path = /\$\.dependencies\.kind\.#{Regexp.escape(keyword)}/
+
+      assert_external_reference_rejected(schema, path)
+    end
+  end
+
+  def test_external_references_nested_under_content_schema_are_rejected
+    %w[$ref $dynamicRef].each do |keyword|
+      schema = { "properties" => {
+        "payload" => {
+          "type" => "string",
+          "contentSchema" => { keyword => "https://example.com/remote-schema" }
+        }
+      } }
+
+      path = /\$\.properties\.payload\.contentSchema\.#{Regexp.escape(keyword)}/
+
+      assert_external_reference_rejected(schema, path)
+    end
+  end
+
+  def test_schema_dependencies_are_guidance_but_pattern_matching_needs_authority
+    schema = {
+      "$defs" => { "named" => { "type" => "string" } },
+      "dependencies" => {
+        "kind" => { "$ref" => "#/$defs/named" },
+        "labels" => {
+          "patternProperties" => { "^x-" => { "type" => "string" } }
+        }
+      }
+    }
+    client = client_for(schema)
+
+    error = assert_raises(Mistri::ConfigurationError) { Mistri::MCP.tools(client) }
+
+    assert_match(/dependencies\.labels\.patternProperties/, error.message)
+    assert Mistri::MCP.tools(client, complete_argument_validator: ->(*) { [] }).first
+  end
+
+  private
+
+  def client_for(schema)
+    schema = { "type" => "object" }.merge(schema)
+    Struct.new(:tools).new(
+      [{ "name" => "remote", "description" => "Remote.", "inputSchema" => schema }]
+    )
+  end
+
+  def assert_external_reference_rejected(schema, path)
+    [nil, ->(*) { [] }].each do |validator|
+      options = validator ? { complete_argument_validator: validator } : {}
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::MCP.tools(client_for(schema), **options)
+      end
+
+      assert_match path, error.message
+      assert_match(/same-document reference beginning with #/, error.message)
+    end
+  end
+end

--- a/test/test_schema_contract.rb
+++ b/test/test_schema_contract.rb
@@ -122,7 +122,7 @@ class TestSchemaContract < Minitest::Test
     end
   end
 
-  def test_task_mode_rejects_a_required_vocabulary_it_cannot_implement
+  def test_inline_vocabulary_declarations_are_not_instance_assertions
     required = {
       "$vocabulary" => { "https://example.test/vocab" => true }, type: "string"
     }
@@ -130,12 +130,10 @@ class TestSchemaContract < Minitest::Test
       "$vocabulary" => { "https://example.test/vocab" => false }, type: "string"
     }
 
-    error = assert_raises(Mistri::ConfigurationError) do
-      Mistri::Schema.task_plan(required)
-    end
-
-    assert_match(/task output schema uses assertions Mistri cannot validate/, error.message)
+    Mistri::Schema.task_plan(required)
     Mistri::Schema.task_plan(optional)
+
+    assert_empty Mistri::Schema.unsupported_assertions(required)
   end
 
   def test_tool_schemas_require_an_object_root

--- a/test/test_session_healing.rb
+++ b/test/test_session_healing.rb
@@ -37,6 +37,29 @@ class TestSessionHealing < Minitest::Test
                  "the stored log gained nothing"
   end
 
+  def test_gemini_replay_keeps_persisted_and_healed_siblings_in_call_order
+    cases = [
+      ["call_1", "first", [{ "result" => "first" }, { "error" => INTERRUPTED }]],
+      ["call_2", "second", [{ "error" => INTERRUPTED }, { "result" => "second" }]]
+    ]
+    cases.each do |answered_id, content, expected|
+      session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+      calls = %w[call_1 call_2].map do |id|
+        Mistri::ToolCall.new(id:, name: "lookup", arguments: {})
+      end
+      session.append_message(Mistri::Message.assistant(tool_calls: calls,
+                                                       stop_reason: :tool_use,
+                                                       provider: :gemini))
+      session.append_message(Mistri::Message.tool(content:, tool_call_id: answered_id,
+                                                  tool_name: "lookup"))
+
+      contents = Mistri::Providers::Gemini::Serializer.contents(session.messages)
+      responses = contents.last[:parts].map { |part| part[:functionResponse][:response] }
+
+      assert_equal expected, responses, answered_id
+    end
+  end
+
   def test_a_resumed_run_sends_a_fully_paired_context
     session = bricked_session
     provider = Mistri::Providers::Fake.new(turns: [{ text: "picking up where we left off" }])
@@ -69,6 +92,21 @@ class TestSessionHealing < Minitest::Test
     session.replay
 
     assert_equal 1, store.loads - before, "context assembly is one store read, healing included"
+  end
+
+  def test_replay_does_not_deserialize_messages_removed_by_compaction
+    store = Mistri::Stores::Memory.new
+    session = Mistri::Session.new(store:)
+    store.append(session.id, {
+                   "type" => "message",
+                   "message" => { "role" => "invalid-before-compaction", "content" => [] }
+                 })
+    session.append("compaction", "summary" => "old context", "kept_from" => 1)
+
+    replay = session.messages
+
+    assert_equal 1, replay.length
+    assert_includes replay.first.text, "old context"
   end
 
   def test_calls_parked_for_approval_are_not_healed_away

--- a/test/test_tool_call_identity.rb
+++ b/test/test_tool_call_identity.rb
@@ -35,7 +35,7 @@ class TestToolCallIdentity < Minitest::Test
     assert_equal 1, retries_recorded
   end
 
-  def test_duplicate_ids_in_legacy_history_fail_before_a_run_writes_or_calls_a_provider
+  def test_reusing_an_unanswered_call_id_in_history_fails_before_a_run_writes_or_calls_a_provider
     session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
     append_assistant_call(session, "same")
     append_assistant_call(session, "same")
@@ -49,6 +49,69 @@ class TestToolCallIdentity < Minitest::Test
     assert_match(/duplicate tool call ID/, error.message)
     assert_equal before, session.entries.length
     assert_empty provider.requests
+  end
+
+  # Releases before the identity audit synthesized per-turn IDs ("call_1")
+  # for Gemini and the Fake provider, so answered reuse across turns is the
+  # normal shape of a durable legacy history and must stay loadable.
+  def test_settled_legacy_call_ids_reuse_across_turns_and_the_session_still_runs
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    session.append_message(Mistri::Message.user("look twice"))
+    2.times { |round| append_answered_call(session, "call_1", result: "ok #{round}") }
+    ran = false
+    tool = Mistri::Tool.define("write", "Write.") do
+      ran = true
+      "written"
+    end
+    turns = [{ tool_calls: [{ id: "fresh-1", name: "write", arguments: {} }] }, { text: "done" }]
+    agent = Mistri::Agent.new(provider: Mistri::Providers::Fake.new(turns:), tools: [tool],
+                              session:)
+
+    assert_empty session.open_approvals
+    assert_equal Set["call_1"], session.tool_call_ids
+
+    result = agent.run("continue")
+
+    assert_predicate result, :completed?
+    assert ran, "a run on top of the legacy history executes normally"
+    assert_equal 3, session.messages.count(&:tool?)
+    assert_equal Set["call_1", "fresh-1"], session.tool_call_ids
+  end
+
+  def test_a_call_id_may_be_reused_after_its_approval_settled
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    call = Mistri::ToolCall.new(id: "call_1", name: "write", arguments: {})
+    session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use))
+    session.append("approval_request", "call" => call.to_h)
+    session.append("approval_decision", "call_id" => "call_1", "approved" => true)
+    session.append_message(Mistri::Message.tool(content: "written", tool_call_id: "call_1",
+                                                tool_name: "write"))
+    append_answered_call(session, "call_1")
+
+    assert_empty session.open_approvals
+    assert_equal Set["call_1"], session.tool_call_ids
+  end
+
+  def test_same_turn_duplicate_ids_still_fail_closed
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    calls = Array.new(2) { Mistri::ToolCall.new(id: "call_1", name: "write", arguments: {}) }
+    session.append_message(Mistri::Message.assistant(tool_calls: calls, stop_reason: :tool_use))
+
+    error = assert_raises(Mistri::ConfigurationError) { session.tool_call_ids }
+
+    assert_match(/duplicate tool call ID/, error.message)
+  end
+
+  def test_compaction_still_cannot_split_a_retired_call_from_its_result
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    session.append_message(Mistri::Message.user("start"))
+    append_answered_call(session, "call_1")
+    append_answered_call(session, "call_1")
+    session.append("compaction", "summary" => "s", "kept_from" => 2)
+
+    error = assert_raises(Mistri::ConfigurationError) { session.tool_call_ids }
+
+    assert_match(/splits a tool call from its result/, error.message)
   end
 
   def test_one_legacy_decision_cannot_execute_duplicate_approval_requests
@@ -269,6 +332,15 @@ class TestToolCallIdentity < Minitest::Test
   def append_assistant_call(session, id)
     call = Mistri::ToolCall.new(id:, name: "write", arguments: {})
     session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use))
+    call
+  end
+
+  def append_answered_call(session, id, provider: :gemini, result: "ok")
+    call = Mistri::ToolCall.new(id:, name: "write", arguments: {})
+    session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use,
+                                                     provider: provider))
+    session.append_message(Mistri::Message.tool(content: result, tool_call_id: id,
+                                                tool_name: "write"))
     call
   end
 

--- a/test/test_tool_call_identity.rb
+++ b/test/test_tool_call_identity.rb
@@ -51,69 +51,6 @@ class TestToolCallIdentity < Minitest::Test
     assert_empty provider.requests
   end
 
-  # Releases before the identity audit synthesized per-turn IDs ("call_1")
-  # for Gemini and the Fake provider, so answered reuse across turns is the
-  # normal shape of a durable legacy history and must stay loadable.
-  def test_settled_legacy_call_ids_reuse_across_turns_and_the_session_still_runs
-    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
-    session.append_message(Mistri::Message.user("look twice"))
-    2.times { |round| append_answered_call(session, "call_1", result: "ok #{round}") }
-    ran = false
-    tool = Mistri::Tool.define("write", "Write.") do
-      ran = true
-      "written"
-    end
-    turns = [{ tool_calls: [{ id: "fresh-1", name: "write", arguments: {} }] }, { text: "done" }]
-    agent = Mistri::Agent.new(provider: Mistri::Providers::Fake.new(turns:), tools: [tool],
-                              session:)
-
-    assert_empty session.open_approvals
-    assert_equal Set["call_1"], session.tool_call_ids
-
-    result = agent.run("continue")
-
-    assert_predicate result, :completed?
-    assert ran, "a run on top of the legacy history executes normally"
-    assert_equal 3, session.messages.count(&:tool?)
-    assert_equal Set["call_1", "fresh-1"], session.tool_call_ids
-  end
-
-  def test_a_call_id_may_be_reused_after_its_approval_settled
-    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
-    call = Mistri::ToolCall.new(id: "call_1", name: "write", arguments: {})
-    session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use))
-    session.append("approval_request", "call" => call.to_h)
-    session.append("approval_decision", "call_id" => "call_1", "approved" => true)
-    session.append_message(Mistri::Message.tool(content: "written", tool_call_id: "call_1",
-                                                tool_name: "write"))
-    append_answered_call(session, "call_1")
-
-    assert_empty session.open_approvals
-    assert_equal Set["call_1"], session.tool_call_ids
-  end
-
-  def test_same_turn_duplicate_ids_still_fail_closed
-    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
-    calls = Array.new(2) { Mistri::ToolCall.new(id: "call_1", name: "write", arguments: {}) }
-    session.append_message(Mistri::Message.assistant(tool_calls: calls, stop_reason: :tool_use))
-
-    error = assert_raises(Mistri::ConfigurationError) { session.tool_call_ids }
-
-    assert_match(/duplicate tool call ID/, error.message)
-  end
-
-  def test_compaction_still_cannot_split_a_retired_call_from_its_result
-    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
-    session.append_message(Mistri::Message.user("start"))
-    append_answered_call(session, "call_1")
-    append_answered_call(session, "call_1")
-    session.append("compaction", "summary" => "s", "kept_from" => 2)
-
-    error = assert_raises(Mistri::ConfigurationError) { session.tool_call_ids }
-
-    assert_match(/splits a tool call from its result/, error.message)
-  end
-
   def test_one_legacy_decision_cannot_execute_duplicate_approval_requests
     session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
     call = Mistri::ToolCall.new(id: "write-1", name: "write", arguments: {})
@@ -332,15 +269,6 @@ class TestToolCallIdentity < Minitest::Test
   def append_assistant_call(session, id)
     call = Mistri::ToolCall.new(id:, name: "write", arguments: {})
     session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use))
-    call
-  end
-
-  def append_answered_call(session, id, provider: :gemini, result: "ok")
-    call = Mistri::ToolCall.new(id:, name: "write", arguments: {})
-    session.append_message(Mistri::Message.assistant(tool_calls: [call], stop_reason: :tool_use,
-                                                     provider: provider))
-    session.append_message(Mistri::Message.tool(content: result, tool_call_id: id,
-                                                tool_name: "write"))
     call
   end
 


### PR DESCRIPTION
## Summary

This completes the two compatibility fixes around the validation boundary without weakening authorization or adding a second strictness API.

- Legacy sessions: only the exact pre-0.6 Gemini/Fake shape may reuse an ID: `call_N`, no provider correlation ID, and a prior occurrence that is answered or crash-interrupted. New provider turns still reserve IDs for the whole session. Audit, compaction, healing, and Gemini wire metadata now track occurrences rather than collapsing them by raw ID.
- Replay safety: persisted and synthesized tool results are rebuilt in source-call order within their direct and approval phases. A reused ID cannot inherit stale approval; an unsettled approval whose generation is ambiguous becomes an in-band interrupted result and never executes.
- MCP schemas: directly reachable portable constraints remain local authorization checks. Unsupported assertions and applicator subtrees remain intact as server-validated guidance, matching the MCP requirement that servers validate every tool input. A complete validator remains the explicit whole-contract seam; the unreleased `strict_schemas:` / `strict:` options were removed rather than made public.
- Schema hazards: external `$ref` and `$dynamicRef` values are rejected even when nested under legacy `dependencies` or `contentSchema`, while empty and fragment-only references remain local. Legacy dependency shapes are validated and traversed. Inline `$vocabulary` is not treated as an instance assertion.
- Release notes retain the one-time prompt-cache re-warm disclosure for schema-less tools.

## Why

Mistri 0.5 synthesized `call_1`, `call_2`, and so on from a per-turn counter for Gemini and the Fake provider. A durable session with tool calls in multiple turns therefore became permanently unusable after the stricter identity audit: `run`, `resume`, and `open_approvals` all raised, with no migration or repair path.

The original compatibility patch admitted those histories, but review exposed three places that still assumed global ID uniqueness:

1. an earlier result could suppress healing for a later dangling occurrence;
2. Gemini could apply the later occurrence's provider metadata to an earlier foreign result;
3. synthetic results could precede persisted siblings and corrupt Gemini's positional pairing for same-name calls.

The final implementation preserves all-time live reservation while making durable replay occurrence- and phase-aware.

Separately, refusing every MCP schema with an unimplemented assertion made ordinary Zod-generated and public servers unbridgeable. The final stance follows the current [MCP Tools specification](https://modelcontextprotocol.io/specification/2025-11-25/server/tools): the client enforces the constraints it can rely on before policy or execution, the server validates the full input contract, and tool errors return in band for model correction.

## Public impact

- Existing pre-0.6 Gemini/Fake sessions with the known repeated `call_N` shape load and continue without rewriting stored history.
- Arbitrary duplicate IDs, same-turn duplicates, provider-backed IDs, and OpenAI/Anthropic duplicate histories still fail closed.
- No new public keyword arguments are introduced.
- MCP schemas with `minimum`, `pattern`, `anyOf`, same-document references, and similar unsupported assertions can bridge as guidance. `complete_argument_validator:` remains available when host policy needs local whole-schema authority.
- Mistri still compiles MCP input schemas as JSON Schema 2020-12 and rejects an explicitly declared older dialect. Current MCP permits draft-07, but supporting it correctly requires a separate dialect-aware implementation rather than a compatibility shortcut.

## Validation

- `bundle exec rubocop`: 188 files, no offenses.
- Hermetic suite on Ruby 3.2.9, 3.3.11, and 3.4.1: 904 runs, 4,701 assertions, 0 failures on each.
- Coverage on Ruby 3.4.1: 98.26% line, 88.07% branch.
- `MISTRI_LIVE=1 bundle exec rake test`: 904 runs, 4,960 assertions, 0 failures, 0 skips.
- Full integration matrix: 60 runs, 399 assertions, 0 failures across Claude Haiku 4.5, GPT-5.6 Terra, and Gemini 2.5 Flash.
- Live repeated-ID continuations passed on Anthropic, OpenAI, and Gemini. The public DeepWiki MCP scenario passed through all three providers.
- `bundle exec rake build`: built `mistri-0.5.0.gem` successfully.
- Two independent adversarial reviews found no remaining session/replay or MCP/schema defect after amendment.

One earlier integration pass had a Gemini-only assertion fail because the model repeated a checkpoint secret in its own later thinking. The exact scenario passed immediately in isolation, and the full 60-scenario matrix passed on rerun; no production change was made for that model-behavior flake.

## Deliberately unchanged

- The schema-less open-to-closed change remains, with its prompt-cache disclosure.
- Task mode remains strict for actual instance assertions local validation cannot guarantee.
- Provider streaming/retry policy is outside this compatibility repair.
