### PR TITLE
Verify Anthropic thinking replay live

### DIFF
--- a/test/test_anthropic_live.rb
+++ b/test/test_anthropic_live.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json"
+
 require_relative "test_helper"
 
 # Real API calls, opt-in: MISTRI_LIVE=1 bundle exec rake test
@@ -72,6 +74,56 @@ class TestAnthropicLive < Minitest::Test
     assert_kind_of Hash, config
     assert_equal "bar", config.dig("series", 0, "type")
     assert_equal [1, 2], config.dig("series", 0, "data")
+  ensure
+    provider&.close
+  end
+
+  def test_foreign_thinking_replays_without_leaking_its_signature
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    item = { "id" => "rs_0123", "type" => "reasoning", "summary" => [],
+             "encrypted_content" => "not-an-anthropic-signature" }
+    session.append_message(Mistri::Message.user("What time is it?"))
+    session.append_message(Mistri::Message.assistant(
+                             content: [Mistri::Content::Thinking.new(
+                               thinking: "Checking the clock.", signature: JSON.generate(item)
+                             ), Mistri::Content::Text.new(text: "It is noon.")],
+                             model: "gpt-5.6-terra", provider: :openai,
+                             stop_reason: Mistri::StopReason::STOP
+                           ))
+    provider = Mistri::Providers::Anthropic.new(
+      api_key: ENV.fetch("ANTHROPIC_API_KEY"), model: "claude-haiku-4-5-20251001"
+    )
+
+    result = Mistri::Agent.new(provider:, session:).run("Reply with exactly: bye")
+
+    refute_predicate result, :errored?, result.error_message
+    assert_equal :completed, result.status
+    assert_match(/bye/i, result.text)
+  ensure
+    provider&.close
+  end
+
+  def test_native_signed_thinking_replays_across_turns
+    provider = Mistri::Providers::Anthropic.new(
+      api_key: ENV.fetch("ANTHROPIC_API_KEY"), model: "claude-haiku-4-5-20251001",
+      max_tokens: 2048,
+      thinking: { type: "enabled", budget_tokens: 1024, display: "summarized" }
+    )
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    agent = Mistri::Agent.new(provider:, session:)
+
+    first = agent.run("Think briefly, then reply with exactly: native one")
+    native = session.messages.reverse.find(&:assistant?)
+
+    refute_predicate first, :errored?, first.error_message
+    assert(native.content.any? do |block|
+      block.is_a?(Mistri::Content::Thinking) && !block.signature.to_s.empty?
+    end, "the first Anthropic turn did not produce signed thinking")
+
+    second = agent.run("Think briefly, then reply with exactly: native two")
+
+    refute_predicate second, :errored?, second.error_message
+    assert_match(/native two/i, second.text)
   ensure
     provider&.close
   end


### PR DESCRIPTION
## Summary

- add a live reproduction of foreign OpenAI reasoning history continuing safely on Anthropic
- add a native Anthropic two-turn replay that requires a real signed thinking block
- keep provider behavior unchanged

## Why

Issue #33 was fixed on main by PR #39: Anthropic replays signed thinking only when Anthropic produced the message, while foreign thinking degrades to neutral text. The unit tests pin that wire shape, but the release suite did not permanently prove both sides against the real API.

These scenarios close that verification gap. The first uses the issue's OpenAI Responses reasoning payload and confirms a later Anthropic turn completes instead of returning an invalid-signature 400. The second forces signed thinking from Haiku 4.5 and confirms a native signature survives the next Anthropic request unchanged.

Provider affinity remains the simplest operating model. This coverage does not encourage switching providers mid-turn; it guarantees that durable history cannot leak one provider's opaque state onto another provider's wire.

## Impact

Test-only. No runtime code, public API, request construction, or streaming path changes. The live release suite adds three small Anthropic calls when `MISTRI_LIVE=1`.

## Validation

- `test/test_anthropic_live.rb`: 5 runs, 30 assertions, 0 failures, 0 skips.
- Exact #33 reproduction: completed with `bye`.
- Forced native signed-thinking continuation: completed across two Anthropic turns.
- Full live provider suite passed with zero failures and zero skips during branch validation.
- Full integration matrix: 60 runs, 399 assertions across Anthropic, OpenAI, and Gemini.
- Hermetic suite remained green across Ruby 3.2, 3.3, and 3.4.
- Two independent adversarial reviews found no replay, flakiness, or public-gem concern.
