### PR TITLE
Rewrite the public documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,11 @@ The live suites need provider keys in a gitignored `.env.development.local`
 
 ```console
 $ MISTRI_LIVE=1 bundle exec rake test      # gated live tests
-$ bundle exec rake integration             # every feature, end to end, per model
+$ bundle exec rake integration             # critical end-to-end scenarios, per model
 ```
+
+Missing keys skip their provider. Read the output before treating a live run as
+three-provider coverage.
 
 ## The rules that keep the gem what it is
 
@@ -24,9 +27,10 @@ $ bundle exec rake integration             # every feature, end to end, per mode
   a runtime dependency needs an unusually good reason.
 - **Tests ship with the change**, in the same commit. New provider-touching
   behavior gets a live test.
-- **Errors are in-band for the model, raised for the host.** A tool failure
-  becomes a tool result the model can react to; configuration and transport
-  failures raise a `Mistri::Error` subclass.
+- **Errors follow their boundary.** A tool failure becomes a tool result the
+  model can react to. Built-in provider failures finish as an errored Result;
+  direct MCP Client and configuration failures raise. A bridged MCP Client
+  failure crosses the ordinary tool-result boundary.
 - **Sessions are append-only.** Derive state from the entry log; never
   require a repair step after a crash.
 - **Comments say why, not what.** Few and load-bearing.
@@ -38,3 +42,11 @@ $ bundle exec rake integration             # every feature, end to end, per mode
 Small, focused, sentence-case titles. Describe the why in a paragraph, not
 a checklist. If the change alters public behavior, add a CHANGELOG entry
 under Unreleased.
+
+## Documentation
+
+The README is the adoption path: category, first success, fit, core mechanism,
+and honest reliability boundaries. Put detailed contracts in the task-oriented
+Markdown guides under `docs/`, and put required host migrations in
+`UPGRADING.md`. Link repository files relatively so links work on branches and
+pull requests. Do not duplicate the changelog into a guide.

--- a/README.md
+++ b/README.md
@@ -7,22 +7,36 @@
 
 <p align="center"><strong>mistri</strong>, the agent harness for Ruby applications.</p>
 
-<p align="center"><a href="https://mistri.sh">mistri.sh</a> · <a href="https://mistri.sh/docs/getting-started/">docs</a></p>
+<p align="center"><a href="https://mistri.sh">mistri.sh</a> · <a href="docs/README.md">documentation</a> · <a href="UPGRADING.md">upgrading</a></p>
 
 <p align="center">
   <a href="https://rubygems.org/gems/mistri"><img alt="Gem Version" src="https://img.shields.io/gem/v/mistri"></a>
   <a href="https://github.com/mcheemaa/mistri/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/mcheemaa/mistri/actions/workflows/ci.yml/badge.svg"></a>
   <a href="https://codecov.io/gh/mcheemaa/mistri"><img alt="Coverage" src="https://img.shields.io/codecov/c/github/mcheemaa/mistri"></a>
   <a href="mistri.gemspec"><img alt="Ruby >= 3.2" src="https://img.shields.io/badge/ruby-%3E%3D%203.2-CC342D"></a>
-  <a href="Gemfile"><img alt="Runtime dependencies: zero" src="https://img.shields.io/badge/runtime_deps-0-brightgreen"></a>
+  <a href="mistri.gemspec"><img alt="Runtime dependencies: zero" src="https://img.shields.io/badge/runtime_deps-0-brightgreen"></a>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
 </p>
 
 A mistri (Urdu: مستری) is the fixer: the skilled tradesperson who actually
-gets it done. This one lives inside your app, not in a terminal. It runs the
-model loop, executes tools, streams every event, persists sessions to your
-own database, and pauses for a human when a tool needs approval, all with
-zero runtime gem dependencies.
+gets it done. Mistri is an application-embedded agent runtime for Ruby. It owns
+the model loop, safe tool boundary, event stream, and append-only session
+record. Your application owns authorization, policy, presentation, and the
+semantics of its side effects.
+
+Mistri works in plain Ruby applications, including Rails, Sinatra, Hanami, jobs,
+and services. Rails integrations are optional. The gem declares zero runtime
+dependencies.
+
+## Start in sixty seconds
+
+Add Mistri to your bundle:
+
+```ruby
+gem "mistri"
+```
+
+Then define a tool and run an agent:
 
 ```ruby
 require "mistri"
@@ -31,330 +45,151 @@ weather = Mistri::Tool.define(
   "get_weather", "Current weather for a city.",
   schema: -> { string :city, "City name", required: true },
 ) do |args|
-  Weather.for(args["city"])
+  { city: args.fetch("city"), forecast: "34 C and clear" }
 end
 
-agent = Mistri.agent("claude-opus-4-8", tools: [weather]) # reads ANTHROPIC_API_KEY
+agent = Mistri.agent("claude-opus-4-8", tools: [weather])
 
-agent.run("What should I wear in Lahore today?") do |event|
+result = agent.run("What should I wear in Lahore today? One sentence.") do |event|
   print event.delta if event.type == :text_delta
 end
+puts
 ```
+
+`Mistri.agent` infers the provider from the model ID and reads
+`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY`. Pass `api_key:`
+explicitly when the host resolves credentials another way. A normally
+completed invocation returns a `Mistri::Result` with status
+predicates, final text, usage, and structured task output when requested.
+Host-contract failures raise as documented in [Reliability](docs/reliability.md).
+
+Runnable examples live in [`examples/`](examples).
 
 ## Why Mistri
 
-- **Built for applications.** Sessions are durable, append-only records in
-  your own store. Runs stop, resume, steer, and compact from any process.
-- **Fire-and-forget human approval.** A gated tool suspends the run and
-  returns immediately. The approval can arrive two days later from a bare
-  web request; nothing sleeps waiting.
-- **Three providers, frontier-deep.** Anthropic, OpenAI, and Gemini, each
-  streamed natively with thinking, prompt caching, parallel tool calls, and
-  constrained JSON output. One message model across all three.
-- **Zero runtime dependencies.** Plain Ruby all the way down.
-- **Verified against real APIs.** A live integration harness runs every
-  feature end to end on every provider (`rake integration`).
+- **One session model.** The same append-only log runs over memory, JSONL,
+  Active Record, or a host store. With a persistent store, runs can suspend,
+  reload, resume, steer, and compact without inventing a second state model. See
+  [Sessions and control](docs/sessions.md).
+- **Human approval does not hold a thread.** A gated tool parks the request and
+  returns. With a shared store, another process can record the decision later;
+  `resume` revalidates the exact call before execution.
+- **Provider semantics survive the abstraction.** Anthropic, OpenAI, and
+  Gemini stream through direct implementations that retain each provider's
+  reasoning, tool-pairing, and replay requirements. Unknown model IDs still
+  pass through when their provider can be inferred.
+- **Tool input crosses a real boundary.** Completed model arguments are owned,
+  bounded, validated, and deeply frozen before hooks, approval predicates, MCP,
+  or handlers see them. See [Tool contracts](docs/tool-contracts.md).
+- **The runtime stays small.** The [gemspec](mistri.gemspec) declares no runtime
+  gem dependencies. Optional Rails adapters load only when required.
+- **Real APIs are part of the test strategy.** The
+  [live integration suite](CONTRIBUTING.md#setup)
+  exercises critical control, persistence, delegation, MCP, and
+  structured-output paths across all three providers when their keys are
+  present. The default CI suite remains hermetic.
 
-## Install
+## Choose the right layer
 
-```ruby
-gem "mistri"
-```
+These projects solve different problems:
 
-## Sixty-second start
+| Need | Start with |
+| --- | --- |
+| A durable tool loop inside any Ruby application, with append-only sessions, approval, steering, compaction, linked workers, and provider-neutral MCP | **Mistri** |
+| Broad model access plus media, embeddings, image generation, and Rails-backed chat | [RubyLLM](https://github.com/crmne/ruby_llm) |
+| Agents expressed through Rails controllers, actions, callbacks, views, and Active Job | [Active Agent](https://github.com/activeagents/activeagent) |
 
-```ruby
-agent = Mistri.agent("claude-opus-4-8")
-result = agent.run("Name three Ruby web frameworks.")
-puts result.text
-```
+Mistri is deliberately not a terminal UI, hosted agent service, broad media
+client, policy engine, or exactly-once job system. The host application keeps
+its users, authorization rules, queues, database, UI, idempotency keys, and
+reconciliation policy. Mistri supplies the execution mechanism that connects
+them.
 
-`Mistri.agent` infers the provider from the model id (`claude-*`, `gpt-*`,
-`gemini-*`) and reads the matching key (`ANTHROPIC_API_KEY`,
-`OPENAI_API_KEY`, `GEMINI_API_KEY`); pass `api_key:` to set it explicitly.
-Every run returns a `Result`: `completed?`, `awaiting_approval?`,
-`aborted?`, `errored?`, with `text` and (for tasks) `output`.
+## How the loop works
 
-## Tools
+1. The input is appended to the session before the provider is called.
+2. Provider events stream to the subscriber as the response arrives.
+3. Completed tool calls cross Mistri's ownership and validation boundary.
+4. Current host policy and approval rules run before a handler can start.
+5. Tool results append to the same session, then the model continues until it
+   answers, hands off the turn, suspends for approval, aborts, or reaches a
+   budget.
 
-A tool is a name, a description, an argument schema, and a block. The block
-returns a String, a Hash (sent as JSON), or content such as an image. The
-agent calls tools, feeds results back, and loops until the model answers;
-independent calls in a turn run in parallel.
+Every completed message is appended to the chosen Session store before the next
+model-visible turn. Opaque reasoning and pairing metadata replay only to the
+provider that created them; the shared transcript stays provider-neutral.
 
-```ruby
-weather = Mistri::Tool.define("get_weather", "Current weather for a city.", schema: lambda {
-  string :city, "City name", required: true
-  string :units, "Temperature units", enum: %w[celsius fahrenheit]
-}) do |args|
-  Weather.for(args["city"], units: args["units"] || "celsius")
-end
-```
+## Tools and approval
 
-A nested object without a block is deliberately freeform. This is useful for
-provider-neutral configuration payloads whose keys Mistri should not prescribe:
-
-```ruby
-chart = Mistri::Tool.define("render_chart", "Renders a chart.", schema: lambda {
-  object :config, "Chart-library configuration", required: true
-}) do |args|
-  Charts.render(args.fetch("config"))
-end
-```
-
-This gives providers an open JSON object schema, where `{}` remains valid. Tool
-arguments remain untrusted input. Mistri owns each completed JSON value and the
-tool's provider-facing schema as immutable UTF-8, requires each completed
-argument value to be an object, and validates its portable schema subset before
-hooks, approval predicates, or handlers can see it. An invalid call receives an
-error result the model can correct; valid calls from the same turn still run.
-The core boundary never coerces model input; an explicit per-tool normalizer,
-described below, is the deliberate compatibility exception. Arguments are
-bounded at 8 MiB, 64 levels, 10,000 JSON nodes, and 64 KiB per numeric token;
-the numeric ceiling applies to both encoded JSON and programmatic
-custom-provider values. The byte ceiling includes the complete serialized JSON
-shape, not only string payloads. Encoded Anthropic/OpenAI arguments take a
-linear lexical width/depth pass before `JSON.parse`, so a wide or pathological
-numeric document stops before allocating its full tree. Each completed outer
-SSE record receives its own 20,001-token lexical preflight plus depth and 64 KiB
-numeric-token ceilings. This bounds Gemini arguments before their enclosing
-record is decoded; it is not a claim that an SSE envelope has already been
-reduced to 10,000 canonical argument nodes. For fragmented Anthropic and OpenAI
-calls, the byte ceiling applies across every delta; raw delta events still
-arrive, while partial snapshots retain a bounded, deeply frozen preview that
-refreshes on a capped schedule.
-
-Completed calls also need non-empty UTF-8 string names, IDs, and opaque pairing
-metadata, with IDs unique for the lifetime of the session. If a custom provider
-violates that envelope, Mistri rejects the whole attempt before persistence or
-policy and lets the configured provider retry request a clean turn; no sibling
-tool runs from the malformed attempt.
-
-`ToolCall#arguments_error?` is the public distinction between usable arguments
-and a durable malformed call. Its non-nil string is an opaque diagnostic, not a
-stable enum for application branching; use the predicate and the typed tool
-result instead.
-
-Every tool input schema must be a JSON Schema object with `type: "object"`.
-A tool defined without a schema is a closed no-argument tool; undeclared model
-fields are rejected before policy. Once a schema is supplied, object schemas
-keep JSON Schema's default-open semantics unless a raw schema explicitly sets
-`additionalProperties: false`. This includes DSL schemas with named properties,
-so handlers should extract declared fields rather than mass-assign the argument
-hash. Use a raw closed schema when extra keys must be rejected.
-Mistri uses JSON Schema 2020-12; an omitted `$schema` means that dialect, an
-explicit older dialect is rejected, and tuple arrays use `prefixItems` rather
-than the pre-2020-12 array form of `items`. The built-in validator enforces JSON
-types and type unions, `enum`, `required`, declared `properties`, `prefixItems`,
-one-schema array `items`, nested boolean schemas, and boolean or schema-valued
-`additionalProperties`. Other keywords remain provider-facing generation
-guidance unless the tool supplies a complete validator. This includes
-constraints such as `pattern`, `format`, and numeric or length bounds. An empty
-object block currently emits the same open schema.
-
-This freeform DSL shape cannot be represented by strict constrained output
-without changing its meaning, so `Schema.strict` raises instead of silently
-narrowing it to an object that only accepts `{}`. Use declared properties, or an
-explicitly closed raw schema, for constrained task output.
-
-Use `argument_validator:` for supplemental host or domain rules. It receives
-the same deeply frozen arguments and canonical schema that policy and execution
-use, and returns an array of model-readable violations. It cannot replace the
-arguments or weaken a core failure:
+A tool has a name, description, JSON Schema object, and handler. Independent
+calls in one model turn execute concurrently up to `max_concurrency`.
 
 ```ruby
-invoice = Mistri::Tool.define(
-  "pay_invoice", "Pays an approved invoice.",
-  input_schema: invoice_schema,
-  argument_validator: lambda { |args, _schema|
-    args["invoice_id"].start_with?("inv_") ? [] : ["$.invoice_id must identify an invoice"]
-  }
-) do |args|
-  Invoices.pay!(args.fetch("invoice_id"))
-end
-```
-
-Use `complete_argument_validator:` when a host validator implements the full
-schema. It has the same `(args, schema)` contract, still runs only after core
-passes, and is deliberately distinct from a supplemental validator. Any
-argument-applicable non-empty `patternProperties` requires this explicit
-authority because core cannot enforce a pattern's value schema even when
-unmatched keys remain open.
-The two validator options are mutually exclusive.
-
-Validator errors are bounded before they reach a model; they should still
-describe expectations rather than include received field values or secrets.
-
-`argument_normalizer:` is the separate, explicit compatibility seam for a tool
-that intentionally accepts legacy aliases. It runs once before validation and
-must return a JSON object; the normalized value is what policy sees, what a
-human approves, and what the handler receives. It should be pure,
-deterministic, and idempotent. A direct `Tool#call` is a trusted host invocation:
-it applies that tool's normalizer for compatibility but does not run the Agent's
-model-input validation boundary.
-
-A tool result carries model content, host-only UI, and a failure fact. The
-`ui` payload rides the `:tool_result` event and persists with the session, but
-never reaches a provider. Return `error: true` for an expected tool failure
-that the model should handle rather than treating as a successful answer:
-
-```ruby
-Mistri::Tool.define("edit_page", "Applies a page edit.", schema: -> {
-  object :changes, "Page changes", required: true
-}) do |args|
-  page = apply(args.fetch("changes"))
-  Mistri::ToolResult.new(content: "Saved.", ui: { "html" => page })
+book_hotel = Mistri::Tool.define(
+  "book_hotel", "Books the selected hotel.",
+  schema: lambda {
+    string :hotel_id, "Hotel ID", required: true
+    number :total_usd, "Quoted total", required: true
+  },
+  needs_approval: ->(args) { args.fetch("total_usd") > 500 },
+) do |args, context|
+  Bookings.create!(
+    hotel_id: args.fetch("hotel_id"),
+    traveler: context.app.fetch(:traveler),
+  )
 end
 
-Mistri::Tool.define("lookup", "Looks up an account.", schema: -> {
-  string :id, "Account ID", required: true
-}) do |args|
-  account = Accounts.find_by(id: args["id"])
-  account || Mistri::ToolResult.new(content: "Account not found.", error: true)
-end
+agent = Mistri.agent(
+  "claude-opus-4-8",
+  tools: [book_hotel],
+  context: { traveler: current_traveler },
+)
 ```
 
-Mistri also sets the flag for unknown tools, blocked calls, handler exceptions,
-timeouts, calls interrupted before invocation, crash-healed calls whose outcome
-is unknown, and failed `after_tool` hooks. `event.tool_error` and
-`event.message.tool_error?` expose it without inspecting result text. A new
-successful result records false; a reloaded legacy result without the field
-keeps `tool_error == nil`, because Mistri cannot infer its historical outcome.
-Human denial is an expected approval outcome and records false. Anthropic and
-Gemini receive their native failure representation; OpenAI receives the same
-explanatory output because its function-result shape has no error member.
-Legacy unknown results replay with the historical unmarked provider shape;
-Mistri never guesses their status from prose.
+Validation runs before the approval predicate, so policy never receives a
+string where the schema promised a number. Invalid calls return a bounded,
+model-readable error and valid siblings still run. Mistri never coerces model
+input implicitly.
 
-The flag means the call did not produce a confirmed successful result. It does
-not mean retrying is safe: a handler can commit an external write before it
-raises or times out. Mistri never mechanically replays the same call because
-this flag is true, but the model may choose to issue another call. Hosts still
-own idempotency, approval, and reconciliation for side effects.
-
-Handlers and hooks can take the run's context as a second argument, and
-`context.app` carries whatever object you pass as `Mistri.agent(context:)`
-(the acting user, a tenant, a request), so tools stay authorization-aware
-without closure gymnastics:
+When a gated call arrives:
 
 ```ruby
-agent = Mistri.agent("claude-opus-4-8", tools: tools,
-                     context: { traveler: current_traveler })
-
-Mistri::Tool.define("book_hotel", "Books the chosen hotel.", schema: -> {
-  string :hotel_id, "Hotel ID", required: true
-}) do |args, context|
-  Bookings.create!(args.fetch("hotel_id"), traveler: context.app[:traveler])
-end
-```
-
-A tool can also be the last word of its turn. `ends_turn: true` makes the
-loop end the run once the tool executes, instead of prompting the model
-again: an `ask_user` tool hands the floor to a human structurally, no
-"remember to stop after asking" prompt required. `result.handed_off?` says the
-model's floor was handed away; the persisted tool result says separately
-whether execution confirmed success. The answer arrives as the next run's
-input:
-
-```ruby
-ask_user = Mistri::Tool.define("ask_user", "Ask the human and wait.",
-                               ends_turn: true,
-                               schema: -> { string :question, "The question", required: true }) do |args|
-  "Question presented to the user."
-end
-```
-
-## Human approval
-
-Mark a tool `needs_approval: true` (or a predicate on its arguments) and the
-run suspends instead of executing it, instantly, with no thread waiting.
-The decision is a one-line session write from any process, any time later;
-`resume` settles it and carries on.
-
-```ruby
-book_hotel = Mistri::Tool.define("book_hotel", "Books the chosen hotel.",
-                                 schema: lambda {
-                                   number :total_usd, "Quoted total", required: true
-                                 },
-                                 needs_approval: ->(args) { args["total_usd"] > 500 }) do |args|
-  Bookings.create!(total_usd: args.fetch("total_usd"))
-end
-
 result = agent.run("Book the corner suite for the Lisbon trip")
-result.awaiting_approval?   # => true; nothing executed
+result.awaiting_approval? # => true; the handler did not run
 
-# Days later, in a controller:
-Mistri::Session.new(store:, id: session_id).approve(call_id)   # or .deny(call_id, note: "...")
-
-# Then, in a worker:
-Mistri.agent("claude-opus-4-8", tools: tools, session: reloaded).resume
+call = result.pending.fetch(0)
+agent.session.approve(call.id, note: "Approved by finance")
+result = agent.resume
 ```
 
-The harness renders nothing: it emits an `:approval_needed` event and your
-app draws the UI.
+That is the smallest in-process flow. With a durable store, a controller,
+route, mutation, job, or console can append the decision using only the Session
+ID and call ID; a later process rebuilds current tools and policy before
+resuming. See [Sessions and control](docs/sessions.md#human-approval).
 
-The preceding assistant message remains the durable provider source. When a
-normalizer changes arguments, the approval stores the exact prepared call the
-human reviewed plus an explicit source marker. `resume` verifies pairing
-metadata and revalidates those approved arguments without rerunning a
-normalizer. Tool-call IDs are session-wide correlation keys; live provider
-turns require session-unique IDs. Replay recognizes only the `call_N` reuse
-without provider correlation IDs that earlier releases wrote for Gemini and
-the Fake provider, and only after the prior occurrence was answered or
-crash-interrupted. Every other duplicate and malformed legacy history fails
-before a handler or provider runs. A reused ID cannot carry stale approval
-forward: an unsettled approval that cannot identify its generation is replayed
-as interrupted. Persisted results must follow one matching call with the same
-name and settle in call order within each direct or approval phase; a compaction
-boundary cannot hide an open approval or split a completed call from its result.
+Tool results can also carry host-only UI data or an explicit failure fact. See
+[Tool contracts](docs/tool-contracts.md) for schemas, validators, normalizers,
+`Mistri::ToolResult`, hooks, and `ends_turn`.
 
-Only one Agent may actively call `run` or `resume` for a session at a time.
-Concurrent appenders such as approval decisions, steers, and worker reports are
-supported. The current execution contract is still at-least-once across the
-gap between handler invocation and durable result persistence: a crash, store
-failure, or subscriber exception in that gap can leave an approved call open,
-and a later resume can execute it again. Simultaneous runners widen the same
-risk. Until durable atomic claims land, hosts must serialize active runners and
-make side effects idempotent or reconcilable.
+## Sessions and control
 
-## Steering
-
-Queue a message into a running exchange from any process. It folds into the
-conversation at the next turn boundary; one that arrives as the model
-finishes cleanly extends the run so it gets answered.
+The default memory store is useful for one process. JSONL persists the complete
+append-only record on local disk without a database:
 
 ```ruby
-Mistri::Session.new(store:, id: session_id).steer("Make the headline blue instead.")
-```
+store = Mistri::Stores::JSONL.new("tmp/mistri-sessions")
+session = Mistri::Session.new(store: store)
 
-Background workers' reports arrive through the same inbox (see Sub-agents).
-A host that wakes an idle session when a steer lands should watch
-`session.pending_inbox`, which holds both, in arrival order.
-
-## Sessions
-
-A session is the durable record of a run: an append-only entry log over a
-pluggable store (memory, JSONL files, or your database).
-
-```ruby
-store = Mistri::Stores::JSONL.new("tmp/sessions")
-session = Mistri::Session.new(store:)
-
-agent = Mistri.agent("claude-opus-4-8", session:)
+agent = Mistri.agent("claude-opus-4-8", session: session)
 agent.run("Start a haiku about the sea.")
 
-# Later, even in another process: reload by id and continue.
-resumed = Mistri.agent("claude-opus-4-8", session: Mistri::Session.new(store:, id: session.id))
-resumed.run("Now finish it.")
+# A later process can reload the same session by ID.
+reloaded = Mistri::Session.new(store: store, id: session.id)
+Mistri.agent("claude-opus-4-8", session: reloaded).run("Now finish it.")
 ```
 
-Sessions can move between built-in providers. Opaque reasoning and pairing
-metadata only replays to its provider of origin. In particular, a completed
-foreign tool exchange becomes ordinary text for Gemini, preserving its result
-without manufacturing a signed Gemini function call.
-
-In Rails, generate a model (name it whatever you like) and use the
-ActiveRecord store:
+For a database-backed store, implement `append(id, entry)` and `load(id)`, or
+use the optional Active Record adapter:
 
 ```console
 $ bin/rails generate mistri:install AgentEntry
@@ -362,515 +197,218 @@ $ bin/rails generate mistri:install AgentEntry
 
 ```ruby
 require "mistri/stores/active_record"
+
 store = Mistri::Stores::ActiveRecord.new(AgentEntry)
 ```
 
-The `Stores::ActiveRecord` store needs LONGTEXT for `payload` on MySQL and Trilogy
-because one legal parallel tool turn can exceed MEDIUMTEXT even when each call
-stays inside its own limit. The generator uses `size: :long` for new
-MySQL-family tables. An existing installation needs its own migration; changing
-the generator cannot widen a table that already exists:
+Steering is another append, so a request handler or worker can redirect a live
+exchange without sharing its Agent object:
 
 ```ruby
-change_column :agent_entries, :payload, :text, size: :long, null: false
-```
-
-## Compaction
-
-Long sessions survive their context window: when the conversation grows into
-the model's safe headroom, the provider writes a visible structured summary
-and replay continues from it. The full history stays exact in your store for
-transcript views. On by default whenever the model's window is known;
-`compaction: false` disables it.
-
-For a catalogued model, Mistri automatically reserves its full output capacity
-plus 4,096 tokens for framing and estimation when input and output share one
-context window. Gemini publishes independent input and output limits, so its
-automatic input reserve remains 16,384 tokens. An uncatalogued model with a
-host-supplied `window:` also uses that 16,384-token fallback; set `reserve:`
-explicitly when the deployment needs different output headroom. An explicit
-reserve is also a useful quality policy when you prefer an earlier checkpoint
-to counter context rot.
-
-```ruby
-agent.context_usage   # => { tokens: 141_000, window: 1_000_000, fraction: 0.141 }
-agent.compact         # the manual button
-
-Mistri::Compaction.new(reserve: 64_000) # explicit quality policy
-```
-
-`:compacting` and `:compaction` events carry the summary, so users see
-exactly what the model still remembers. A single run can compact between tool
-turns without splitting a tool call from its results. Very large tool results
-are shortened only in the request sent to the summarizer. That shortening
-never mutates the durable result or an ordinary request that still replays it.
-Once compaction commits, replay intentionally becomes the visible summary plus
-its kept tail.
-
-## Task mode
-
-A run that must end in JSON matching a schema. Tools run as usual; providers
-constrain the final answer natively where they can, and the answer is
-validated client-side everywhere. A violation goes back to the model once,
-then raises. Task output uses the same portable subset and 8 MiB, 64-level,
-10,000-node, and 64 KiB numeric-token limits as tool input. A schema containing
-an assertion outside that subset fails at configuration time instead of
-claiming a guarantee Mistri cannot enforce. The prompt and final local check
-share one deeply frozen strict schema snapshot. Each provider derives a native
-constraint only when its structured-output subset can represent that contract,
-the model is catalogued for that provider, and documented complexity ceilings
-are satisfied. Otherwise Mistri omits the native constraint and relies on the
-same prompt, validation, and correction loop. You get a guaranteed shape or a
-loud error, never silence.
-
-```ruby
-schema = {
-  type: "object",
-  properties: { "tiers" => { type: "array", items: { type: "string" } } },
-  required: ["tiers"],
-}
-
-result = agent.task("Extract the pricing tiers from this page.", schema: schema)
-result.output # => { "tiers" => [...] }, parsed and validated
-```
-
-A run that suspends for approval, or that an `ends_turn` tool ended,
-returns as-is: validation applies to answers, not handoffs. Route on
-`result.handed_off?` and ask again once the human's answer arrives.
-
-## Skills
-
-Expert playbooks with progressive disclosure: each skill costs one line in
-the system prompt until the model decides it is relevant and pulls the full
-body through an auto-provided `read_skill` tool.
-
-```ruby
-agent = Mistri.agent("claude-opus-4-8", skills: "app/skills")   # or an array of Mistri::Skill
-```
-
-A skill is a `SKILL.md` (or flat `.md`) with `name:`/`description:`
-frontmatter, or built from database rows with
-`Mistri::Skill.new(name:, description:, body:)`.
-
-## Definitions
-
-An agent as a markdown file: YAML frontmatter for config, the body as the
-prompt, `{placeholders}` filled at build time (unfilled ones raise). Tool
-names and any extra keys stay your vocabulary; the gem only reads the
-file.
-
-```ruby
-definition = Mistri::Definition.load("app/agents/trip_planner.md")
-agent = Mistri.agent(definition.model,
-                     system: definition.render(first_name: traveler.first_name),
-                     tools: registry.build(definition.tools, traveler))
-```
-
-## Sub-agents
-
-Delegate to a child agent with a clean context: exploration fills the
-child's window, and only the final answer returns. Children run on their own
-sessions in your store, linked in the parent transcript; their events stream
-into the parent tagged with an `origin`. Each run of a specialist can carry
-its own name, so two parallel researchers read as Corgi and Beagle in your
-UI instead of "researcher" twice.
-
-```ruby
-researcher = Mistri::SubAgent.new(
-  name: "researcher", description: "Reads pages and answers factual questions.",
-  provider: Mistri.provider("claude-haiku-4-5-20251001"),   # cheaper model for grunt work
-  system: "Research. Report findings only.", tools: [fetch_page],
-)
-agent = Mistri.agent("claude-opus-4-8", tools: [researcher.tool])
-```
-
-Or hand the model an open spawn tool and let it compose its own workers:
-a name, instructions, a tool subset, and a host-allowlisted model per
-child. Several spawns in one turn fan out in parallel. `pack` is the whole
-kit: the spawn tool plus a management console (`list_agents`, `read_agent`,
-`steer_agent`, `stop_agent`), with curated types and an optional
-dispatcher:
-
-```ruby
-spawn = Mistri::SubAgent.spawner(provider: provider, tools: [fetch_page, search])
-
-tools = Mistri::SubAgent.pack(
-  provider: provider, tools: [fetch_page, search],
-  types: { "researcher" => Mistri::Definition.load("agents/researcher.md") },
-  models: ["claude-haiku-4-5-20251001"],
-  dispatcher: Mistri::Dispatchers::Thread.new,      # or one lambda onto your queue
+Mistri::Session.new(store: store, id: session_id).steer(
+  "Make the headline blue instead."
 )
 ```
 
-A typed worker takes its prompt, tools, and model from the host's
-definition; `general-purpose` stays open for the model to compose.
-`max_children` (default 4) caps live workers, and every policy violation
-answers the model in band.
+Only one Agent may actively call `run` or `resume` for a session at a time.
+Approvals, steering, and worker reports may append concurrently. Read the
+[reliability contract](docs/reliability.md) before connecting tools with
+external side effects.
 
-Everything cross-process (stopping a worker from another process, the
-`:interrupted` liveness read, and the lease fence below) rides a lock
-adapter; configure one at boot. Without it, workers still run, but stops
-need the parent's own signal, a crashed child reads `:running`, and
-dispatched retries are unfenced:
+## Streaming into any Ruby application
+
+Every run accepts a block. Handle events directly, or compose a sink:
 
 ```ruby
-Mistri.locks = Mistri::Locks::RailsCache.new   # Locks::Memory for a single process
-```
-
-With a dispatcher, `spawn_agent` takes `mode: "background"`: the model gets
-a truthful receipt at once and keeps working while the child runs. The
-console manages the roster with the same functions a host UI calls, so
-agent and user control stay structurally equal: either can read a worker's
-transcript, steer it mid-run, or stop it, from any process. When a worker
-finishes, its report delivers itself: a typed entry queues in the parent's
-inbox and folds at the next turn boundary as `[Corgi finished] <report>`
-(failures carry the error), while a `:subagent_report` event settles the
-worker's lane in whatever UI watched the spawn. In a queue host, the job
-rebuilds tools from the serializable spec and calls
-`SubAgent.run_dispatched`, which fences on the child's lease: a redelivered
-job leaves the running owner alone, a retry of a finished child is a no-op,
-and a retry of a crashed one runs it again.
-
-Everything about a child derives from the store and reads the same from
-any process, while it runs and forever after:
-
-```ruby
-session.children               # => [#<Mistri::Child Corgi running>, ...]
-child.status                   # :queued, :running, :done, :stopped, :failed
-child.report                   # the terminal entry's report, once finished
-child.say("Check pricing too") # folds at the child's next turn boundary
-child.stop                     # cooperative, cross-process, within a tick
-
-session.transcript(include_children: true)
-# the whole conversation, each child's log spliced at its link entry and
-# origin-tagged like the live stream: a reloading UI rebuilds its lanes
-```
-
-## Editing documents
-
-The document tools (`read_file`, `edit_file`, `write_file`, `find_in_file`,
-`list_files`) work over a workspace: a directory, memory, ActiveRecord, or
-a single value anywhere, like one database column holding a page:
-
-```ruby
-workspace = Mistri::Workspace::Single.new(
-  read: -> { page.html },
-  write: ->(html) { page.update!(html: html) },
-  path: "hero.html",
-)
-agent = Mistri.agent("claude-opus-4-8", tools: Mistri::Tools.files(workspace))
-```
-
-The edit engine matches exactly, then whitespace-tolerantly; an ambiguous
-match refuses (never silently edits the wrong place), and a near-miss error
-names the closest region so the model's retry is one-shot.
-
-## MCP
-
-Bridge any Model Context Protocol server's tools into an agent. The client
-speaks Streamable HTTP with zero new dependencies; auth is a token string
-or a lambda that re-resolves once on 401, so refresh logic lives in one
-place. Approval gates compose: a third-party write tool can require a
-human.
-
-```ruby
-client = Mistri::MCP::Client.new(url: "https://mcp.linear.app/mcp",
-                                 token: -> { connection.bearer_token })
-tools = Mistri::MCP.tools(client, prefix: "linear",
-                          gates: { "create_issue" => true })
-
-agent = Mistri.agent("claude-opus-4-8", tools: tools)
-```
-
-Common MCP map input schemas work with Mistri's portable validator through
-schema-valued `additionalProperties`. Standard assertions outside that subset
-(`minimum`, `pattern`, `anyOf`, same-document `$ref`, ...) bridge as guidance:
-Mistri enforces directly reachable portable constraints locally. Constraints
-inside an unsupported applicator such as `anyOf` remain server guidance as one
-unit, and the server validates the full contract, which the MCP spec already
-requires of it. When host policy must rely on assertions outside the portable
-subset, a complete validator takes explicit whole-contract authority locally:
-
-```ruby
-tools = Mistri::MCP.tools(
-  client,
-  complete_argument_validator: ->(args, schema) { validator.errors(args, schema) }
-)
-```
-
-Argument-applicable non-empty `patternProperties` requires the complete
-validator because regex matching changes validation and can determine key
-legality in a closed schema. Core will not approximate it. Omitted MCP
-`inputSchema` means a no-argument object. Explicit `null` and non-object roots
-are configuration errors. Mistri currently compiles MCP inputs as JSON Schema
-2020-12 and rejects an explicit older dialect. External references are rejected
-in every mode so validation never performs hidden network or file resolution.
-
-Remote URLs are untrusted input. Mistri accepts public HTTPS destinations by
-default, rejects the whole DNS result when any answer is non-public, and pins an
-approved address while keeping the hostname for Host, SNI, and certificate
-verification. Each connection cycle resolves and validates every DNS answer;
-Net::HTTP's internal keep-alive reconnects start a new cycle. Approved
-candidates from one result are tried only before request bytes are sent. MCP
-and server-side OAuth requests do not follow redirects or inherit ambient HTTP
-proxy settings.
-
-Private MCP and authorization servers remain available through one narrow host
-policy, passed to the client and every OAuth operation:
-
-```ruby
-INTERNAL_RANGE = IPAddr.new("10.20.0.0/16")
-ALLOW_INTERNAL_MCP = lambda do |uri, address|
-  %w[mcp.internal.example auth.internal.example].include?(uri.hostname) &&
-    INTERNAL_RANGE.include?(address)
-end
-
-# Override this hook in a generated Rails connection model.
-class McpConnection
-  def self.mcp_allow_non_public = ALLOW_INTERNAL_MCP
-end
-
-client = Mistri::MCP::Client.new(url: "https://mcp.internal.example/mcp",
-                                 allow_non_public: ALLOW_INTERNAL_MCP)
-```
-
-The callback is consulted only for non-public addresses; it cannot permit an
-invalid URL or plaintext HTTP to a non-loopback destination. Local development
-can explicitly use `->(_uri, address) { address.loopback? }`.
-
-The bridge lists the server's tools once, at build time; `client.tools(refresh: true)`
-re-lists when a host wants a changed toolset. Discovery rejects repeated cursors
-and defaults to 100 pages or 10,000 tools; `max_tool_pages:` and `max_tools:`
-let a host set explicit limits. `prefix:` namespaces local names
-(`linear__create_issue`) because duplicate tool names raise at `Agent.new`:
-collisions fail loud instead of one server's tool silently shadowing another's.
-
-Inbound JSON bodies, individual SSE lines, and stdio JSON records default to an
-8 MiB `max_record_bytes:` ceiling. It limits one atomic record, not the total
-length of a stream. Each completed SSE JSON record also gets one bounded linear
-lexical scan with a 20,001-token ceiling, plus depth and 64 KiB numeric-token
-ceilings, before parsing. That scan can raise `ResponseTooComplexError`; byte
-overflow raises `ResponseTooLargeError`. Both errors carry `kind` and `limit` as
-machine-readable data.
-
-Either boundary closes and resets the MCP wire, including its session, protocol
-version, and server information, so the next operation performs a fresh
-handshake. If an unconfirmed `tools/call` crosses either boundary, Mistri raises
-`AmbiguousDeliveryError`: the operation may have completed and must not be
-retried automatically. A matching result received before an invalid trailing
-SSE record remains authoritative, but the wire is still reset. For a trusted
-server, configure a larger explicit byte limit; the structural ceilings remain
-fixed.
-
-Large tool output is better stored by the server or host and returned as an MCP
-`resource_link`; Mistri renders its URI for the model and never fetches the
-target itself.
-
-Local stdio servers spawn as child processes, credentials in their
-environment. That is also the whole "give the agent a browser" story:
-
-```ruby
-browser = Mistri::MCP::Client.new(
-  command: ["npx", "-y", "@playwright/mcp@latest", "--browser", "chrome", "--headless"],
-  max_record_bytes: 16 * 1024 * 1024, # explicit trust for larger screenshots
-)
-agent = Mistri.agent("claude-opus-4-8",
-                     tools: Mistri::MCP.tools(browser, allow: %w[browser_navigate browser_snapshot]))
-```
-
-For the full connect-your-tools story in Rails, generate a connection model
-(name it whatever you like):
-
-```console
-$ bin/rails generate mistri:mcp McpConnection
-```
-
-Each row is one server connection carrying its own OAuth flow state and
-encrypted tokens. The OAuth services underneath (`Mistri::MCP::OAuth.start`,
-`.complete`, `.refresh`) are storage-agnostic, so the same flow works from a
-controller, a GraphQL mutation, or a job. Registration happens as your
-application: `client_name:` is yours to set. The generated row persists the
-authorization-server identity selected during registration; token endpoints
-are rediscovered from that exact issuer before code exchange and refresh.
-
-```ruby
-connection, authorize_url = McpConnection.connect(
-  name: "Linear", url: params[:url],
-  client_name: "YourApp", redirect_uri: mcp_callback_url,
-)
-# redirect the user to authorize_url; then, in the callback:
-connection = McpConnection.complete(state: params[:state], code: params[:code])
-
-agent = Mistri.agent("claude-opus-4-8", tools: connection.tools(prefix: "linear"))
-```
-
-When calling the low-level OAuth services directly, persist `flow["issuer"]`
-and `flow["resource"]`, verify callback state against `flow["state"]`, and pass
-the same `allow_non_public:` callback to `start`, `complete`, and `refresh` for
-an internal server. A pre-registered `client_id` belongs to a specific
-authorization server, so `start` requires the exact trusted `issuer:` supplied
-when that client was registered. If protected-resource metadata advertises
-more than one issuer, the host must select one explicitly. `start` still
-returns `token_endpoint` for compatibility, but `complete` and `refresh` do
-not trust it; they rediscover the current endpoint from `issuer`.
-
-Generated models copied by an older Mistri release are not rewritten when the
-gem updates. Before using this version, add an `issuer` string column, pass it
-to `complete` and `refresh`, and thread one class-owned egress policy through
-all three OAuth operations and `Client` if non-public destinations are used.
-Restart pending OAuth flows. Existing connected rows may be backfilled only
-when the application independently recorded the exact issuer used during
-registration; otherwise reconnect them. Never infer an issuer from a token
-endpoint. The current generator shows the complete wiring.
-
-## Streaming into Rails
-
-Sinks bridge the event stream to a transport, and compose as blocks:
-
-```ruby
-cable = Mistri::Sinks::ActionCable.new("agent_#{session.id}")
-sink = Mistri::Sinks::Coalesced.new(cable) # merges token bursts to UI speed
+sse = Mistri::Sinks::SSE.new(stream)          # any IO-like object
+sink = Mistri::Sinks::Coalesced.new(sse)      # merge token bursts to UI speed
 
 agent.run(input, &sink)
 ```
 
-`Mistri::Sinks::SSE.new(response.stream)` does the same for
-`ActionController::Live`. There is no Railtie and nothing to configure;
-the generator and stores duck-type into any app.
+`Mistri::Sinks::ActionCable` is available for Rails, but no Railtie is required.
+The same event stream works in Sinatra, Rack, a WebSocket server, a background
+job, or a test. Event types form an extensible union; consumers should handle
+the types they use and ignore the rest.
 
-## Stopping, budgets, reliability
+## Long conversations and structured tasks
 
-```ruby
-# Trip the signal from anywhere; the partial turn persists, resume is clean.
-signal = Mistri::AbortSignal.new
-agent.run("Draft a long essay.", signal: signal)
-
-# Ceilings are opt-in and off by default. Dollar cost uses each request's
-# published paid-list rate, including long-context tiers and dated changes.
-budget = Mistri::Budget.new(turns: 20, cost_usd: 2.00)
-
-# Anthropic and OpenAI need an explicit standard tier for a cost budget.
-agent = Mistri.agent("gpt-5.6-terra", budget: budget,
-                     provider_options: { service_tier: "default" })
-
-# Transient failures (429, 5xx, timeouts) retry with backoff, invisibly to
-# the model. On by default; retries: false disables.
-policy = Mistri::RetryPolicy.new(attempts: 3)
-```
-
-Cost is explicit: `result.usage.cost.known?` is false when Mistri cannot
-price every turn. Constructing an agent with `cost_usd` therefore requires a
-catalogued model, a list-priced origin, and deterministic standard-tier policy
-instead of treating unknown cost as free. Anthropic uses `standard_only`;
-OpenAI uses `default`; Gemini's omitted tier is standard by contract. All
-ceilings are checked between model-visible turns, so the final turn, including
-its provider retry attempts, can exceed one. If an attempted request has no
-trustworthy usage, the run raises `BudgetError` and does not retry it. The
-error exposes `usage` and `provider_message`, and the session records an
-`unpriced_attempt` entry for reconciliation. Reported dollars are standard paid
-direct-API list-price estimates; contracted or regional uplifts and separately
-billed provider tools are outside this total.
-Gemini free-tier usage is conservatively valued at the paid rate.
-
-Built-in providers disable catalog pricing for a custom `origin:`. Pass
-`catalog_pricing: true` only when that route bills the same published rates.
-Pricing never changes service-tier policy. Anthropic and OpenAI usage is known
-only when the response reports their standard tier; Priority, Flex, or a
-missing tier stays unknown. A host that needs deterministic list-price
-budgeting can select it explicitly with `provider_options: { service_tier:
-"standard_only" }` for Anthropic or `"default"` for OpenAI. Gemini observes
-`usageMetadata.serviceTier`; Flex and Priority are unpriced by this catalog.
-A custom provider can support cost ceilings by returning true from
-`prices_usage?` and attaching a known cost to every response, commonly with
-`Mistri::Usage#with_cost`; missing or partial pricing then fails closed at
-runtime.
-
-Retries are invisible to the model but not to your UI: each backoff emits a
-`:retry` event carrying `attempt`, `max_attempts`, and `delay`, so a sink can
-show a live "reconnecting" state instead of a silent spinner. Terminal events
-are loop-owned: `:done` and `:error` reach the subscriber only for the
-accepted attempt, so a recovered retry never flashes an error it then walks
-back.
-
-Every provider attempt begins with one `:start` event carrying an immutable
-empty assistant snapshot. Each opened text, thinking, or tool-call block then
-has a matched start/delta/end sequence, including before a terminal failure.
-
-Built-in assemblers fail malformed known stream lifecycles instead of accepting
-content that could become executable. Terminal records fence later known
-content. Anthropic requires sequential/open block indexes and a delta kind that
-matches the open block. OpenAI requires one open item, checks its kind and any
-present item/output correlation fields on known deltas, and requires terminal
-event and response status to agree. Unknown future event and block types remain
-ignorable for forward compatibility. Interrupted tool calls remain marked
-incomplete and are removed before Agent persistence or execution.
-
-Tool execution emits `:tool_started` when each resolved call commits to
-execution, then `:tool_result` with an explicit `tool_error` boolean. Calls
-still queued behind `max_concurrency`, blocked by policy, waiting for approval,
-denied, unknown, or interrupted before invocation never claim to have started.
-Starts arrive from tool worker threads as execution begins; sinks must tolerate
-serialized callbacks from those threads. Results settled in the same batch
-retain deterministic model-call order and emit after the parallel batch joins,
-as before. A subscriber exception from `:tool_started` or handler-emitted
-progress propagates to the run and never becomes a tool result.
-Event types are an extensible union; subscribers should handle the types they
-use and ignore the rest.
+Compaction is on by default for catalogued models. When a session enters the
+model's safe headroom, Mistri asks the provider for a visible structured
+summary, appends it, and continues from the summary plus a recent tail. The
+exact history remains in the store for transcripts.
 
 ```ruby
-agent.run("Plan the itinerary.") do |event|
-  case event.type
-  when :text_delta then stream(event.delta)
-  when :retry then banner("Retrying (#{event.attempt}/#{event.max_attempts}) in #{event.delay}s")
-  when :tool_started then tool_running(event.tool_call)
-  when :tool_result then tool_finished(event.tool_call, failed: event.tool_error)
-  when :done, :error then clear_banner
-  end
-end
+agent.context_usage
+# => { tokens: 141_000, window: 1_000_000, fraction: 0.141 }
+
+agent.compact # explicit checkpoint; returns nil when nothing should compact
 ```
 
-## Images and provider options
+Task mode requires a final JSON value matching a schema. Providers use native
+constraints only when they can represent the contract; Mistri validates the
+answer locally in every case.
 
 ```ruby
-photo = Mistri::Content::Image.from_bytes(File.binread("chart.png"), mime_type: "image/png")
-photo = Mistri::Content::Image.from_data_uri(params[:image])   # canvases and uploads
-agent.run("What trend does this chart show?", images: [photo])
+schema = {
+  type: "object",
+  properties: {
+    "tiers" => { type: "array", items: { type: "string" } },
+  },
+  required: ["tiers"],
+}
 
-Mistri.agent("gpt-5.6", provider_options: { reasoning: { effort: "high" } })
-Mistri.agent("claude-opus-4-8", provider_options: { cache: false })
-Mistri.agent("gemini-3.1-pro-preview",
-             provider_options: { max_record_bytes: 16 * 1024 * 1024 })
+result = agent.task("Extract the pricing tiers.", schema: schema)
+result.output # parsed and validated
 ```
 
-## Testing
+Task validation applies when that invocation completes normally. An approval
+suspension or `ends_turn` handoff returns with `output` nil; after settlement or
+the human answer, call `task` again if structured output is still required.
 
-`rake test` is hermetic and fast. The Fake provider streams like the real
-ones for ordinary small fixtures, tool-call arguments included: its eager
-partials make UI tests simple, while real Anthropic/OpenAI assemblers expose a
-bounded cached preview under adversarial fragmentation. A UI that renders tool
-input as it arrives still tests headless. `rake integration` runs every feature
-end to end against real provider APIs, once per model in the matrix: an
-Anthropic, an OpenAI, and a Gemini model by default. Scenarios assert that
-coined codenames (a ghost of a word like `Wraithowyn` exists in no training
-data) flowed through tool results, summaries, and child agents: proof of
-information flow, not model knowledge.
+See [Sessions and control](docs/sessions.md) for compaction boundaries,
+cross-provider replay, stores, approvals, and transcripts.
+
+## Sub-agents
+
+Delegate work into a child session so exploration does not consume the parent's
+context. Only the report returns to the parent, while the full child transcript
+remains linked and inspectable.
+
+```ruby
+researcher = Mistri::SubAgent.new(
+  name: "researcher",
+  description: "Reads pages and answers factual questions.",
+  provider: Mistri.provider("claude-haiku-4-5"),
+  system: "Research the question. Return findings and sources.",
+  tools: [fetch_page],
+)
+
+agent = Mistri.agent("claude-opus-4-8", tools: [researcher.tool])
+```
+
+Mistri also provides a host-bounded spawn tool, named worker types, background
+dispatch, reports, steering, stopping, and a management console. See
+[Sub-agents](docs/sub-agents.md), including the concurrency and lease limits a
+production dispatcher must understand.
+
+## Model Context Protocol
+
+Bridge tools over Streamable HTTP or stdio, then apply the same local approval
+and validation boundary:
+
+```ruby
+client = Mistri::MCP::Client.new(
+  url: "https://mcp.linear.app/mcp",
+  token: -> { connection.bearer_token },
+)
+
+tools = Mistri::MCP.tools(
+  client,
+  prefix: "linear",
+  gates: { "create_issue" => true },
+)
+```
+
+Remote URLs default to public HTTPS with validated, pinned DNS answers. Inbound
+records are size-bounded. An unconfirmed `tools/call` is never replayed
+automatically because the server may already have committed its side effect.
+OAuth services are storage-agnostic; the Rails connection generator is one
+optional host adapter.
+
+Read [MCP](docs/mcp.md) for stdio, OAuth, private-network policy, schema
+authority, response limits, and large-result resource links.
+
+## Skills, definitions, and workspaces
+
+- **Skills** expose one-line descriptions until the model requests the full
+  `SKILL.md`, keeping the system prompt small.
+- **Definitions** load an agent's model, tool names, and prompt from Markdown
+  with YAML frontmatter and checked placeholders.
+- **Workspaces** give the built-in read, write, edit, find, and list tools a
+  directory, memory value, Active Record table, or single host-owned value.
+
+The edit engine refuses ambiguous matches. A Directory workspace rejects
+lexical escape and traversal through existing symlinks in a stable,
+host-controlled tree; it is not an operating-system sandbox. See
+[Context and workspaces](docs/context-and-workspaces.md) and the runnable
+[`page_editor.rb`](examples/page_editor.rb) example.
+
+## Reliability contract
+
+Mistri makes failures explicit, but it does not pretend distributed side
+effects are exactly once:
+
+- Provider requests retry transient failures with backoff. The MCP client never
+  replays an ambiguous tool call; the Agent bridge returns the uncertainty as
+  an error-marked tool result.
+- A process can crash after a handler commits an external write but before the
+  result reaches the session. Tools with side effects must be idempotent or
+  reconcilable.
+- Budgets are checked between model-visible turns, so they are soft ceilings.
+- Provider and MCP records default to an 8 MiB per-record limit; streaming has
+  no total-size limit while each record remains safe.
+- `Mistri::AbortSignal` is an in-process cooperative signal. Cross-process
+  worker control uses the configured lock adapter and is also cooperative.
+
+The complete operational contract, event lifecycle, retry behavior, pricing
+rules, and sink guidance live in [Reliability](docs/reliability.md).
+
+## Documentation
+
+All primary documentation is versioned with the code and renders directly on
+GitHub:
+
+| Guide | What it covers |
+| --- | --- |
+| [Documentation index](docs/README.md) | The complete task-oriented map |
+| [Tool contracts](docs/tool-contracts.md) | Schemas, validation, approval, hooks, results, and handoff |
+| [Sessions and control](docs/sessions.md) | Stores, replay, approvals, steering, compaction, and transcripts |
+| [Context and workspaces](docs/context-and-workspaces.md) | Skills, definitions, context transforms, host-owned memory, and editable documents |
+| [Sub-agents](docs/sub-agents.md) | Specialists, spawning, dispatch, locks, reports, and control |
+| [MCP](docs/mcp.md) | HTTP and stdio, OAuth, egress policy, limits, and schema handling |
+| [Reliability](docs/reliability.md) | Retries, events, budgets, stopping, concurrency, and side effects |
+| [Upgrade guide](UPGRADING.md) | Required host changes between releases |
+| [Changelog](CHANGELOG.md) | Complete release history and exact behavior changes |
+
+## Testing and contributing
+
+The default suite is hermetic and needs no API keys:
 
 ```console
+$ bundle exec rake test
+$ bundle exec rubocop
+```
+
+Live tests read provider keys from the gitignored
+`.env.development.local` file:
+
+```console
+$ MISTRI_LIVE=1 bundle exec rake test
 $ bundle exec rake integration
 $ MISTRI_INTEGRATION_MODELS=claude-opus-4-8 bundle exec rake integration
 ```
 
-## Roadmap
+The integration matrix exercises critical end-to-end scenarios against one
+Anthropic, OpenAI, and Gemini model by default when the corresponding keys are
+present. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the project contract.
 
-Next up: atomic cross-process claims for active session runners,
-provider-native MCP passthrough, optional full JSON Schema adapters, and
-resource-backed handling for very large tool results.
+## Compatibility and support
+
+Mistri supports Ruby 3.2 and newer. It is pre-1.0: minor releases may include
+intentional contract changes with an explicit migration path. Read
+[UPGRADING.md](UPGRADING.md) and [CHANGELOG.md](CHANGELOG.md) before upgrading.
+
+Use [GitHub issues](https://github.com/mcheemaa/mistri/issues) for reproducible
+bugs and focused feature proposals. Report vulnerabilities privately as
+described in [SECURITY.md](SECURITY.md).
 
 ## Credits
 
 Mistri's architecture is informed by [pi](https://github.com/badlogic/pi-mono)
-by Mario Zechner. See NOTICE.
+by Mario Zechner. See [NOTICE](NOTICE).
 
 ## License
 
-MIT. See LICENSE.
+MIT. See [LICENSE](LICENSE).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,458 @@
+# Upgrading Mistri
+
+Mistri follows SemVer from 0.x: patches fix behavior, while a minor release may
+add features and intentional contract changes. Every change belongs in the
+[changelog](CHANGELOG.md); this guide extracts only the work an existing host
+may need to perform.
+
+Upgrade a representative application and persisted session set in staging
+before production. Do not treat a passing bundle update as a session migration
+test.
+
+## From 0.5.x to 0.6.x
+
+This is a safety-focused minor upgrade. The built-in Anthropic, OpenAI, and
+Gemini providers preserve ordinary 0.5 sessions, including the repeated
+`call_N` IDs older Gemini and Fake-provider turns generated after the earlier
+occurrence settled. There is no blanket session rewrite step.
+
+Hosts that used implicit tool schemas, mutated arguments, supplied custom
+providers, generated MCP OAuth models, stored sessions in MySQL, or configured
+cost budgets need to review the sections below.
+
+### Checklist
+
+- [ ] Declare every argument a model may send to a formerly schema-less tool.
+- [ ] Remove handler or policy mutations of model argument hashes and arrays.
+- [ ] Replace implicit coercion with an explicit per-tool normalizer where it is
+      genuinely part of the contract.
+- [ ] Make event subscribers tolerate new event types and read `tool_error`
+      structurally.
+- [ ] Ensure at most one `run` or `resume` is active per Session across all
+      processes.
+- [ ] Audit custom provider tool-call IDs, names, arguments, and metadata.
+- [ ] Widen Active Record session payloads to LONGTEXT on MySQL or Trilogy.
+- [ ] Update generated MCP OAuth models to persist issuer and share egress
+      policy across the complete flow.
+- [ ] Review the new MCP and provider response limits and ambiguous-delivery
+      behavior.
+- [ ] Configure a deterministic standard service tier for any cost budget.
+- [ ] Remove intentional symlinks from model-controlled Directory workspaces.
+- [ ] Exercise active persisted sessions, approvals, tool failures, compaction,
+      and one real call per configured provider in staging.
+
+## Tool schemas are enforced locally
+
+Model-originated arguments now cross ownership and schema validation before
+`before_tool`, approval predicates, `ends_turn`, MCP, or handlers.
+
+Invalid input receives a bounded error result the model can correct. Valid
+sibling calls still run. Mistri does not coerce values.
+
+### Schema-less tools are closed
+
+In 0.5, the no-argument wire schema did not explicitly reject extra fields. In
+0.6, a tool without `schema:` or `input_schema:` is a closed no-argument tool.
+
+No change is needed when the tool truly accepts no arguments:
+
+```ruby
+Mistri::Tool.define("current_time", "Returns the current time.") do
+  Time.now.utc.iso8601
+end
+```
+
+Declare every accepted field when the handler uses arguments:
+
+```ruby
+Mistri::Tool.define("lookup", "Looks up one account.", schema: lambda {
+  string :account_id, "Account ID", required: true
+}) do |args|
+  Accounts.fetch(args.fetch("account_id"))
+end
+```
+
+For an intentionally freeform object, say so explicitly:
+
+```ruby
+input_schema = {
+  type: "object",
+  additionalProperties: true,
+}
+```
+
+The schema-less wire shape changes once, so provider prompt caches for affected
+tool sets will re-warm after deployment.
+
+### Supplied objects remain open by default
+
+JSON Schema object properties do not close the object. If extra keys must fail,
+use a raw schema with `additionalProperties: false`. Otherwise extract declared
+fields instead of mass-assigning the complete argument hash.
+
+### JSON Schema dialect and subset
+
+Tool schemas use JSON Schema 2020-12. Replace legacy tuple-array `items: [...]`
+with `prefixItems`. A supplied explicit older dialect is rejected.
+
+Core enforces its documented portable subset. Use `argument_validator:` for
+domain additions and `complete_argument_validator:` only when the host
+validator implements the entire schema. Argument-applicable non-empty
+`patternProperties` requires complete authority. External references are never
+resolved.
+
+Task mode now rejects an assertion Mistri cannot guarantee locally instead of
+claiming validated output and leaving part of the schema to provider guidance.
+Freeform objects cannot become strict task output without changing meaning.
+
+See [Tool contracts](docs/tool-contracts.md).
+
+### Schema objects are canonical and immutable
+
+`Tool#input_schema` and `Schema.strict` now expose deeply frozen canonical JSON
+with String keys. Replace Symbol-key access and mutation:
+
+```ruby
+# Before
+tool.input_schema[:properties][:account_id] = rule
+
+# After
+account_schema = tool.input_schema.fetch("properties").fetch("account_id")
+```
+
+Build a new schema when the host needs a changed contract. `Tool.define` now
+rejects supplying both `schema:` and `input_schema:`; choose one. Calling
+`Schema.build` without a block now raises because it declares no argument
+intent.
+
+## Arguments are immutable and policy sees validated types
+
+Completed arguments and the canonical schema are deeply frozen. Code that
+mutated model input must copy the portion it owns:
+
+```ruby
+# Before: mutates the value shared with policy and replay.
+args["tags"] << "processed"
+
+# After: build application-owned data.
+tags = args.fetch("tags", []).dup
+tags << "processed"
+```
+
+For a fully mutable JSON copy:
+
+```ruby
+owned = JSON.parse(JSON.generate(args))
+```
+
+Approval predicates can now rely on declared types. Remove defensive coercion
+that changes authorization meaning:
+
+```ruby
+# Do not turn "all" into zero at an authorization boundary.
+approval_policy = ->(args) { args.fetch("total_usd") > 500 }
+```
+
+When a host intentionally accepts a legacy alias or representation, use
+`argument_normalizer:`. Its output is what validation, policy, approval, and
+the handler see. It runs once before validation and does not run again on
+resume.
+
+Direct `Tool#call` remains a trusted host path. It applies the tool's normalizer
+but does not invoke the Agent's model-input validation boundary.
+
+## Tool lifecycle and event subscribers
+
+Tool results now carry a structured error fact. A handler may return
+`Mistri::ToolResult.new(content: ..., error: true)`, and Mistri sets the same
+fact for invalid, blocked, unknown, interrupted, timed-out, or failed calls.
+
+`:tool_started` is emitted only when a resolved call commits to handler
+invocation. `:tool_result` always carries a boolean `event.tool_error`; new
+persisted tool messages carry the same value. Legacy messages without the field
+remain unknown rather than being classified from prose.
+
+`:tool_started` and handler progress callbacks originate on tool worker threads.
+Custom sinks must be thread-safe. Code that manually constructs a
+`:tool_result` `Mistri::Event` must now supply a boolean `tool_error` matching
+the Message.
+
+Update exhaustive event switches to ignore unknown future members:
+
+```ruby
+case event.type
+when :text_delta
+  stream(event.delta)
+when :tool_started
+  mark_running(event.tool_call)
+when :tool_result
+  settle(event.tool_call, failed: event.tool_error)
+else
+  # Event types are an extensible union.
+end
+```
+
+Do not decide failure by matching prefixes such as `"Error:"`. Human denial is
+an expected control result and is not marked as execution failure.
+
+The error fact never authorizes mechanical replay. A handler can commit a side
+effect before it raises.
+
+Public value records gained fields: `ToolCall` adds `arguments_error` and
+`provider_call_id`, `ToolResult` adds `error`, and Message/Event records add
+`tool_error`. Keyword construction remains compatible through defaults, but
+exact positional deconstruction or pattern matching can break. Prefer named
+accessors and key patterns, and treat value and event records as extensible.
+
+## Custom provider contract
+
+Built-in providers already satisfy the new envelope. A custom provider must
+return completed `Mistri::ToolCall` values with:
+
+- a non-empty, valid UTF-8 String ID;
+- an ID unique for new calls over the active Session;
+- a non-empty, valid UTF-8 String name;
+- a JSON object for valid arguments, or a durable `arguments_error` for
+  malformed encoded input;
+- non-empty valid UTF-8 signature and provider call ID strings when present;
+- provider correlation IDs unique within an assistant turn.
+
+If any completed call makes the assistant turn unpairable, Mistri rejects the
+whole provider attempt before persistence, policy, or sibling execution. The
+ordinary provider retry asks for a clean turn with unchanged history.
+
+`ToolCall#arguments_error?` is the stable predicate. Its non-nil String is an
+opaque diagnostic, not a public enum.
+
+Audit active custom-provider sessions without mutating them:
+
+```ruby
+active_session_ids.each do |session_id|
+  session = Mistri::Session.new(store: store, id: session_id)
+  session.tool_control_state # validates persisted call and approval identity
+end
+```
+
+The legacy repeated `call_N` exception is deliberately limited to settled 0.5
+Gemini and Fake-provider history without provider correlation IDs. Do not copy
+that shape into a custom provider.
+
+Fake-provider call IDs are now namespaced instead of restarting at `call_1`,
+`call_2`, and so on. Script an explicit `id:` when a test or persisted fixture
+needs deterministic identity.
+
+If an old custom log contains malformed IDs that cannot be paired safely, keep
+the old application version available long enough to complete or retire that
+session according to host policy. Do not invent replacement IDs in replay; they
+would corrupt tool-result correlation.
+
+## Session stores
+
+### MySQL and Trilogy payload width
+
+The generated Active Record session table now uses LONGTEXT for `payload`. An
+existing table is not changed by updating the generator:
+
+```ruby
+class WidenAgentEntryPayload < ActiveRecord::Migration[7.2]
+  def change
+    change_column :agent_entries, :payload, :text, size: :long, null: false
+  end
+end
+```
+
+Use the migration version appropriate for the host application. PostgreSQL
+`text` needs no width change.
+
+### Store value ownership
+
+`Mistri::Stores::Memory` now owns data on append and returns fresh mutable
+snapshots on load, matching stores that decode JSON on every read. A custom
+store should not rely on Mistri mutating a previously returned entry object.
+
+### Active Session execution
+
+Mistri does not lease top-level Session execution. The host must ensure that at
+most one `run` or `resume` is active for a Session across all processes.
+Concurrent-safe store appends and child lock adapters do not provide this
+guarantee. Keep external writes idempotent or reconcilable across the
+handler-commit/result-append gap.
+
+`Session#entries` and serialized usage are extensible records. Raw host readers
+must ignore unknown entry types and keys. This release adds lifecycle, approval
+provenance, unpriced-attempt, and `cost.known` data.
+
+## MCP changes
+
+### Existing generated OAuth models
+
+The 0.5 Rails MCP generator stored `token_endpoint`. The current flow persists
+the authorization-server `issuer` and rediscovers the token endpoint from that
+exact identity before code exchange and refresh.
+
+For an existing generated model:
+
+1. Add an `issuer` String column.
+2. Persist `flow["issuer"]` in `connect` instead of trusting
+   `flow["token_endpoint"]`.
+3. Pass `issuer:` to `OAuth.complete` and `OAuth.refresh`.
+4. Keep and pass `token_auth_method`.
+5. Add one class-owned `mcp_allow_non_public` policy and pass it to
+   `OAuth.start`, `.complete`, `.refresh`, and `MCP::Client` when internal
+   destinations are allowed.
+6. Restart pending OAuth flows.
+7. Reconnect existing rows unless the application independently recorded the
+   exact issuer used during registration.
+
+Mistri no longer adds `offline_access`; include it explicitly in `scope:` only
+when host policy and the authorization server require it. The former implicit
+localhost allowance is also gone. Loopback HTTP development now needs an
+explicit `allow_non_public: ->(_uri, address) { address.loopback? }` through the
+complete flow. A pre-registered client, or discovery advertising multiple
+authorization servers, requires the exact trusted `issuer:`.
+
+Never infer an issuer from a token endpoint. They are different security
+identities. An unused legacy `token_endpoint` column may be removed in a later
+host migration after rollback needs have passed.
+
+Compare the generated files in
+[`lib/generators/mistri/mcp/templates/`](lib/generators/mistri/mcp/templates)
+with the host copy. Updating the gem never rewrites generated application code.
+
+### Network policy
+
+Remote MCP and server-side OAuth now default to public HTTPS, validated DNS,
+direct connections, no redirects, and no ambient proxy. An internal server must
+receive the same narrow `allow_non_public:` callback through the entire flow.
+
+Custom headers are copied when the Client is constructed, and transport-owned
+framing, MCP session, and protocol names are rejected. Use the token callable for
+rotating authorization. Deployments that require an ambient forward proxy or
+HTTP redirects need a host-supplied client; the built-in Client deliberately
+connects directly.
+
+### Response limits and delivery
+
+JSON bodies, individual SSE lines, and stdio records default to 8 MiB per
+record. Set a larger `max_record_bytes:` only for a trusted server after
+reviewing the memory boundary.
+
+Provider records use `provider_options: { max_record_bytes: ... }`; the MCP
+Client takes `max_record_bytes:` directly. Servers exceeding the new default of
+100 discovery pages or 10,000 tools must set reviewed `max_tool_pages:` and
+`max_tools:` values explicitly.
+
+An unconfirmed `tools/call` response now raises
+`Mistri::AmbiguousDeliveryError` and is never replayed automatically. Catch it
+when calling the Client directly, mark the operation for reconciliation, and
+verify remote state before deciding whether a new call is safe. A Client used
+through `Mistri::MCP.tools` raises inside the tool executor, which returns the
+same uncertainty as an error-marked tool result. The transport still does not
+replay it, but the model may choose to issue a new call.
+
+### MCP schemas
+
+Mistri enforces directly reachable portable assertions and lets the MCP server
+enforce standard assertions outside that subset. Common map schemas with
+schema-valued `additionalProperties` work in core. Use a complete validator only
+when local policy depends on the whole schema.
+
+An explicit `inputSchema: null` now rejects. Omit `inputSchema` for a closed
+no-argument tool, or provide an object schema.
+
+See [MCP](docs/mcp.md).
+
+## Cost budgets and pricing
+
+0.5 exposed a cost budget but did not calculate provider cost, so the comparison
+effectively saw zero. 0.6 prices catalogued standard paid direct-API usage and
+represents unknown cost as unknown.
+
+A `cost_usd` budget now fails at construction unless the model, origin, and
+service-tier policy can produce deterministic catalog pricing. Configure:
+
+```ruby
+# Anthropic
+anthropic_options = { service_tier: "standard_only" }
+
+# OpenAI
+openai_options = { service_tier: "default" }
+```
+
+Gemini's omitted tier is standard. Flex, Priority, an unreported nonstandard
+tier, an unknown model, or a custom origin remains unpriced unless the custom
+provider supplies complete known cost.
+
+Without a cost budget, unknown models and custom origins continue to work.
+Inspect `result.usage.cost.known?` before presenting an estimate.
+
+Budgets remain soft ceilings checked between model-visible turns. A final turn
+and its retries may cross the configured amount.
+
+## Compaction behavior
+
+Catalogued Anthropic and OpenAI windows now use their published long-context
+limits. Automatic reserve protects the model's full shared output capacity plus
+framing slack; Gemini keeps its separately published input-oriented reserve.
+
+Sessions with default compaction will therefore compact at different and more
+accurate boundaries. An explicit `reserve:` remains host policy and wins.
+
+Compaction can occur more than once inside one run while preserving tool-call
+pairing. The full entry log remains exact; replay after a successful compaction
+intentionally becomes the visible summary plus kept tail.
+
+Review any UI or alerting code that assumed the old early thresholds. Only the
+`:compaction` event carries the summary; `:compacting` is the start signal.
+
+## Provider refusal and stream behavior
+
+Documented provider refusals, content-policy stops, and invalid requests now
+fail fast instead of looking like clean completion or consuming retries on the
+same rejected input. Unknown transient stream failures still follow the retry
+policy.
+
+Interrupted tool calls and partial Anthropic thinking signatures are removed
+before persistence. Built-in stream assemblers now enforce known lifecycle,
+index, and terminal-record invariants while ignoring unknown future event types
+for forward compatibility.
+
+If host code classified provider errors by prose, move to the typed
+`result.errored?`, `result.message.error`, `result.stop_reason`, and structured
+event or message fields. Built-in provider refusals finish in the Result
+contract; they are not raised as ordinary transport exceptions.
+
+## Directory workspaces
+
+Directory workspaces no longer follow existing symlinks in model-controlled
+paths and omit symlinked entries from listings. Replace intentional links with
+host-controlled tools or real files inside the workspace root. This boundary is
+deliberate and has no opt-out in the model-controlled file tools.
+
+## Verification before production
+
+At minimum:
+
+1. Run the hermetic suite and application tests.
+2. Audit active persisted sessions with `tool_control_state`.
+3. Resume a 0.5 Anthropic session with tool calls and reasoning.
+4. Resume a 0.5 Gemini session containing tool calls from more than one turn.
+5. Exercise one approval grant and denial after rebuilding current policy.
+6. Run a write tool with an idempotency key and simulate failure before result
+   persistence in the host test harness.
+7. Reconnect and refresh one MCP OAuth connection.
+8. Run the provider-specific live tests and integration matrix with every
+   expected key present.
+
+```console
+$ bundle exec rake test
+$ bundle exec rubocop
+$ MISTRI_LIVE=1 bundle exec rake test
+$ bundle exec rake integration
+```
+
+Missing provider keys skip live coverage. Read the output and verify the models
+that actually ran.
+
+For exact behavior and latency notes, read the [Unreleased](CHANGELOG.md#unreleased)
+changelog entry.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,87 @@
+# Mistri documentation
+
+Mistri is an agent harness for Ruby applications. The
+[project README](../README.md) is the shortest path from installation to a
+working tool-using agent. This directory carries the contracts needed when the
+agent becomes part of a real application.
+
+## Start here
+
+1. Run the [sixty-second example](../README.md#start-in-sixty-seconds).
+2. Read [Tool contracts](tool-contracts.md) before connecting model output to
+   application behavior.
+3. Read [Sessions and control](sessions.md) before making a run durable or
+   accepting approvals from another process.
+4. Read [Reliability](reliability.md) before a tool performs external writes.
+5. Check the [upgrade guide](../UPGRADING.md) before changing Mistri versions.
+
+## Guides
+
+| Guide | Use it when |
+| --- | --- |
+| [Tool contracts](tool-contracts.md) | Defining schemas, validating arguments, gating tools, returning UI data, or handing off a turn |
+| [Sessions and control](sessions.md) | Choosing a store, resuming, steering, approving, compacting, or rendering transcripts |
+| [Context and workspaces](context-and-workspaces.md) | Loading Skills and Definitions, transforming context, storing host-owned memory, or exposing editable documents |
+| [Sub-agents](sub-agents.md) | Delegating into child sessions, dispatching background workers, or exposing worker controls |
+| [MCP](mcp.md) | Connecting Streamable HTTP or stdio servers, OAuth, private networks, or large results |
+| [Reliability](reliability.md) | Handling retries, events, budgets, response limits, cancellation, concurrency, and side effects |
+| [Upgrade guide](../UPGRADING.md) | Moving an existing host between releases |
+| [Changelog](../CHANGELOG.md) | Reading the exact history of every public behavior change |
+
+## Common paths
+
+### Add a durable conversation
+
+Use [`Mistri::Session`](sessions.md#sessions) with a built-in store or a host
+adapter. The store contract is two methods: `append(id, entry)` and `load(id)`.
+
+### Put a human before a write
+
+Declare `needs_approval:` on the tool, route the returned call ID to the human,
+append the decision through a bare Session, and rebuild the current tools and
+policy before calling `resume`. The complete flow is in
+[Human approval](sessions.md#human-approval).
+
+### Stream into a web response
+
+Pass a block to `run`, or use `Mistri::Sinks::SSE` with any IO-like stream.
+Action Cable is an optional sink, not a framework requirement. See
+[Events and sinks](reliability.md#events-and-sinks).
+
+### Connect an MCP server
+
+Build `Mistri::MCP::Client` with exactly one of `url:` or `command:`, then turn
+the remote tools into local tools with `Mistri::MCP.tools`. Start with
+[MCP transports](mcp.md#transports).
+
+### Run work in another agent
+
+Use `Mistri::SubAgent` for a fixed specialist or `Mistri::SubAgent.pack` for a
+host-bounded worker pool. Read the [execution modes](sub-agents.md#execution-modes)
+before adding a queue dispatcher.
+
+### Give the model editable context
+
+Use Skills for on-demand playbooks, Definitions for host-assembled Agent
+configuration, a Workspace for document tools, or `Mistri::Memory` for one
+host-owned value shared across Sessions. The boundaries are in
+[Context and workspaces](context-and-workspaces.md).
+
+## Framework policy
+
+The gem owns mechanism. The host application owns users, authorization,
+business policy, queues, persistence schema, presentation, and the semantics of
+external side effects. Optional adapters are provided for common Rails
+components, but every core contract works without Rails.
+
+## Source landmarks
+
+- [`lib/mistri/agent.rb`](../lib/mistri/agent.rb) owns the run loop.
+- [`lib/mistri/session.rb`](../lib/mistri/session.rb) owns the append-only replay
+  and approval audit.
+- [`lib/mistri/tool.rb`](../lib/mistri/tool.rb) and
+  [`lib/mistri/schema.rb`](../lib/mistri/schema.rb) own tool contracts.
+- [`lib/mistri/mcp/`](../lib/mistri/mcp) contains the MCP client and transports.
+
+For contribution setup and quality gates, see
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/context-and-workspaces.md
+++ b/docs/context-and-workspaces.md
@@ -1,0 +1,285 @@
+# Context and workspaces
+
+Mistri keeps several kinds of context separate so the host can give each one
+the right lifetime and authority:
+
+| Mechanism | Purpose | Source lifetime |
+| --- | --- | --- |
+| `system:` | Stable instructions for the Agent | Agent instance |
+| `context:` | Host objects available to tool policy and handlers | Agent instance |
+| `skills:` | Host-curated playbooks loaded by the model on demand | Host files or objects |
+| `transform_context:` | Per-turn view of replay history | Agent instance |
+| Session messages | Durable conversation and control facts | Session store |
+| Workspace | Text the built-in document tools can edit | Workspace backend |
+| `Mistri::Memory` | Host-owned knowledge shared across sessions | Host backend |
+
+Any model-visible Skill, workspace, or memory tool call and result is still an
+ordinary Session message. Reading external context can therefore copy that
+content into the Session log.
+
+Do not put credentials into prompts, Skills, or persisted messages. Pass
+request-scoped identity and services through `context:` and authorize every tool
+at its execution boundary.
+
+## Skills
+
+A Skill is a named playbook with a short description and a full Markdown body.
+Only the descriptions join the system prompt. Mistri adds `read_skill`, and the
+model requests a body when the current task needs it.
+
+Load either `<root>/<name>/SKILL.md` directories or flat `<root>/<name>.md`
+files:
+
+```ruby
+skills = Mistri::Skills.load("app/agent_skills")
+
+agent = Mistri.agent(
+  "claude-opus-4-8",
+  skills: skills,
+  tools: application_tools,
+)
+```
+
+`skills:` also accepts the directory path directly. A Skill file may begin with
+the deliberately small frontmatter contract:
+
+```markdown
+---
+name: incident-review
+description: Review an incident timeline for missing evidence and unsafe claims.
+---
+
+# Incident review
+
+Read the timeline first. Separate observed facts from inference...
+```
+
+Only flat `name` and `description` string fields are interpreted. This is not a
+general YAML configuration surface. Without frontmatter, the file or directory
+name becomes the Skill name.
+
+Skill bodies are instructions, not a security boundary. Load only host-reviewed
+files, keep descriptions specific enough for correct selection, and let tool
+authorization enforce what the model may actually do.
+
+## Definitions
+
+A Definition keeps an Agent's editable prompt and host vocabulary in one
+Markdown file:
+
+```markdown
+---
+role: Trip planner
+model: claude-opus-4-8
+tools:
+  - search_flights
+  - book_hotel
+---
+
+Plan the trip for {first_name}. Confirm constraints before booking.
+```
+
+Load and assemble it through a host registry:
+
+```ruby
+definition = Mistri::Definition.load("app/agents/trip_planner.md")
+tools = definition.tool_names.map { |name| tool_registry.fetch(name) }
+
+agent = Mistri.agent(
+  definition.model,
+  system: definition.render(first_name: traveler.first_name),
+  tools: tools,
+)
+```
+
+`render` raises when a placeholder has no value instead of leaking a literal
+`{first_name}` into the prompt. A nil value renders as empty. `role`, `model`,
+and `tools` have convenience readers; other frontmatter remains available
+through `definition.config` for the host to interpret.
+
+Mistri never resolves a tool name or arbitrary Definition key by itself. The
+host registry is the authority that turns configuration into application code.
+
+## Application context
+
+Pass acting identity and request-scoped services through `context:`:
+
+```ruby
+agent = Mistri.agent(
+  "claude-opus-4-8",
+  tools: tools,
+  context: { actor: current_user, tenant: current_tenant },
+  before_tool: lambda { |call, tool_context|
+    allowed = policy.allowed?(
+      tool_context.app.fetch(:actor),
+      call.name,
+      call.arguments,
+    )
+    next if allowed
+
+    "not authorized"
+  },
+)
+```
+
+Handlers that accept a second argument receive the same
+`Mistri::ToolContext`; `context.app` is exactly the host value. This context is
+not persisted. Rebuild it from current identity and policy before resuming a
+persisted Session. Return a sanitized block reason from `before_tool`; an
+unexpected hook exception is also reported to the model and Session, including
+its class and message.
+
+## Per-turn context transforms
+
+`transform_context:` accepts one callable or an Array. Before every provider
+request, each callable receives the replay Messages and returns the Messages
+that request should see. The transformed view is not appended to the Session.
+
+This seam supports host redaction, retrieval, and deliberate windowing, but it
+is low-level. Preserve message order and every tool-call/result pair. A
+provider will reject a history whose correlation facts were removed.
+
+For periodic instruction reinforcement, use the built-in Reminder:
+
+```ruby
+reminder = Mistri::Reminder.every(
+  3,
+  "Stay within the approved catalog. Verify availability before claiming it.",
+)
+
+agent = Mistri.agent(
+  "claude-opus-4-8",
+  tools: tools,
+  transform_context: reminder,
+)
+```
+
+The reminder counts completed assistant turns, appears only in the provider
+request when due, and never becomes a Session message. Pass `after:` when the
+first reminder should use a different turn boundary.
+
+## Workspaces and document tools
+
+A workspace is a four-method port:
+
+```ruby
+read(path)             # String or nil
+write(path, content)
+delete(path)
+list(prefix = nil)     # sorted path Strings
+```
+
+Bind one to the built-in read, write, edit, find, and list tools:
+
+```ruby
+workspace = Mistri::Workspace::Memory.new
+workspace.write("brief.md", "# Launch brief\n")
+
+agent = Mistri.agent(
+  "claude-opus-4-8",
+  tools: Mistri::Tools.files(workspace),
+  system: "Read before editing. Keep the brief concise.",
+)
+```
+
+The tool names deliberately use the familiar file vocabulary even when the
+backend is a database row or host callback.
+
+### Memory workspace
+
+`Mistri::Workspace::Memory` is a mutex-protected document map for tests and
+ephemeral work. It is not durable across processes.
+
+### Directory workspace
+
+```ruby
+workspace = Mistri::Workspace::Directory.new("tmp/agent-workspace")
+```
+
+Directory expands model paths under one canonical root, rejects lexical escape,
+refuses traversal through existing file or directory symlinks, and omits
+symlinked entries from listings. The host must keep the root and its tree stable
+for the workspace instance's lifetime. This is not an operating-system sandbox
+against a concurrent process changing filesystem entries.
+
+Use a dedicated root with host-owned permissions. Do not point model-controlled
+tools at an application checkout, credential directory, or shared mutable tree.
+
+### Single-value workspace
+
+Wrap one host-owned value, such as a page draft or database column:
+
+```ruby
+workspace = Mistri::Workspace::Single.new(
+  path: "page.html",
+  read: -> { page.reload.draft_html },
+  write: ->(html) { page.update!(draft_html: html) },
+)
+```
+
+The value can be read and rewritten but not deleted. The callback owns
+transactions, optimistic locking, validation, and authorization.
+
+### Active Record workspace
+
+The optional adapter is not loaded by `require "mistri"`:
+
+```ruby
+require "mistri/workspace/active_record"
+
+workspace = Mistri::Workspace::ActiveRecord.new(
+  AgentDocument,
+  scope: { tenant_id: current_tenant.id },
+)
+```
+
+The host model needs `path` and `content` columns and a unique index covering
+the scope plus `path`. The adapter uses the host's Active Record connection;
+Mistri does not require Rails or Active Record as a runtime dependency.
+
+## Durable memory across sessions
+
+`Mistri::Memory` is one replaceable text value stored wherever the host chooses:
+
+```ruby
+memory = Mistri::Memory.new(
+  read: -> { organization.agent_memory.to_s },
+  write: ->(text) { organization.update!(agent_memory: text) },
+)
+
+agent = Mistri.agent(
+  "claude-opus-4-8",
+  tools: Mistri::Tools.memory(memory),
+)
+```
+
+The generated `read_memory` and `update_memory` tools make the model read the
+current value and replace it as one coherent document. The host decides scope,
+authorization, size, retention, and conflict handling. Expose only
+`read_memory` when writes are not allowed; when a memory update requires human
+approval, build an equivalent gated Tool around `Memory#replace`. The helper's
+`update_memory` tool is ungated. Memory is not a hidden vector store. Its
+backing value lives outside the Session, but `read_memory` copies the value into
+a persisted tool result and `update_memory` persists the replacement text in
+the tool call.
+
+## Concurrency and delegation
+
+Workspace thread safety is backend-defined. Memory synchronizes its map;
+Directory and Single do not turn host resources into transactions. Active
+Record supplies database operations, but the host still owns isolation and
+conflict policy.
+
+Sub-agent tools are ordinary Ruby objects and may close over a workspace. A
+background worker's `workspace: "own"` declaration does not clone those
+objects. Reconstruct isolated tool and workspace instances in a production
+dispatcher before allowing parent and child work to overlap. See
+[Sub-agents](sub-agents.md#execution-modes).
+
+## Related guides
+
+- [Tool contracts](tool-contracts.md)
+- [Sessions and control](sessions.md)
+- [Sub-agents](sub-agents.md)
+- [Reliability](reliability.md)
+- [Upgrading](../UPGRADING.md)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,366 @@
+# Model Context Protocol
+
+Mistri can turn tools from a Model Context Protocol server into ordinary local
+tools. The Agent's validation, approval, event, session, and result contracts
+then apply to the remote call.
+
+The built-in client supports Streamable HTTP and stdio with no additional gem
+dependency. `Mistri::MCP.tools` is duck-typed, so a different client can bridge
+when it responds to `tools` and `call_tool(name, arguments)` with the documented
+hash shapes.
+
+## Transports
+
+### Streamable HTTP
+
+```ruby
+client = Mistri::MCP::Client.new(
+  url: "https://mcp.linear.app/mcp",
+  token: -> { connection.bearer_token },
+)
+
+tools = Mistri::MCP.tools(
+  client,
+  prefix: "linear",
+  allow: %w[search_issues get_issue create_issue],
+  gates: { "create_issue" => true },
+)
+
+agent = Mistri.agent("claude-opus-4-8", tools: tools)
+```
+
+`token:` accepts a String or callable. The callable resolves for every request.
+After a 401, Mistri resolves it once more and retries once, so the host can put
+refresh behavior behind the callable.
+
+Use `headers:` for fixed application headers. Mistri copies them at client
+construction and rejects framing plus MCP session and protocol headers. A fixed
+Authorization header is permitted; when `token:` is supplied, Mistri owns
+Bearer authorization and overwrites it.
+
+One Client serializes its requests. Parallel Agent tool calls against the same
+client queue rather than interleave. Use distinct clients only when the server
+and host policy allow true parallel connections.
+
+### Stdio
+
+```ruby
+browser = Mistri::MCP::Client.new(
+  command: [
+    "npx", "-y", "@playwright/mcp@latest",
+    "--browser", "chrome", "--headless",
+  ],
+  read_timeout: 180,
+)
+
+tools = Mistri::MCP.tools(
+  browser,
+  prefix: "web",
+  allow: %w[browser_navigate browser_snapshot],
+)
+```
+
+`command:` is an argument array, not a shell string. Pass credentials through
+`env:` when the child process needs them. Mistri writes one JSON-RPC object per
+line and bounds the complete record read, including the time after its first
+byte.
+
+`@latest` is convenient for local exploration. Pin a reviewed package version
+in an application or deployment so the executable does not change without a
+code review.
+
+Call `client.close` when a long-lived host is finished. For stdio, it terminates
+the child. For HTTP, it closes the local connection and forgets the negotiated
+session, but does not send the optional MCP DELETE termination request; remote
+resources expire by server policy. The discovered tool cache remains available.
+`call_tool` or `tools(refresh: true)` performs a fresh handshake when needed.
+
+## Tool discovery
+
+`client.tools` performs the handshake and follows `tools/list` pagination once,
+then caches the result. Use `client.tools(refresh: true)` when the host decides
+to accept a changed toolset.
+
+Discovery defaults to at most 100 pages and 10,000 tools:
+
+```ruby
+client = Mistri::MCP::Client.new(
+  url: server_url,
+  max_tool_pages: 20,
+  max_tools: 2_000,
+)
+```
+
+Repeated cursors, malformed collections, and exceeded limits raise instead of
+looping or allocating without bound.
+
+`Mistri::MCP.tools` filters remote names with `allow:` and `deny:`. `prefix:`
+creates local names such as `linear__create_issue` while the remote call still
+uses `create_issue`. Duplicate local tool names make Agent construction fail;
+one server can never silently shadow another.
+
+`needs_approval:` gates every bridged tool. `gates:` sets policy by remote name
+and overrides the shared default.
+
+## Schema authority
+
+Mistri validates the directly reachable portable subset described in
+[Tool contracts](tool-contracts.md). The MCP server remains responsible for its
+full advertised input schema, as required by the
+[MCP tools contract](https://modelcontextprotocol.io/specification/2025-11-25/server/tools).
+
+Standard assertions outside Mistri's subset, such as `minimum`, `pattern`,
+`format`, and `anyOf`, bridge as server-facing guidance. An unsupported
+applicator subtree remains one guidance unit; Mistri does not partially enforce
+inside it and imply a stronger guarantee.
+
+When local policy depends on the full schema, supply a complete validator:
+
+```ruby
+tools = Mistri::MCP.tools(
+  client,
+  complete_argument_validator: lambda { |args, schema|
+    host_json_schema_validator.errors(args, schema)
+  },
+)
+```
+
+The callback must implement the whole contract and return an Array of Strings.
+Core ownership and its portable checks still run first.
+
+An argument-applicable, non-empty `patternProperties` requires this explicit
+complete authority. Same-document references can remain server guidance;
+external references are rejected even with a complete validator so validation
+never performs hidden file or network resolution.
+
+An omitted `inputSchema` means a closed no-argument object. Explicit null,
+non-object roots, malformed keyword shapes, and an explicit older dialect are
+configuration errors. Mistri compiles MCP input as JSON Schema 2020-12.
+
+## Results and large data
+
+Mistri maps MCP text, images, embedded resources, and `resource_link` into its
+content model. `structuredContent` is used when no ordinary content is present
+and is also retained in an error explanation. On a successful result containing
+both fields, ordinary content currently wins and `structuredContent` is not
+preserved.
+
+`isError` becomes `ToolResult#error?` and remains structured in events and the
+session. Anthropic receives native `is_error`; Gemini receives its error result
+key. OpenAI's function-result shape has no error member, so it receives the same
+explanatory content without a separate flag.
+
+Large results should live behind a server or host resource. Return an MCP
+`resource_link` and a concise description instead of embedding an unbounded
+payload. Mistri renders the URI for the model and never fetches it automatically;
+fetching credentials, retention, and access policy belong to the host or server.
+
+## Response boundaries
+
+Provider and MCP JSON bodies, individual SSE lines, and stdio records default
+to an 8 MiB `max_record_bytes:` limit:
+
+```ruby
+client = Mistri::MCP::Client.new(
+  url: trusted_server_url,
+  max_record_bytes: 16 * 1024 * 1024,
+)
+```
+
+The limit applies to one atomic record, not the lifetime of an SSE stream.
+Successful HTTP bodies are counted incrementally, and a declared oversized body
+fails before it is read. Requests use identity encoding so compressed expansion
+cannot bypass the boundary.
+
+Each completed SSE JSON record also receives fixed structural ceilings before
+JSON parsing: 20,001 lexical tokens, 64 levels, and 64 KiB per numeric token.
+These protect allocation even when a record stays under its byte limit.
+
+Byte overflow raises `Mistri::ResponseTooLargeError`. Structural overflow raises
+`Mistri::ResponseTooComplexError`. Both expose `kind` and `limit`.
+
+Either failure resets the wire and negotiated session. The next operation must
+handshake again.
+
+### Ambiguous tool delivery
+
+A response boundary or wire failure after `tools/call` is different from an
+ordinary read failure: the server may have received and committed the operation
+before the response disappeared.
+
+When no matching result was confirmed, Mistri raises
+`Mistri::AmbiguousDeliveryError` and never replays the call automatically. The
+message tells the caller to verify external state before any retry.
+
+That is the direct Client contract. A tool bridged through `Mistri::MCP.tools`
+runs inside the normal tool executor, which converts the raised exception into
+an error-marked tool result for the model and host. The transport still does not
+replay the call. A model may choose to issue a new call after reading the error,
+so approval, idempotency, and reconciliation remain host policy.
+
+If a matching result arrived before an invalid trailing SSE record, that result
+remains authoritative. The wire is still reset for the next operation.
+
+Session-expired and authentication retries occur only through explicit server
+responses that establish the request was not accepted under the old session or
+credential. An ambiguous outcome never takes those replay paths.
+
+## Remote network policy
+
+Remote MCP and server-side OAuth URLs are untrusted input. By default Mistri:
+
+- requires public HTTPS;
+- resolves and validates every DNS answer against special-purpose address
+  ranges, including embedded NAT64 destinations;
+- rejects the whole result if any answer is unsafe;
+- pins an approved address while preserving the hostname for Host, SNI, and
+  certificate verification;
+- resolves and validates again for each new connection cycle, including an
+  internal keep-alive reconnect;
+- tries alternate approved addresses only before request bytes are sent;
+- follows no redirects;
+- ignores ambient HTTP proxy settings.
+
+Private HTTPS servers require one narrow host callback:
+
+```ruby
+require "ipaddr"
+
+private_range = IPAddr.new("10.20.0.0/16")
+allow_internal = lambda do |uri, address|
+  %w[mcp.internal.example auth.internal.example].include?(uri.hostname) &&
+    private_range.include?(address)
+end
+
+client = Mistri::MCP::Client.new(
+  url: "https://mcp.internal.example/mcp",
+  allow_non_public: allow_internal,
+)
+```
+
+The callback is consulted only for otherwise blocked addresses. Match both the
+expected hostname and an explicit IP range. It cannot permit an invalid URL.
+Plain HTTP remains limited to an explicitly approved address that actually
+resolves to loopback, which is suitable only for local development:
+
+```ruby
+allow_loopback = ->(_uri, address) { address.loopback? }
+```
+
+Pass the same policy to the Client and every OAuth operation for an internal
+deployment.
+
+## OAuth
+
+`Mistri::MCP::OAuth` implements the storage-agnostic OAuth 2.1 flow required by
+MCP. The host owns the connection record, callback route, token encryption, and
+authorization-server selection.
+
+Start discovery and registration:
+
+```ruby
+flow = Mistri::MCP::OAuth.start(
+  url: server_url,
+  client_name: "YourApp",
+  redirect_uri: callback_url,
+  scope: requested_scope,
+  allow_non_public: allow_internal,
+)
+
+# Persist the returned flow, then send the user's browser to this URL.
+authorize_url = flow.fetch("authorize_url")
+```
+
+Persist at least the state, code verifier, client ID and secret, token auth
+method, issuer, resource, and redirect URI. `token_endpoint` is returned for
+compatibility and display only; later operations rediscover it from the exact
+issuer.
+
+The host must compare callback state with the persisted value before exchange:
+
+```ruby
+unless host_secure_compare(callback_state, flow.fetch("state"))
+  raise "invalid OAuth state"
+end
+
+tokens = Mistri::MCP::OAuth.complete(
+  code: params.fetch(:code),
+  code_verifier: flow.fetch("code_verifier"),
+  client_id: flow.fetch("client_id"),
+  client_secret: flow["client_secret"],
+  token_auth_method: flow.fetch("token_auth_method"),
+  issuer: flow.fetch("issuer"),
+  resource: flow.fetch("resource"),
+  redirect_uri: flow.fetch("redirect_uri"),
+  allow_non_public: allow_internal,
+)
+```
+
+Refresh tokens can rotate, so persist a returned replacement:
+
+```ruby
+tokens = Mistri::MCP::OAuth.refresh(
+  refresh_token: connection.refresh_token,
+  client_id: connection.client_id,
+  client_secret: connection.client_secret,
+  token_auth_method: connection.token_auth_method,
+  issuer: connection.issuer,
+  resource: connection.url,
+  allow_non_public: allow_internal,
+)
+```
+
+An authorization server may omit `refresh_token` or `scope` from a successful
+refresh. Low-level callers must retain the current stored value unless the
+response supplies a replacement. The generated Active Record adapter already
+does this.
+
+Mistri requires S256 PKCE. It follows protected-resource and authorization-server
+discovery, binds metadata to exact resource and issuer identifiers, and honors
+challenge scope. It does not add `offline_access` as gem policy.
+
+When discovery advertises multiple authorization servers, the host must pass
+`issuer:` explicitly. A pre-registered `client_id` always requires the exact
+issuer trusted when it was provisioned. Servers without dynamic registration
+also accept `client_secret:` and an explicit supported `token_auth_method:`.
+
+OAuth response bodies are uncompressed and bounded to 256 KiB. Provider error
+descriptions are not copied into credential-bearing exceptions.
+
+## Optional Rails connection generator
+
+Rails applications can generate an encrypted connection model and migration:
+
+```console
+$ bin/rails generate mistri:mcp McpConnection
+```
+
+Each row stores one server, OAuth flow state, issuer, encrypted tokens, expiry,
+and scope. The generated model exposes `connect`, `complete`, token refresh, a
+Client, and bridged tools. Set up Active Record encryption before storing
+credentials.
+
+Override the generated class policy when the server is internal:
+
+```ruby
+class McpConnection < ApplicationRecord
+  def self.mcp_allow_non_public
+    ALLOW_INTERNAL_MCP
+  end
+end
+```
+
+The generator is an adapter, not a requirement. The same OAuth services work in
+Sinatra, Hanami, GraphQL, jobs, or any host with a durable record and callback
+route.
+
+Generated application files are copies and do not change when the gem updates.
+Read the [upgrade guide](../UPGRADING.md) before upgrading an existing generated
+connection model.
+
+## Related guides
+
+- [Tool contracts](tool-contracts.md)
+- [Sessions and control](sessions.md)
+- [Reliability](reliability.md)
+- [Upgrading](../UPGRADING.md)

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -1,0 +1,427 @@
+# Reliability
+
+Mistri makes the execution boundary explicit. It does not turn a model call,
+network, process, database, and external side effect into one transaction.
+
+The core rule is simple: the gem owns mechanism; the host owns policy. Mistri
+validates and records what it can know. The application supplies authorization,
+runner serialization, idempotency, reconciliation, queue guarantees, and UI.
+
+## Result and error model
+
+Every run returns `Mistri::Result` unless a separate host contract must raise:
+
+```ruby
+result.completed?
+result.awaiting_approval?
+result.aborted?
+result.stopped_by_budget?
+result.errored?
+result.handed_off?
+```
+
+`result.text` reads the final assistant message. `result.output` is the parsed,
+validated value from task mode. `result.usage` sums provider attempts and
+compaction calls made during that invocation.
+
+Failures the model can correct stay in band. Unknown tools, invalid arguments,
+policy blocks, expected tool failures, handler exceptions, and timeouts become
+typed tool results. Valid sibling calls may still execute.
+
+Built-in provider failures, including exhausted retries and provider response
+limits, finish as `result.errored?`. Configuration and Session contract failures,
+final task validation, and unknown-cost reconciliation raise a `Mistri::Error`
+subclass. Store and subscriber callbacks can propagate their own exceptions.
+
+Direct MCP Client failures raise. A tool bridged through `Mistri::MCP.tools`
+runs inside the tool executor, so its Client exception, including ambiguous
+delivery, becomes an error-marked tool result. The transport has not replayed
+the call; the model may still choose to issue a new one.
+
+Rescue `Mistri::Error` for the gem's public error family. Do not rescue
+`StandardError` around the entire run and silently convert programming or
+subscriber bugs into model output.
+
+## Side-effect outcomes can be ambiguous
+
+Only one Agent may actively call `run` or `resume` for a Session at a time. The
+store can accept independent approval, steer, and worker-report appends, but
+active runners are a host scheduling concern.
+
+Even with one runner, this gap remains:
+
+1. Mistri records that a call is ready.
+2. The handler commits an external write.
+3. The process, subscriber, or store fails before the result append.
+
+On replay, Mistri can prove that the call has no durable result. It cannot prove
+whether step 2 happened. The Session synthesizes an interrupted error so the
+provider transcript remains pairable and tells the caller to verify effects.
+
+Build write tools around a domain idempotency key or reconciliation handle:
+
+```ruby
+Mistri::Tool.define(
+  "send_gift", "Sends one gift order.",
+  schema: lambda {
+    string :order_id, "Host-issued idempotency key", required: true
+    string :recipient_id, "Recipient ID", required: true
+  },
+) do |args|
+  GiftOrders.create_once!(
+    idempotency_key: args.fetch("order_id"),
+    recipient_id: args.fetch("recipient_id"),
+  )
+end
+```
+
+The exact mechanism belongs to the application and its downstream system. For
+some APIs it is an idempotency header; for a database it may be a unique key and
+transaction; for an irreversible operation it may require a reconciliation
+screen instead of automatic retry.
+
+Approval reduces authorization risk but does not make execution exactly once.
+Mistri guarantees neither exactly-once execution nor eventual at-least-once
+delivery: a call may run once, more than once after host or model retry, or not
+at all. Durable facts tell the host what is known; idempotency and reconciliation
+decide what to do next.
+
+## Provider retries
+
+Transient provider failures retry with jittered exponential backoff by default:
+
+```ruby
+policy = Mistri::RetryPolicy.new(
+  attempts: 3,    # retries; up to four total requests
+  base: 1.0,
+  max_delay: 30.0,
+)
+
+agent = Mistri.agent("claude-opus-4-8", retries: policy)
+```
+
+Set `retries: false` to disable the Agent retry loop.
+
+Rate limits, overload, timeouts, selected server statuses, dropped or truncated
+streams, and empty completions are retryable. Authentication errors, invalid
+requests, content-policy refusals, unsafe configuration, and host bugs fail
+fast. A provider `Retry-After` value is honored within `max_delay`.
+
+Each retry sends unchanged durable history. Failed attempts are not appended as
+conversation messages, but their usage and retry record remain available for
+accounting.
+
+The subscriber receives `:retry` with `attempt`, `max_attempts`, and `delay`.
+Only the accepted provider attempt's `:done` or `:error` event is released, so a
+recovered retry does not flash a terminal failure and then retract it.
+
+MCP `tools/call` is intentionally different. Once sent, a missing response is
+an ambiguous side effect and is not replayed by the Client. The Agent bridge
+returns that exception as an error-marked tool result. See
+[Ambiguous tool delivery](mcp.md#ambiguous-tool-delivery).
+
+## Events and sinks
+
+Every built-in provider attempt emits:
+
+1. `:start` with an empty immutable assistant snapshot;
+2. matched start and end events for each recognized text, thinking, or tool-call
+   block, with zero or more delta events as content arrives.
+
+A retried attempt's terminal event is suppressed and `:retry` is its visible
+boundary. Only the accepted attempt releases exactly one `:done` or `:error`.
+Block deltas from the failed attempt may already have reached the subscriber;
+on `:retry` or the next `:start`, a UI must reset or replace that ephemeral
+attempt instead of appending it to the next one. Only the accepted Message is
+persisted.
+
+A custom provider must emit the same lifecycle when host subscribers depend on
+streaming; the Agent does not synthesize provider events around `stream`.
+
+Those terminal events end one provider turn, not necessarily the Agent run. If
+the turn calls tools, the Agent emits tool lifecycle events, appends results,
+and starts another provider turn.
+
+Loop-level events are:
+
+- `:tool_started` when a resolved call commits to handler invocation;
+- `:tool_result` after settlement, with a required `tool_error` boolean;
+- `:approval_needed` when a prepared call parks;
+- `:compacting` before summary work and `:compaction` with the committed
+  summary in `content`;
+- `:retry` before provider backoff;
+- `:subagent_report` when a background child reaches a terminal state.
+
+Event types form an extensible union. Handle the types the application uses and
+ignore the rest:
+
+```ruby
+agent.run(input) do |event|
+  case event.type
+  when :text_delta
+    stream_text(event.delta)
+  when :retry
+    show_retry(event.attempt, event.max_attempts, event.delay)
+  when :tool_started
+    mark_tool_running(event.tool_call)
+  when :tool_result
+    settle_tool(event.tool_call, failed: event.tool_error)
+  when :approval_needed
+    request_human_decision(event.tool_call)
+  when :done, :error
+    settle_provider_turn(event.message)
+  end
+end
+```
+
+`:tool_started` and handler progress originate on tool worker threads. Calls
+within one Agent are serialized before reaching the subscriber, but background
+children can emit alongside the parent. A custom sink must be thread-safe.
+
+`Mistri::Sinks::Coalesced` is origin-aware and thread-safe. It merges bursts of
+text, thinking, and tool-argument deltas by event type, content index, and
+origin, then flushes before any other event:
+
+```ruby
+raw = Mistri::Sinks::SSE.new(io)
+sink = Mistri::Sinks::Coalesced.new(raw, interval: 0.05)
+
+agent.run(input, &sink)
+```
+
+`Mistri::Sinks::SSE` accepts any object with `write` and optionally `flush`.
+`Mistri::Sinks::ActionCable` resolves Action Cable lazily or accepts an explicit
+broadcaster. None of these require a Railtie.
+
+Subscriber callbacks are not an error-isolation boundary. An exception can
+abort an operation and, after a handler starts, create the same unknown-outcome
+gap as a process crash. Do not raise intentionally from a sink; keep it small,
+observable, thread-safe, and independently retryable where possible.
+
+## Stopping
+
+`Mistri::AbortSignal` is an in-process, thread-safe, one-way latch:
+
+```ruby
+signal = Mistri::AbortSignal.new
+
+runner = Thread.new do
+  agent.run("Draft a long report.", signal: signal)
+end
+
+signal.abort!("user cancelled")
+runner.join
+```
+
+The provider transport registers a callback that closes an in-flight socket,
+so abort does not wait for the read timeout. The Agent checks the signal at safe
+boundaries and persists a replay-valid partial turn.
+
+Tool handlers are application code. A handler doing long work should inspect
+`context.signal&.aborted?` at safe points or arrange its own cancellable I/O.
+Cancellation is cooperative; Mistri does not kill arbitrary handler code.
+
+The signal object cannot be shared across processes. Cross-process child stop
+uses a shared lock adapter and a cooperative flag, as described in
+[Sub-agent lock adapters](sub-agents.md#lock-adapters). Top-level session runner
+coordination remains host policy.
+
+## Budgets
+
+Budgets are opt-in:
+
+```ruby
+budget = Mistri::Budget.new(
+  turns: 20,
+  tokens: 500_000,
+  cost_usd: 5.00,
+  wall_clock: 300,
+)
+```
+
+Limits are checked between model-visible turns. A turn already in progress,
+including its retry attempts, completes before the next check. Every budget is
+therefore a soft ceiling and may exceed its configured value by one turn.
+
+### Cost budgets
+
+Unknown price is not zero. Constructing a cost-budgeted Agent requires a
+catalogued model, a list-priced origin, and deterministic standard-tier policy.
+
+Anthropic and OpenAI require the tier explicitly:
+
+```ruby
+anthropic = Mistri.agent(
+  "claude-opus-4-8",
+  budget: Mistri::Budget.new(cost_usd: 5.00),
+  provider_options: { service_tier: "standard_only" },
+)
+
+openai = Mistri.agent(
+  "gpt-5.6-terra",
+  budget: Mistri::Budget.new(cost_usd: 5.00),
+  provider_options: { service_tier: "default" },
+)
+```
+
+Gemini's omitted tier is standard by contract. A reported Flex or Priority
+tier remains unpriced by the standard catalog.
+
+If a cost-budgeted request returns usage that cannot be priced, Mistri raises
+`Mistri::BudgetError` and does not retry under false certainty. The exception
+exposes `usage` and `provider_message`; the Session also records an
+`unpriced_attempt` entry for reconciliation.
+
+`result.usage.cost.known?` distinguishes known accounting from an unavailable
+estimate. Dollar values use published standard paid direct-API list prices
+embedded and versioned with the installed gem; they are not fetched live.
+Contracted pricing, regional uplifts, taxes, and separately billed provider
+tools are outside the estimate. Gemini free-tier usage is conservatively valued
+at the paid rate.
+
+Custom provider origins disable catalog pricing by default. Pass
+`catalog_pricing: true` only when that route bills exactly the same published
+rates. This flag never changes service-tier policy.
+
+## Inbound response limits
+
+Provider and MCP JSON bodies, individual SSE lines, and stdio records default
+to 8 MiB per record. A stream can exceed 8 MiB in total while every atomic
+record remains within the boundary.
+
+Successful bodies are counted while reading. Declared oversized bodies fail
+before their body is read. Error responses retain at most a 500-byte valid UTF-8
+preview. Requests use identity encoding so compressed expansion cannot evade
+the limit.
+
+Completed SSE JSON records receive a bounded structural scan before parsing.
+Fragmented Anthropic and OpenAI tool arguments also carry an aggregate 8 MiB
+limit across deltas; their partial preview refreshes on a bounded schedule while
+raw delta events continue.
+
+Set `max_record_bytes:` through `provider_options:` only after deciding the
+larger trusted boundary is acceptable:
+
+```ruby
+agent = Mistri.agent(
+  "gemini-3.1-pro-preview",
+  provider_options: { max_record_bytes: 16 * 1024 * 1024 },
+)
+```
+
+The byte boundary is configurable. Fixed structural ceilings protect the JSON
+allocation shape and are not raised by that option.
+
+## Provider input and options
+
+Images are immutable content blocks:
+
+```ruby
+photo = Mistri::Content::Image.from_bytes(
+  File.binread("chart.png"),
+  mime_type: "image/png",
+)
+
+agent.run("What trend does this chart show?", images: [photo])
+```
+
+`from_data_uri` accepts the `data:<mime>;base64,<data>` shape commonly produced
+by a canvas or upload. The host still owns media allowlists, decoded-size
+limits, and content inspection.
+
+Provider constructor settings go through `provider_options:`:
+
+```ruby
+Mistri.agent(
+  "gpt-5.6",
+  provider_options: { reasoning: { summary: "auto" } },
+)
+
+Mistri.agent(
+  "claude-opus-4-8",
+  provider_options: { cache: false },
+)
+```
+
+Provider-specific per-turn overrides belong on a directly constructed
+provider's `stream` contract. The Agent intentionally exposes a stable common
+loop rather than mirroring every provider option as a top-level keyword.
+
+## Custom providers
+
+A provider used by `Mistri::Agent` exposes a model ID and responds to `stream`:
+
+```ruby
+message = provider.stream(
+  messages: messages,
+  system: system,
+  tools: tool_specs,
+  signal: signal,
+  **overrides,
+) do |event|
+  # Mistri::Event instances
+end
+```
+
+`provider.model` is required by default compaction and cost-policy checks.
+Disable compaction explicitly only when a custom provider cannot describe a
+model context window.
+
+It returns an assistant `Mistri::Message`. A completed tool call must be a
+`Mistri::ToolCall` with:
+
+- a non-empty UTF-8 String ID unique for new calls in the Session;
+- a non-empty UTF-8 String name;
+- an owned JSON object for valid arguments, or `arguments_error` for malformed
+  encoded input;
+- non-empty UTF-8 signature and provider call ID strings when present.
+
+A malformed completed envelope rejects the whole provider attempt before the
+assistant message persists or any sibling tool runs. Do not invent missing IDs
+inside the Agent; the provider owns its wire correlation.
+
+Custom providers may return `native_output_schema(schema)` when they can enforce
+the requested task contract. Returning nil leaves the prompt and local
+validation path intact.
+
+To support cost budgets, return true from `prices_usage?` and attach a known
+cost to every response, commonly with `Mistri::Usage#with_cost`. Missing or
+partial pricing then fails closed at runtime.
+
+Study `Mistri::Providers::Fake` for a hermetic implementation and the built-in
+assemblers for strict streaming lifecycle behavior.
+
+## Testing strategy
+
+The default suite uses the Fake provider, recorded wire fixtures, local stub
+servers, and no network:
+
+```console
+$ bundle exec rake test
+$ bundle exec rubocop
+```
+
+Gated live tests exercise exact provider regressions when keys are present:
+
+```console
+$ MISTRI_LIVE=1 bundle exec rake test
+```
+
+The integration harness runs critical end-to-end scenarios across an Anthropic,
+OpenAI, and Gemini model by default:
+
+```console
+$ bundle exec rake integration
+$ MISTRI_INTEGRATION_MODELS=claude-opus-4-8 bundle exec rake integration
+```
+
+Keys load from the gitignored `.env.development.local`. A missing key skips that
+provider; inspect the test output before claiming a full three-provider run.
+
+## Related guides
+
+- [Tool contracts](tool-contracts.md)
+- [Sessions and control](sessions.md)
+- [Sub-agents](sub-agents.md)
+- [MCP](mcp.md)
+- [Upgrading](../UPGRADING.md)

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,283 @@
+# Sessions and control
+
+A session is Mistri's source of truth: an append-only sequence of typed JSON
+entries. Messages, approvals, steering, compaction boundaries, child links, and
+reports share that one record. Derived state is rebuilt from the log instead of
+being repaired in place after a crash. Persistence strength belongs to the
+chosen store.
+
+## Sessions
+
+Every Agent has a Session. Without one, Mistri creates an in-memory session:
+
+```ruby
+agent = Mistri.agent("claude-opus-4-8")
+agent.session.id
+```
+
+Pass a persistent store when work must survive a process:
+
+```ruby
+store = Mistri::Stores::JSONL.new("tmp/mistri-sessions")
+session = Mistri::Session.new(store: store)
+
+agent = Mistri.agent("claude-opus-4-8", session: session)
+agent.run("Start the research plan.")
+
+reloaded = Mistri::Session.new(store: store, id: session.id)
+Mistri.agent("claude-opus-4-8", session: reloaded).run("Continue the plan.")
+```
+
+`Session#entries` returns the raw typed log. `Session#messages` returns the
+provider-neutral conversation after replay and compaction. `Session#transcript`
+returns a presentation-oriented entry view with inline image bytes removed. It
+is not an authorization or redaction boundary: prompts, tool arguments and
+results, UI payloads, errors, and provider metadata can remain. Authorize and
+redact before exposing a transcript.
+
+Mistri does not encrypt JSONL or Active Record session payloads. The host owns
+storage encryption, access control, retention, deletion, and redaction specific
+to the application. Treat the complete session record as sensitive data.
+
+## Store contract
+
+A store implements:
+
+```ruby
+append(session_id, entry_hash) # append one JSON-shaped entry
+load(session_id)               # return entries in append order
+```
+
+The store must preserve each append as one entry and provide a total order per
+session. Values returned by `load` must not let caller mutation rewrite durable
+history: return fresh decoded copies or deeply immutable snapshots. Mistri does
+not rely on Ruby object identity. `Session#append` normalizes entries through
+JSON, so store implementations see string keys and JSON values.
+
+Built-in stores are:
+
+- `Mistri::Stores::Memory` for one process and tests;
+- `Mistri::Stores::JSONL` for one file per session;
+- `Mistri::Stores::ActiveRecord` for a host model and database.
+
+JSONL closes each append, so completed lines survive an ordinary process
+restart. It does not call `fsync`, provide a database transaction, or promise
+power-loss durability. Use a database or host store when that distinction
+matters.
+
+### Active Record
+
+The adapter is opt-in and Mistri never requires Rails at boot:
+
+```ruby
+require "mistri/stores/active_record"
+
+store = Mistri::Stores::ActiveRecord.new(AgentEntry)
+```
+
+Generate a host-named model and migration in Rails:
+
+```console
+$ bin/rails generate mistri:install AgentEntry
+```
+
+The table needs `session_id`, `position`, and `payload`, plus a unique index on
+`[session_id, position]`. The unique index is the optimistic append boundary for
+independent writers.
+
+On MySQL and Trilogy, `payload` must be LONGTEXT because one legal parallel
+tool turn can exceed MEDIUMTEXT even while each call stays inside its own
+limit. New migrations use `size: :long`. Existing tables need a host migration:
+
+```ruby
+change_column :agent_entries, :payload, :text, size: :long, null: false
+```
+
+PostgreSQL `text` does not need that change.
+
+## Run and resume
+
+`run` appends a new user input and advances the model loop. Do not call it while
+the session has open approvals; use `resume`.
+
+`resume` does not append user text. It audits open approval state, returns
+immediately if a decision is still missing, settles decided calls, and then
+continues the existing exchange.
+
+Rebuild the Agent with the current tool definitions, authorization context,
+hooks, provider configuration, and business policy before resuming. The Session
+contains durable facts, not frozen application policy.
+
+## Human approval
+
+Declare a boolean or argument predicate on the tool:
+
+```ruby
+send_gift = Mistri::Tool.define(
+  "send_gift", "Sends a physical gift.",
+  schema: lambda {
+    string :recipient_id, "Recipient ID", required: true
+    number :value_usd, "Gift value", required: true
+  },
+  needs_approval: ->(args) { args.fetch("value_usd") > 100 },
+) do |args|
+  Gifts.send!(
+    recipient_id: args.fetch("recipient_id"),
+    value_usd: args.fetch("value_usd"),
+  )
+end
+```
+
+When the model calls it:
+
+```ruby
+result = agent.run("Send the launch gift to customer 42")
+result.awaiting_approval? # => true
+
+call = result.pending.first
+session_id = agent.session.id
+```
+
+The handler has not run. Persist or route `session_id` and `call.id` in the
+host's own UI. A decision needs only a store and Session:
+
+```ruby
+session = Mistri::Session.new(store: store, id: session_id)
+session.approve(call.id, note: "Approved by finance")
+# or: session.deny(call.id, note: "Use the standard gift instead")
+```
+
+The decision may be appended from another process at any later time. Nothing
+sleeps while waiting. To continue:
+
+```ruby
+session = Mistri::Session.new(store: store, id: session_id)
+agent = Mistri.agent(
+  "claude-opus-4-8",
+  tools: current_tools,
+  session: session,
+  context: current_authorization_context,
+  before_tool: current_policy,
+)
+
+result = agent.resume
+```
+
+Approved arguments are the exact prepared value the human reviewed. Resume
+verifies their source and pairing metadata, revalidates them against the current
+schema, and runs `before_tool` again. It does not renormalize or reevaluate the
+approval predicate.
+
+`Session#open_approvals` derives every still-open call and its decision from the
+log. Duplicate, late, malformed, or mismatched control entries fail closed.
+
+Denial is returned to the model as an expected result so it can choose another
+path. It is not marked as a tool execution error.
+
+## Steering and the inbox
+
+Steering queues a user message for the next turn boundary:
+
+```ruby
+Mistri::Session.new(store: store, id: session_id).steer(
+  "Focus only on contracts renewed this quarter."
+)
+```
+
+The active Agent does not need to be shared with the writer. If a steer lands
+while the model finishes cleanly, the run extends for another turn so the new
+instruction is answered.
+
+Background child reports use the same ordered inbox. A host that wakes idle
+sessions should watch `session.pending_inbox`, not only
+`session.pending_steers`, so worker reports receive the same treatment.
+
+Inbox consumption is itself an append: the folded message records the source
+entry ID. A crash cannot consume a steer invisibly or require a repair write.
+
+## Compaction
+
+For a catalogued model, automatic compaction begins when estimated context use
+crosses the published window minus safe output headroom. Disable it with
+`compaction: false`, or pass policy explicitly:
+
+```ruby
+settings = Mistri::Compaction.new(
+  reserve: 64_000,
+  keep_recent: 24_000,
+  instructions: "Preserve decisions, identifiers, and unresolved risks.",
+)
+
+agent = Mistri.agent("claude-opus-4-8", compaction: settings)
+```
+
+An explicit `window:` enables compaction for an uncatalogued deployment. An
+explicit `reserve:` is host policy; the automatic default otherwise protects a
+catalogued model's shared output capacity plus framing slack. Gemini publishes
+an independent input limit, so its automatic reserve remains input-oriented.
+
+```ruby
+agent.context_usage
+# => { tokens: 141_000, window: 1_000_000, fraction: 0.141 }
+
+agent.compact
+```
+
+Manual `compact` returns nil when there is no useful cut. During a compaction,
+`:compacting` announces that work began. The later `:compaction` event carries
+the visible summary in `event.content`.
+
+The summary and kept-tail boundary append to the session. Provider replay then
+uses the visible summary plus the retained tail, while the full original log
+remains available through `entries` and `transcript`. Compaction cannot hide an
+open approval or split a completed tool call from its result.
+
+Very large tool results may be shortened only in the request sent to the
+summarizer. The durable result and ordinary replay remain unchanged until a
+successful compaction intentionally replaces earlier context with the summary.
+
+## Provider changes
+
+The shared message model permits a session to continue with another built-in
+provider. Opaque reasoning, signatures, and pairing metadata replay only to the
+provider that created them.
+
+Completed foreign tool exchanges become a neutral representation when needed.
+In particular, Mistri does not manufacture a signed Gemini function call from
+another provider's metadata.
+
+Changing providers can alter model behavior even when replay is valid. Treat it
+as explicit host policy, not transparent failover.
+
+## Transcripts and child sessions
+
+```ruby
+session.transcript
+session.transcript(include_children: true)
+```
+
+With `include_children: true`, each child transcript is spliced after its link
+entry. Entries carry the same origin labels used by live events, so a reloaded
+UI can reconstruct parent and worker lanes. See [Sub-agents](sub-agents.md).
+
+## Concurrency and crashes
+
+Independent appenders such as approvals, steering, and child reports are part
+of the design. Active execution is different: only one Agent may call `run` or
+`resume` for a session at a time.
+
+Mistri persists each completed message promptly, but a process can still fail
+after a handler starts or commits an external write and before its result is
+durable. Replay heals an unanswered call with an interrupted error so the
+provider history remains pairable. That error explicitly says the tool may
+have run; it does not make replay safe.
+
+Hosts must serialize active runners and make side effects idempotent or
+reconcilable. Read [Reliability](reliability.md) for the complete contract.
+
+## Related guides
+
+- [Tool contracts](tool-contracts.md)
+- [Sub-agents](sub-agents.md)
+- [Reliability](reliability.md)
+- [Upgrading](../UPGRADING.md)

--- a/docs/sub-agents.md
+++ b/docs/sub-agents.md
@@ -1,0 +1,297 @@
+# Sub-agents
+
+A sub-agent runs a self-contained task in a new Session. Its exploration stays
+out of the parent's context; only the final report returns. The child transcript
+remains linked for inspection, streaming, and UI reconstruction.
+
+Mistri supports two shapes on that mechanism:
+
+- a fixed specialist curated by the host;
+- a host-bounded spawn tool whose model chooses a name, instructions, type,
+  tool subset, model, and execution mode within explicit allowlists.
+
+The open Spawner rejects `spawn_agent` in its own pool, so model-composed
+recursive spawning is not available by default. A host may deliberately give a
+fixed specialist another specialist or spawn tool; nested origins and
+transcripts are supported.
+
+## Fixed specialists
+
+```ruby
+researcher = Mistri::SubAgent.new(
+  name: "researcher",
+  description: "Reads approved sources and answers factual questions.",
+  provider: Mistri.provider("claude-haiku-4-5"),
+  system: "Research the question. Return findings and source URLs.",
+  tools: [fetch_page],
+)
+
+agent = Mistri.agent(
+  "claude-opus-4-8",
+  tools: [researcher.tool],
+)
+```
+
+Each call creates a fresh child Session in the parent's store. The model may
+provide a display name for that run, so parallel specialists can appear as
+distinct lanes.
+
+Pass `schema:` to validate a normally completed report as structured output.
+An `ends_turn` tool hands off with unvalidated text and `output` nil, so do not
+grant one when every report must satisfy the schema. Other Agent options, such
+as a budget or compaction policy, pass to the child through
+`Mistri::SubAgent.new`.
+
+## The spawn tool
+
+The open spawner lets the parent compose a worker from a pool the host controls:
+
+```ruby
+spawn = Mistri::SubAgent.spawner(
+  provider: child_provider,
+  tools: [fetch_page, search_catalog],
+  models: ["claude-haiku-4-5", "gpt-5-nano"],
+  max_children: 4,
+)
+
+agent = Mistri.agent("claude-opus-4-8", tools: [spawn])
+```
+
+The generated `spawn_agent` tool asks for a complete task and system
+instructions. The model may select only tools in the pool and only model IDs in
+`models:`. Without an explicit model, the child inherits the supplied provider
+object.
+
+Do not place `spawn_agent` inside its own tool pool. Mistri rejects that host
+configuration.
+
+### Typed workers
+
+Definitions let the host own a worker's base prompt and its default tools and
+model:
+
+```ruby
+types = {
+  "researcher" => Mistri::Definition.load("agents/researcher.md"),
+  "reviewer" => Mistri::Definition.load("agents/reviewer.md"),
+}
+
+spawn = Mistri::SubAgent.spawner(
+  provider: child_provider,
+  tools: [fetch_page, search_catalog, inspect_record],
+  types: types,
+  models: ["claude-haiku-4-5"],
+)
+```
+
+A typed worker always begins with its Definition's rendered prompt. The model
+may append focus instructions, choose another subset from the host's tool pool,
+and select another model from the explicit allowlist. Without those overrides,
+the Definition's declared tool names and model are the defaults. Definitions
+are checked when the spawner is built, so a missing pool tool or unresolved
+placeholder fails before a model can spawn. Use a fixed `Mistri::SubAgent` when
+the worker's tools and model must not be model-selectable.
+
+`general-purpose` remains the built-in open type and requires model-written
+instructions.
+
+## Execution modes
+
+Without a dispatcher, a child runs inline inside the tool call. The parent waits
+for the report, and its abort signal cascades to the child.
+
+Add a dispatcher to expose `mode: "background"`:
+
+```ruby
+tools = Mistri::SubAgent.pack(
+  provider: child_provider,
+  tools: [fetch_page, search_catalog],
+  dispatcher: Mistri::Dispatchers::Thread.new,
+)
+```
+
+`pack` returns the spawn tool plus `list_agents`, `read_agent`, `steer_agent`,
+and `stop_agent`.
+
+### Thread dispatcher
+
+`Mistri::Dispatchers::Thread` starts a Ruby thread and returns a receipt to the
+parent immediately. It is useful for development and short work in a process
+whose lifetime the host controls. It is not a durable job queue.
+
+### Queue dispatcher
+
+A production host can dispatch the serializable spec to its queue:
+
+```ruby
+dispatcher = lambda do |spec, _in_process_runner|
+  RunMistriChildJob.perform_later(spec)
+end
+```
+
+The job reconstructs current tools, provider, Definition, and policy from host
+registries, then enters the shared child lifecycle:
+
+```ruby
+Mistri::SubAgent.run_dispatched(
+  spec,
+  provider: HostAgents.provider_for(spec),
+  system: HostAgents.system_for(spec),
+  tools: HostAgents.tools_for(spec),
+  store: mistri_store,
+  emit: event_sink,
+)
+```
+
+Treat that code as an architectural shape, not a copy-paste registry API. The
+host owns serialization and reconstruction because application tools commonly
+close over credentials, tenants, database objects, or framework state that
+must not ride in a queue payload.
+
+`workspace: "parent"` is rejected for background mode, but this field is a
+model-supplied scheduling declaration, not capability isolation. Choosing or
+omitting `workspace: "own"` does not clone Tool objects or the workspace objects
+they close over. A production dispatcher must reconstruct background tools with
+isolated, host-owned workspace instances; otherwise parent and child can mutate
+the same resource concurrently.
+
+## Reports and control
+
+A background spawn returns a truthful receipt based on the child's stored
+status. When the child reaches a terminal state, it writes its result to its own
+session and delivers one typed report into the parent inbox.
+
+The parent folds that report at its next turn boundary as a labeled message.
+The `:subagent_report` event closes the worker's live UI lane. Duplicate report
+delivery is dropped by child Session ID when redeliveries are sequential. The
+current check is not an atomic uniqueness constraint, so a queue must serialize
+delivery or deduplicate concurrent attempts in host storage.
+
+Host code and the management tools use the same `Mistri::Child` facade:
+
+```ruby
+child = parent_session.children.first
+
+child.status                   # :queued, :running, :interrupted, :done, :stopped, :failed
+child.report                   # terminal report when done
+child.error                    # terminal error when failed
+child.transcript(tail: 20)     # presentation-oriented recent entries
+child.say("Check pricing too") # queues a steer
+child.stop                     # cooperative; requires a lock adapter
+```
+
+Child events forwarded into the parent stream carry an `origin` such as
+`Corgi#ab12cd34`. `session.transcript(include_children: true)` uses the same
+labels when rebuilding lanes from the store.
+
+Like `Session#transcript`, a child transcript only strips inline image bytes. It
+is not an authorization or redaction boundary; authorize and redact it before
+exposing it.
+
+## Provider concurrency
+
+Several spawn calls in one parent turn are tool calls and can begin
+concurrently. Actual model requests depend on provider instances:
+
+- Calls sharing one built-in provider object serialize through that provider's
+  transport.
+- Give independent children distinct provider instances when their model calls
+  must overlap.
+- A typed Definition with its own model builds a provider for that worker; an
+  inherited provider remains shared.
+
+This distinction avoids promising network fan-out when only tool scheduling is
+parallel.
+
+## Approval
+
+A child cannot suspend and wait for a human. It must return a report to its
+parent.
+
+Mistri rejects statically approval-gated tools when a SubAgent or Spawner is
+built. A predicate gate cannot always be detected statically; if one triggers at
+runtime, Mistri denies and settles the call, fails the child, and leaves no open
+approval.
+
+Gate the delegation itself instead:
+
+```ruby
+reviewer = Mistri::SubAgent.new(
+  name: "external_reviewer",
+  description: "Sends material to the external review service.",
+  provider: reviewer_provider,
+  tools: [external_review],
+  needs_approval: true,
+)
+```
+
+## Lock adapters
+
+Cross-process liveness and stop requests require a shared lock adapter. Configure
+one at boot:
+
+```ruby
+# One process, including the thread dispatcher:
+Mistri.locks = Mistri::Locks::Memory.new
+```
+
+Rails cache support is optional and must be required explicitly:
+
+```ruby
+require "mistri/locks/rails_cache"
+
+Mistri.locks = Mistri::Locks::RailsCache.new(cache: Rails.cache)
+```
+
+The cache must implement atomic `unless_exist` writes and be shared by every
+worker process. A local memory cache is not a cross-process adapter.
+
+A custom adapter implements:
+
+```text
+acquire(key, ttl:) -> boolean
+renew(key, ttl:)
+release(key)
+held?(key) -> boolean
+set_flag(key, ttl:)
+flag?(key) -> boolean
+clear_flag(key)
+```
+
+The current lease is a best-effort duplicate-suppression and liveness signal,
+not an ownership token or exactly-once fence. It stores no holder identity. A
+process stalled beyond the TTL can resume after another process acquires the
+same key, and unconditional renewal or release cannot distinguish those
+generations.
+
+Queue jobs must therefore keep child work idempotent or reconcilable. A held
+lease suppresses an ordinary redelivery while the first worker is healthy; an
+expired lease allows a retry of a child that appears interrupted. A finished
+child's terminal entry makes later delivery a no-op.
+
+Without an adapter:
+
+- inline and dispatched work can still run;
+- a non-terminal started child reads `:running`, because no shared liveness
+  signal exists;
+- `Child#stop` cannot send a cross-process request;
+- queue redeliveries receive no lease-based suppression.
+
+## Capacity is advisory
+
+`max_children` counts the parent's currently live children before spawning. It
+is a useful model-facing limit, but the read-then-create sequence is not an
+atomic distributed admission control. Concurrent parent runners are already
+outside the Session execution contract, and independent callers can race the
+count.
+
+If worker capacity is a hard operational limit, enforce it atomically in the
+host queue, database, or scheduler. Keep `max_children` as the in-band guidance
+the model sees.
+
+## Related guides
+
+- [Sessions and control](sessions.md)
+- [Tool contracts](tool-contracts.md)
+- [Reliability](reliability.md)
+- [Upgrading](../UPGRADING.md)

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -1,0 +1,324 @@
+# Tool contracts
+
+A Mistri tool is application code exposed to model output. Treat that boundary
+like an HTTP endpoint: declare what it accepts, authorize the acting context,
+and make writes idempotent or reconcilable.
+
+This guide covers local tools. Remote MCP tools cross the same execution
+boundary; see [MCP](mcp.md) for the additional server contract.
+
+## Define a tool
+
+```ruby
+charge_card = Mistri::Tool.define(
+  "charge_card", "Charges a saved payment method.",
+  schema: lambda {
+    string :payment_method_id, "Saved payment method ID", required: true
+    number :amount_usd, "Amount in US dollars", required: true
+  },
+  needs_approval: ->(args) { args.fetch("amount_usd") >= 500 },
+) do |args, context|
+  Payments.charge!(
+    customer: context.app.fetch(:customer),
+    payment_method_id: args.fetch("payment_method_id"),
+    amount_usd: args.fetch("amount_usd"),
+  )
+end
+```
+
+The handler may accept only `args`, or `args` and `context`. `context.app` is
+the object passed as `Mistri.agent(context:)`; it is the usual place for the
+acting user, tenant, or request-scoped authorization context.
+
+Handlers may return:
+
+- a String, delivered to the model as text;
+- a Hash, number, boolean, nil, or data Array, serialized as JSON or empty text;
+- an Array made only of Strings and Mistri content blocks, delivered as
+  multiple content blocks, including images;
+- `Mistri::ToolResult`, which separates model content, host-only UI, and an
+  explicit failure fact.
+
+## The execution boundary
+
+A completed model call moves through these phases in order:
+
+1. Mistri verifies the provider's call envelope and pairing metadata.
+2. The argument value is copied into bounded, immutable JSON owned by Mistri.
+3. The tool's explicit `argument_normalizer`, if any, runs once.
+4. Core schema validation and the tool's host validator run.
+5. `before_tool` evaluates current application policy.
+6. `needs_approval` decides whether the prepared call must park.
+7. A free call emits `:tool_started` and invokes the handler.
+8. `after_tool` may rewrite the result, which then persists and emits
+   `:tool_result`.
+
+Malformed or invalid calls do not reach policy or execution. The model receives
+a bounded error result it can correct, while valid sibling calls in the same
+turn continue. Results settle in the model's call order even when handlers run
+concurrently.
+
+An approved call is revalidated against the current tool definition and passes
+through `before_tool` again on `resume`. Its normalizer and approval predicate
+do not run again: the human approved the already prepared arguments.
+
+## Schema forms
+
+The DSL builds a JSON Schema 2020-12 object:
+
+```ruby
+search = Mistri::Tool.define("search", "Searches products.", schema: lambda {
+  string :query, "Search text", required: true
+  integer :limit, "Maximum result count"
+  array :tags, "Required tags", items: { type: "string" }
+  object :filters, "Structured filters" do
+    string :country, "ISO country code"
+    boolean :in_stock, "Only products in stock"
+  end
+}) do |args|
+  filters = args.fetch("filters", {})
+  Catalog.search(
+    query: args.fetch("query"),
+    limit: args["limit"],
+    tags: args.fetch("tags", []),
+    country: filters["country"],
+    in_stock: filters["in_stock"],
+  )
+end
+```
+
+Use `input_schema:` for a raw schema:
+
+```ruby
+schema = {
+  type: "object",
+  properties: {
+    "invoice_id" => { type: "string" },
+  },
+  required: ["invoice_id"],
+  additionalProperties: false,
+}
+
+Mistri::Tool.define("pay_invoice", "Pays one invoice.", input_schema: schema) do |args|
+  Invoices.pay!(args.fetch("invoice_id"))
+end
+```
+
+The root must be an object schema. `Tool.define` without `schema:` or
+`input_schema:` creates a closed no-argument tool; model-supplied fields are
+rejected.
+
+### Open and closed objects
+
+Supplied object schemas follow JSON Schema's default-open semantics. Declared
+properties do not automatically reject additional keys. Extract the fields you
+intend to use rather than mass-assigning the entire model hash.
+
+Set `additionalProperties: false` in a raw schema when extra keys must fail.
+
+A nested object declared without a block is intentionally freeform:
+
+```ruby
+object :config, "Chart-library configuration", required: true
+```
+
+It accepts any JSON object, including `{}`. This is useful when Mistri should
+not prescribe keys owned by another library. A bare top-level `Schema.build`
+raises because it communicates no argument contract.
+
+Freeform objects cannot become strict constrained output without changing their
+meaning. `Schema.strict` and task planning reject that shape instead of silently
+narrowing it to `{}`.
+
+### Portable validation subset
+
+Mistri's zero-dependency validator enforces:
+
+- JSON `type`, including type unions;
+- `enum`;
+- `required` and declared `properties`;
+- one-schema array `items`;
+- tuple array `prefixItems`;
+- boolean schemas;
+- boolean or schema-valued `additionalProperties`.
+
+Other standard keywords remain provider-facing generation guidance unless a
+complete validator is supplied. Examples include `minimum`, `pattern`,
+`format`, length constraints, and applicators such as `anyOf`.
+
+An argument-applicable, non-empty `patternProperties` requires complete
+authority because approximating its key and value interactions would be
+unsafe. External references are not resolved.
+
+Task output is stricter than tool input: task planning rejects assertions that
+local validation cannot guarantee. A task promises a validated value; a tool
+server can still enforce its own broader contract after Mistri's local subset.
+
+## Host validation
+
+Use `argument_validator:` for domain rules that supplement core validation:
+
+```ruby
+invoice = Mistri::Tool.define(
+  "pay_invoice", "Pays an approved invoice.",
+  input_schema: invoice_schema,
+  argument_validator: lambda { |args, _schema|
+    if args.fetch("invoice_id").start_with?("inv_")
+      []
+    else
+      ["$.invoice_id must identify an invoice"]
+    end
+  },
+) do |args|
+  Invoices.pay!(args.fetch("invoice_id"))
+end
+```
+
+The validator receives the deeply frozen arguments and canonical schema. It
+must return an Array of Strings. Core validation runs first and cannot be
+weakened.
+
+Use `complete_argument_validator:` only when the host validator implements the
+whole schema, including interactions outside Mistri's portable subset. It has
+the same `(args, schema)` signature and is mutually exclusive with
+`argument_validator:`.
+
+Validator errors are sent back to the model. Describe the expected contract;
+do not echo received secrets or field values.
+
+## Explicit normalization
+
+Mistri does not coerce model input. If a tool intentionally accepts a legacy
+alias or representation, declare that compatibility policy on the tool:
+
+```ruby
+normalizer = lambda do |args|
+  next args unless args.key?("account")
+  raise ArgumentError, "choose account or account_id" if args.key?("account_id")
+
+  normalized = args.dup
+  normalized["account_id"] = normalized.delete("account")
+  normalized
+end
+
+tool = Mistri::Tool.define(
+  "lookup_account", "Looks up one account.",
+  schema: -> { string :account_id, "Account ID", required: true },
+  argument_normalizer: normalizer,
+) do |args|
+  Accounts.find(args.fetch("account_id"))
+end
+```
+
+The normalizer must return a Hash and should be pure, deterministic, and
+idempotent. Its output is what validation, policy, approval, and the handler
+see.
+
+Direct `Tool#call` is a trusted host invocation. It applies the normalizer for
+compatibility, but the Agent's model-input ownership and validation boundary is
+not involved.
+
+## Policy hooks
+
+`before_tool` can block a call with a model-readable reason:
+
+```ruby
+before_tool = lambda do |call, context|
+  next "customer cannot perform this action" unless context.app.fetch(:customer).active?
+  next "currency is not enabled" unless call.arguments.fetch("currency") == "USD"
+end
+
+agent = Mistri.agent("claude-opus-4-8", tools: tools, before_tool: before_tool)
+```
+
+The hook also runs when an approved call resumes, so long-lived approval does
+not bypass current authorization. A raised hook error blocks conservatively.
+
+`after_tool` receives `(call, result, context)` and may return a replacement
+result. Returning nil keeps the original. If the original result is an error,
+rewriting its text cannot relabel it as success.
+
+## Results and UI
+
+Use `Mistri::ToolResult` when the model and host need different views:
+
+```ruby
+Mistri::Tool.define("edit_page", "Applies a page edit.", schema: lambda {
+  object :changes, "Page changes", required: true
+}) do |args|
+  page = Pages.apply(args.fetch("changes"))
+  Mistri::ToolResult.new(
+    content: "Saved the page.",
+    ui: { "html" => page.html, "revision" => page.lock_version },
+  )
+end
+```
+
+`ui` persists on the tool message and appears on the `:tool_result` event, but
+is never sent to a provider.
+
+Non-text tool-result content remains provider-neutral in the Session. Anthropic
+can receive image blocks in a tool result. The current OpenAI and Gemini
+function-result serializers have no such encoding and send an explicit
+non-text-omission marker alongside the text instead.
+
+Return `error: true` for an expected failure the model should handle:
+
+```ruby
+account || Mistri::ToolResult.new(
+  content: "Account not found.",
+  error: true,
+)
+```
+
+Mistri also marks unknown tools, validation and policy rejection, handler
+exceptions, timeouts, pre-invocation interruption, failed result hooks,
+crash-healed calls, and MCP `isError` results. Human denial is an expected
+control outcome, not an execution failure.
+
+`event.tool_error` and `event.message.tool_error?` expose the fact without
+parsing prose. A legacy persisted result without the field remains unknown;
+Mistri does not infer historical success from text.
+
+An error flag does not make a replay safe. A handler may have committed a write
+before raising or timing out. Mistri never mechanically replays the same call
+because it is marked failed, but the model may issue another call. The host
+still owns idempotency and reconciliation.
+
+## Hand off the turn
+
+`ends_turn: true` ends the run after the tool executes instead of asking the
+model for another response. This is useful for `ask_user`, escalation, or a
+structural handoff:
+
+```ruby
+ask_user = Mistri::Tool.define(
+  "ask_user", "Asks the human and waits.",
+  ends_turn: true,
+  schema: -> { string :question, "Question", required: true },
+) do |_args|
+  "Question presented to the user."
+end
+```
+
+`result.handed_off?` reports that the model's floor moved away. It does not
+claim the tool succeeded; inspect the tool result separately. The human answer
+arrives as the next `run` input.
+
+## Resource limits
+
+Completed arguments are bounded at 8 MiB, 64 levels, 10,000 JSON nodes, and 64
+KiB per numeric token. Encoded Anthropic and OpenAI arguments receive a linear
+lexical pass before JSON parsing. Gemini's enclosing SSE record receives the
+same structural preflight before its argument object is canonicalized.
+
+These are safety boundaries, not business validation. Keep tool schemas narrow,
+validate domain rules explicitly, and return references rather than embedding
+unbounded data in a tool call.
+
+## Related guides
+
+- [Sessions and control](sessions.md)
+- [MCP](mcp.md)
+- [Reliability](reliability.md)
+- [Upgrading](../UPGRADING.md)

--- a/examples/browser.rb
+++ b/examples/browser.rb
@@ -14,11 +14,14 @@ browser = Mistri::MCP::Client.new(
   read_timeout: 180
 )
 
-tools = Mistri::MCP.tools(browser, prefix: "web",
-                                   allow: %w[browser_navigate browser_snapshot])
+begin
+  tools = Mistri::MCP.tools(browser, prefix: "web",
+                                     allow: %w[browser_navigate browser_snapshot])
 
-agent = Mistri.agent("claude-opus-4-8", tools: tools,
-                                        system: "Use the browser tools to answer. Be brief.")
+  agent = Mistri.agent("claude-opus-4-8", tools: tools,
+                                          system: "Use the browser tools to answer. Be brief.")
 
-puts agent.run("Open https://example.com and report the main heading.").text
-browser.close
+  puts agent.run("Open https://example.com and report the main heading.").text
+ensure
+  browser.close
+end

--- a/examples/page_editor.rb
+++ b/examples/page_editor.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # The landing-page shape: one value (a database column in production, a
-# string here) edited in place through the document tools, with the updated
-# page broadcast on the ui channel the model never sees.
+# string here) edited in place through the document tools. A host can wrap the
+# result in ToolResult when it also needs a separate UI payload.
 # Needs ANTHROPIC_API_KEY.
 #
 #   ruby examples/page_editor.rb

--- a/mistri.gemspec
+++ b/mistri.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Muhammad Ahmed Cheema"]
   spec.summary = "The agent harness for Ruby applications."
   spec.description = "Mistri (مستری) is the fixer: an agent harness that lives inside your " \
-                     "app. Durable sessions in your own database, streaming, tools, " \
+                     "app. Durable sessions in your own store, streaming, tools, " \
                      "fire-and-forget human approval, steering, compaction, structured " \
                      "output, skills, and sub-agents, across Anthropic, OpenAI, and " \
                      "Gemini, with zero runtime dependencies."
@@ -20,10 +20,15 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/mcheemaa/mistri/blob/main/CHANGELOG.md"
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["rubygems_mfa_required"] = "true"
-  spec.metadata["documentation_uri"] = "https://mistri.sh/docs/getting-started/"
+  spec.metadata["documentation_uri"] =
+    "https://github.com/mcheemaa/mistri/blob/v#{spec.version}/docs/README.md"
   spec.metadata["bug_tracker_uri"] = "https://github.com/mcheemaa/mistri/issues"
 
   # The .tt generator templates must ship, or rails g mistri:install breaks.
-  spec.files = Dir["lib/**/*.{rb,tt}", "README.md", "LICENSE", "NOTICE", "CHANGELOG.md"]
+  public_files = Dir["lib/**/*.{rb,tt}", "docs/**/*.md", "assets/**/*", "examples/*.rb"]
+                 .select { |path| File.file?(path) }
+  root_files = %w[CHANGELOG.md CONTRIBUTING.md LICENSE NOTICE README.md SECURITY.md
+                  UPGRADING.md mistri.gemspec]
+  spec.files = (public_files + root_files).sort
   spec.require_paths = ["lib"]
 end

--- a/test/test_package.rb
+++ b/test/test_package.rb
@@ -12,7 +12,8 @@ require_relative "test_helper"
 # The package smoke test exercises the artifact a user installs, outside Bundler and the checkout.
 class TestPackage < Minitest::Test
   ROOT = File.expand_path("..", __dir__)
-  SHIPPED_DOCUMENTS = %w[CHANGELOG.md LICENSE NOTICE README.md].freeze
+  SHIPPED_ROOT_FILES = %w[CHANGELOG.md CONTRIBUTING.md LICENSE NOTICE README.md SECURITY.md
+                          UPGRADING.md mistri.gemspec].freeze
 
   def test_strict_package_installs_and_loads_in_isolation
     Dir.mktmpdir("mistri-package") do |temporary|
@@ -43,6 +44,8 @@ class TestPackage < Minitest::Test
     assert_empty spec.executables
     assert_equal "https://rubygems.org", spec.metadata["allowed_push_host"]
     assert_equal "true", spec.metadata["rubygems_mfa_required"]
+    assert_equal "https://github.com/mcheemaa/mistri/blob/v#{Mistri::VERSION}/docs/README.md",
+                 spec.metadata["documentation_uri"]
     assert_equal expected_files, spec.files.sort
   end
 
@@ -50,7 +53,14 @@ class TestPackage < Minitest::Test
     libraries = Dir.glob(File.join(ROOT, "lib", "**", "*"))
                    .select { |path| File.file?(path) }
                    .map { |path| Pathname(path).relative_path_from(Pathname(ROOT)).to_s }
-    (libraries + SHIPPED_DOCUMENTS).sort
+    documentation = Dir.glob(File.join(ROOT, "docs", "**", "*.md"))
+                       .map { |path| Pathname(path).relative_path_from(Pathname(ROOT)).to_s }
+    public_assets = %w[assets examples].flat_map do |directory|
+      Dir.glob(File.join(ROOT, directory, "**", "*"))
+         .select { |path| File.file?(path) }
+         .map { |path| Pathname(path).relative_path_from(Pathname(ROOT)).to_s }
+    end
+    (libraries + documentation + public_assets + SHIPPED_ROOT_FILES).sort
   end
 
   def isolated_environment(temporary)


### PR DESCRIPTION
The README had grown into a long mixed reference that made first adoption slower and hid the contracts that matter in production. This rewrites it as a concise front door: one working Agent, an honest fit comparison, the execution model, and direct paths into versioned task guides.

The new guides cover tool validation and approval, sessions and replay, Skills and workspaces, sub-agents, MCP, reliability, and the 0.5-to-0.6 host migration. Every material claim was checked against the implementation and independently reviewed for both source-level truth and first-time usability. The gem now ships those guides, the linked examples and assets, and a tag-versioned documentation URI, so installed documentation remains internally complete. There is no runtime API change.

Validation:
- `bundle exec rake test`: 904 runs, 4,702 assertions, 0 failures
- coverage: 98.26% line, 88.07% branch
- `bundle exec rubocop`: 188 files, 0 offenses
- real-provider suite: 904 runs, 4,961 assertions, 0 failures, 0 skips across Anthropic, OpenAI, and Gemini
- strict package install, Markdown lint, local and packaged link checks, 89 compiled Ruby fences, and live quickstart/approval/page-editor examples

The broader live integration harness passed 59 of 60 scenarios. Gemini 2.5 Flash made the multi-compaction harness fail two different model-dependent exact-count/tail assertions on two runs even though the checkpoint state survived. That pre-existing stochastic harness issue is intentionally kept out of this documentation-only change and recorded for a focused follow-up before release.