### PR TITLE
Reconstruct background worker capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Background dispatch now crosses a versioned, deeply owned JSON capability
+  boundary instead of closing over the spawn-time provider, Tool objects, Agent
+  options, and workspace state. Every `dispatcher:` requires a host
+  `runtime_factory:` that constructs a `SubAgent::Runtime` inside the worker;
+  the runtime provider model and unique Tool names must match the durable grant
+  exactly before any provider call or tool side effect. Missing, additional,
+  renamed, duplicated, non-Tool, reconstructed statically approval-gated, and
+  synthetic Skill capabilities fail closed before execution. New immutable
+  specs carry `spec_version`, require a model identity, reject unknown fields,
+  and omit the model-controlled `workspace` field. The identical canonical
+  spec is stored in the child Session before dispatch; `run_dispatched` compares
+  the complete queue copy and uses the stored grant for execution and report
+  routing, so a changed capability, task, model, name, or parent ID leaves the
+  child untouched. Legacy unversioned specs containing `workspace` remain
+  executable. Finished redeliveries are rejected before factory construction;
+  a configured child lease also rejects concurrent live redeliveries. The
+  compatible direct form receives the same grant checks.
+  Runtime factory exceptions remain retryable for queues by default; built-in
+  in-process runners and an explicit `retry_factory_errors: false` persist a
+  terminal failure before re-raising. An optional Runtime `cleanup:` hook runs
+  exactly once without masking a primary error. Generic child Agent options
+  are allowlisted and travel as one isolated Hash, so they cannot replace the
+  durable Session, task, signal, event sink, or other lifecycle state; Runtime
+  cannot add Skill capabilities. The dispatched
+  lease now spans runtime construction, execution, cleanup, terminal
+  persistence, and parent report delivery; it suppresses ordinary stop and
+  redelivery races while the tokenless lease remains live. Queued and
+  interrupted cancellations now deliver their durable stopped report while holding that
+  lease even when the queue never starts or retries the job; repeating stop
+  reconciles a transient parent-report failure. A queue copy that does not
+  match the persisted grant raises the public, non-retryable
+  `Mistri::DispatchGrantError`, which is reserved for grant binding.
+  Model selection records only its identity at spawn time; its provider is
+  constructed in the worker. `tools: []` now grants no tools, while omission
+  keeps the general pool or typed defaults, so an empty typed Definition can no
+  longer inherit the entire pool. Duplicate pool, model, or model-selected tool
+  names fail before a child starts, and Spawner owns copies of its policy
+  arrays. Dispatch adds one bounded spec ownership/comparison and one linear
+  capability-name check per child, outside all provider streaming paths.
 - Model-originated tool calls now cross a local execution boundary rather than
   relying on provider guidance alone. Completed calls deeply own immutable JSON,
   canonicalize symbol keys without coercing values, retain malformed encoded
@@ -290,7 +329,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   steers, and reports remain concurrency-safe, but hosts must allow only one
   `run` or `resume` at a time for a session. Even with one runner, a crash,
   result-store failure, or subscriber exception after invocation but before
-  result persistence can leave an approved call open for at-least-once
+  result persistence can leave an approved call open for possible duplicate
   re-execution. Simultaneous runners widen the same risk. Hosts must use
   idempotency/reconciliation across that commit gap; durable atomic claiming is
   the next synchronization feature, not simulated by a local mutex.
@@ -389,7 +428,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   requires inline mode, enforced in band.
 
 - Report delivery: a background child's terminal outcome reports back to
-  its parent, exactly once. The report queues in the parent's inbox as a
+  its parent. The report queues in the parent's inbox as a
   typed subagent_report entry and folds at the next turn boundary the way
   a steer does (the model sees `[Magpie finished] <report>`; failures
   carry the error, stops say so), and a report landing as a run finishes
@@ -397,9 +436,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   event (agent, session_id, status, content) closes the child's lane in
   whatever UI watched the spawn. Session#pending_inbox is the
   steers-and-reports view (hosts that wake idle sessions on steers should
-  watch it instead); Session#deliver_report is the idempotent primitive
-  underneath.
-- Dispatched runs are fenced by the child's lease, taken before the
+  watch it instead); Session#deliver_report drops sequential duplicate
+  delivery by child Session ID. Concurrent callers need serialization.
+- With a lock adapter, dispatched runs use the child's lease before the
   run-or-not decision: a queue that redelivers a live job leaves the
   owner alone, a retry of a finished or cancelled child is a clean no-op,
   and a retry of a child a crashed process left mid-run runs it again

--- a/README.md
+++ b/README.md
@@ -288,9 +288,10 @@ agent = Mistri.agent("claude-opus-4-8", tools: [researcher.tool])
 ```
 
 Mistri also provides a host-bounded spawn tool, named worker types, background
-dispatch, reports, steering, stopping, and a management console. See
-[Sub-agents](docs/sub-agents.md), including the concurrency and lease limits a
-production dispatcher must understand.
+dispatch with worker-side runtime reconstruction, exact capability grants,
+reports, steering, stopping, and a management console. See
+[Sub-agents](docs/sub-agents.md), including the runtime, concurrency, and lease
+limits a production dispatcher must understand.
 
 ## Model Context Protocol
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,8 +17,9 @@ Gemini providers preserve ordinary 0.5 sessions, including the repeated
 occurrence settled. There is no blanket session rewrite step.
 
 Hosts that used implicit tool schemas, mutated arguments, supplied custom
-providers, generated MCP OAuth models, stored sessions in MySQL, or configured
-cost budgets need to review the sections below.
+providers, dispatched background children, generated MCP OAuth models, stored
+sessions in MySQL, or configured cost budgets need to review the sections
+below.
 
 ### Checklist
 
@@ -38,8 +39,106 @@ cost budgets need to review the sections below.
       behavior.
 - [ ] Configure a deterministic standard service tier for any cost budget.
 - [ ] Remove intentional symlinks from model-controlled Directory workspaces.
+- [ ] Add a runtime factory to every background spawner and queue worker.
+- [ ] Review queued child specs and ensure their exact `tool_names` grant is
+      still intended before executing them under 0.6.
 - [ ] Exercise active persisted sessions, approvals, tool failures, compaction,
       and one real call per configured provider in staging.
+
+## Background children reconstruct their runtime
+
+A dispatcher no longer captures the spawn-time provider, Tool objects, Agent
+options, or their workspace closures. Every spawner with `dispatcher:` must now
+provide a host-owned `runtime_factory:`. Mistri invokes it inside the worker and
+requires a `Mistri::SubAgent::Runtime`:
+
+```ruby
+runtime_factory = lambda do |spec|
+  workspace = HostWorkspaces.for_child(spec.fetch("session_id"))
+  provider = HostModels.build(spec.fetch("model"))
+  tools = HostTools.build(spec.fetch("tool_names"), workspace: workspace)
+
+  Mistri::SubAgent::Runtime.new(
+    provider: provider,
+    system: HostAgents.system_for(spec),
+    tools: tools,
+    cleanup: -> { HostAgents.release(provider: provider, tools: tools) },
+    budget: HostAgents.child_budget,
+  )
+end
+
+spawn = Mistri::SubAgent.spawner(
+  provider: child_provider,
+  tools: declared_tools,
+  dispatcher: Mistri::Dispatchers::Thread.new,
+  runtime_factory: runtime_factory,
+)
+```
+
+The provider model and unique Tool names returned by the factory must match the
+versioned dispatch spec exactly. Mistri rejects missing, additional, duplicate,
+renamed, or reconstructed statically approval-gated tools before the provider
+runs. This turns `tool_names` into a durable capability grant rather than queue
+metadata. A versioned spec and its exact parent routing are also stored in the
+child Session; a changed queue copy raises without failing or reporting the
+legitimate child.
+
+`cleanup:` is optional and called exactly once after Mistri accepts a Runtime,
+including after validation or execution failure. Use it for per-child provider
+sockets, MCP subprocesses, and other host-owned resources. It never masks the
+primary error. `skills:` is rejected because it would add an
+undeclared `read_skill` tool. Spawner Agent options apply only to inline
+children; declare background Agent options on the Runtime.
+
+Sub-agent Agent options are now limited to `budget`, `max_concurrency`,
+`transform_context`, `compaction`, `retries`, `skills`, `before_tool`,
+`after_tool`, and application `context`; background Runtime still rejects
+`skills`. Lifecycle keys such as `session`, `task`, `signal`, and `emit` are
+owned by the child and cannot be overridden through generic keyword options.
+
+The model-facing `workspace` argument has been removed. It never cloned a Tool
+closure or proved isolation. Existing queued specs that contain `workspace`
+remain readable, but new specs omit it. Build child-scoped resources from
+trusted host state and stable identifiers such as `session_id`; a retry should
+reopen the same durable scope. Inline children still use the exact objects the
+host supplied and may share their backends.
+
+Queue jobs should pass the factory into the lifecycle entry point:
+
+```ruby
+Mistri::SubAgent.run_dispatched(
+  spec,
+  store: mistri_store,
+  runtime_factory: HostAgents.method(:runtime_for),
+)
+```
+
+Factory exceptions are retryable by default: the child remains non-terminal
+and the exception returns to the queue. Pass `retry_factory_errors: false` on a
+final attempt to persist and report the failure before the exception re-raises.
+The flag does not control the job system's retry or discard decision. The
+built-in Thread and Inline runners use terminal behavior because they have no
+durable retry owner.
+
+If the queue copy differs from the stored grant, `run_dispatched` raises
+`Mistri::DispatchGrantError` without touching the legitimate child. Treat the
+unchanged job as poison: discard it and alert rather than retrying it. This
+error is reserved for Mistri's stored-grant binding; do not raise it from a
+runtime factory.
+
+The compatible direct `provider:`, `system:`, and `tools:` form remains, but it
+now receives the same exact model and tool-grant validation. A job that used to
+pass its entire registry must instead reconstruct only the Tool objects named
+by `spec.fetch("tool_names")`.
+Legacy 0.5 specs keep their serialized grant, including any broad grant created
+by the old empty-Definition bug. Their old child entries also have no stored
+copy against which Mistri can verify capability or report-routing changes.
+Drain or review unversioned queued work before relying on the new boundary.
+
+Tool selection now distinguishes omission from an explicit empty list. Omitted
+`tools` means the general pool or a typed Definition's defaults. `tools: []`
+means no tools for either worker shape, and a typed Definition that declares no
+tools no longer inherits the general pool.
 
 ## Tool schemas are enforced locally
 

--- a/docs/context-and-workspaces.md
+++ b/docs/context-and-workspaces.md
@@ -271,9 +271,14 @@ Record supplies database operations, but the host still owns isolation and
 conflict policy.
 
 Sub-agent tools are ordinary Ruby objects and may close over a workspace. A
-background worker's `workspace: "own"` declaration does not clone those
-objects. Reconstruct isolated tool and workspace instances in a production
-dispatcher before allowing parent and child work to overlap. See
+dispatcher therefore requires a host-owned runtime factory; the model has no
+workspace selector. The factory receives the immutable dispatch spec and
+constructs the provider, tools, and workspace inside the worker. Mistri
+enforces the spec's exact tool-name grant, while the host remains responsible
+for whether the reconstructed backend is fresh, shared, transactional, or
+actually isolated. Derive durable workspace scope from trusted identifiers such
+as the child Session ID, reopen that same scope on queue retry, and release
+per-child resources through Runtime's `cleanup:` hook. See
 [Sub-agents](sub-agents.md#execution-modes).
 
 ## Related guides

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -150,7 +150,9 @@ Loop-level events are:
 - `:compacting` before summary work and `:compaction` with the committed
   summary in `content`;
 - `:retry` before provider backoff;
-- `:subagent_report` when a background child reaches a terminal state.
+- `:subagent_report` when a running background child reaches a terminal state;
+  an inactive `Child#stop` persists the report without this callback because it
+  has no event sink.
 
 Event types form an extensible union. Handle the types the application uses and
 ignore the rest:

--- a/docs/sub-agents.md
+++ b/docs/sub-agents.md
@@ -59,8 +59,9 @@ agent = Mistri.agent("claude-opus-4-8", tools: [spawn])
 
 The generated `spawn_agent` tool asks for a complete task and system
 instructions. The model may select only tools in the pool and only model IDs in
-`models:`. Without an explicit model, the child inherits the supplied provider
-object.
+`models:`. Without an explicit model, an inline child inherits the supplied
+provider object. A background child records that provider's model identity and
+the Runtime factory reconstructs its provider inside the worker.
 
 Do not place `spawn_agent` inside its own tool pool. Mistri rejects that host
 configuration.
@@ -103,21 +104,72 @@ for the report, and its abort signal cascades to the child.
 Add a dispatcher to expose `mode: "background"`:
 
 ```ruby
+runtime_factory = lambda do |spec|
+  workspace = HostWorkspaces.for_child(spec.fetch("session_id"))
+  provider = HostModels.build(spec.fetch("model"))
+  tools = HostTools.build(spec.fetch("tool_names"), workspace: workspace)
+
+  Mistri::SubAgent::Runtime.new(
+    provider: provider,
+    system: HostAgents.system_for(spec),
+    tools: tools,
+    cleanup: -> { HostAgents.release(provider: provider, tools: tools) },
+  )
+end
+
 tools = Mistri::SubAgent.pack(
   provider: child_provider,
   tools: [fetch_page, search_catalog],
   dispatcher: Mistri::Dispatchers::Thread.new,
+  runtime_factory: runtime_factory,
 )
 ```
 
 `pack` returns the spawn tool plus `list_agents`, `read_agent`, `steer_agent`,
-and `stop_agent`.
+and `stop_agent`. A dispatcher always requires `runtime_factory:`. The static
+provider, tool pool, types, and model allowlist declare what the model may
+request. The factory constructs what one background child may actually use.
+
+`Mistri::SubAgent::Runtime` holds the provider, system prompt, exact tools, an
+optional `cleanup:` callable, and safe Agent options for one execution:
+`budget`, `max_concurrency`, `transform_context`, `compaction`, `retries`,
+`before_tool`, `after_tool`, and application `context`. `skills:` is refused in
+a background Runtime because Agent would add a `read_skill` tool outside the
+durable grant. Lifecycle keywords such as `session`, `task`, `signal`, and
+`emit` are never Agent options; the child boundary owns them. The same option
+validation applies to fixed specialists and Spawner. Spawner-level Agent
+options still apply only to inline children; put a background child's options
+on its Runtime.
+
+Mistri calls the factory inside the worker after ruling out a finished
+redelivery. While a configured child lease remains live, it also rules out an
+ordinary concurrent delivery first. It then requires the runtime provider's
+model and the unique runtime tool names to match the versioned dispatch spec
+exactly.
+Missing, additional, renamed, duplicated, or statically approval-gated runtime
+tools fail the child before a provider call or tool side effect. Runtime tools
+are reordered to the durable grant so provider prompt order is deterministic.
+Mistri calls `cleanup` exactly once for a Runtime the factory returned,
+including after validation or execution failure. A cleanup failure does not
+replace an active primary error; by itself it raises after the terminal result
+and report are durable. Use it to release per-child providers, MCP clients, or
+other connections. Mistri does not guess which objects the host owns.
+
+The model has no workspace selector. Derive resource scope from trusted host
+state and stable identifiers such as the child Session ID, not from its name,
+task, or instructions. Reconstructing a Ruby object is not itself isolation:
+the host must decide whether two runtimes use separate directories, database
+rows, credentials, MCP clients, or other backends. Use the same deterministic
+child scope on a queue retry rather than creating a random empty workspace.
 
 ### Thread dispatcher
 
 `Mistri::Dispatchers::Thread` starts a Ruby thread and returns a receipt to the
-parent immediately. It is useful for development and short work in a process
-whose lifetime the host controls. It is not a durable job queue.
+parent immediately. The runtime factory executes on that thread. The host must
+still construct fresh or deliberately shared dependencies; a Proc can close
+over any object, and Mistri does not pretend to inspect its closure. The Thread
+dispatcher is useful for development and short work in a process whose
+lifetime the host controls. It is not a durable job queue.
 
 ### Queue dispatcher
 
@@ -129,37 +181,76 @@ dispatcher = lambda do |spec, _in_process_runner|
 end
 ```
 
-The job reconstructs current tools, provider, Definition, and policy from host
-registries, then enters the shared child lifecycle:
+The spec is a deeply owned, immutable, bounded JSON Hash containing a spec
+version, child and parent Session IDs, worker type, model-written instructions,
+task, exact tool names, and model ID. The identical canonical spec is stored in
+the child Session before dispatch. `run_dispatched` compares the complete queue
+copy with that durable grant before checking a finished result, constructing a
+Runtime, or routing a report. A changed grant, task, model, name, or parent ID
+raises `Mistri::DispatchGrantError` and leaves the legitimate child untouched.
+The unchanged queue item cannot heal: configure the job system to discard it
+and alert an operator. The class is reserved for Mistri's stored-grant binding;
+a runtime factory must not use it as an application signal. Versioned specs
+reject unknown fields.
+
+Unversioned 0.5 queue specs remain executable because their child entries did
+not store a comparable grant. That compatibility cannot retroactively prove
+their queue copy or report routing. Drain or inspect those jobs before relying
+on the versioned boundary.
+
+The spec contains no providers, tools, workspaces, credentials, or callbacks.
+If queue execution needs a tenant or account ID, put that trusted identifier
+beside the spec in the host's job envelope and reauthorize it in the worker; do
+not add fields to the spec or put live application objects inside it.
+
+The job invokes the same host registry locally, then enters the shared child
+lifecycle:
 
 ```ruby
 Mistri::SubAgent.run_dispatched(
   spec,
-  provider: HostAgents.provider_for(spec),
-  system: HostAgents.system_for(spec),
-  tools: HostAgents.tools_for(spec),
   store: mistri_store,
   emit: event_sink,
+  runtime_factory: HostAgents.method(:runtime_for),
 )
 ```
 
-Treat that code as an architectural shape, not a copy-paste registry API. The
-host owns serialization and reconstruction because application tools commonly
-close over credentials, tenants, database objects, or framework state that
-must not ride in a queue payload.
+The factory itself is host code and is never serialized. Existing jobs may
+continue to pass directly reconstructed `provider:`, `system:`, and `tools:` to
+`run_dispatched`; Mistri applies the same exact model and capability checks.
+Prefer the factory form because it runs after the stored terminal check and,
+with a configured lock adapter, successful child-lease acquisition. It avoids
+constructing credentials, connections, or workspaces for a finished delivery
+and for an ordinary concurrent delivery while that lease remains live.
 
-`workspace: "parent"` is rejected for background mode, but this field is a
-model-supplied scheduling declaration, not capability isolation. Choosing or
-omitting `workspace: "own"` does not clone Tool objects or the workspace objects
-they close over. A production dispatcher must reconstruct background tools with
-isolated, host-owned workspace instances; otherwise parent and child can mutate
-the same resource concurrently.
+An exception raised while the queue's factory is constructing dependencies is
+retryable by default: `run_dispatched` releases the lease, leaves no terminal,
+and re-raises so the queue can retry. Runtime contract mismatches are terminal.
+On a queue's final attempt, pass `retry_factory_errors: false` to record and
+report the construction failure before the exception re-raises. The flag does
+not decide whether the job system retries or discards the exception. The
+in-process runner already uses terminal behavior because Thread and Inline have
+no durable retry owner.
+
+The factory boundary applies to dispatched children. Inline spawns and fixed
+specialists continue to use the provider and Tool objects supplied by the host;
+parallel inline calls may therefore share whatever those objects close over.
+That is deliberate host policy, not an isolation guarantee.
 
 ## Reports and control
 
 A background spawn returns a truthful receipt based on the child's stored
 status. When the child reaches a terminal state, it writes its result to its own
 session and delivers one typed report into the parent inbox.
+
+An inactive queued or interrupted cancellation owns that durable inbox delivery
+while it holds the child lease, so the parent receives the stopped report even
+if the queue never starts or retries the job. The callback-only
+`:subagent_report` event is not emitted for that host-initiated path because
+`Child#stop` has no event sink; the durable parent inbox is authoritative.
+If that cross-session inbox append raises, the stopped terminal remains
+durable. Repeating `Child#stop` or `stop_agent` retries the report under the
+child lease and sequentially deduplicates an earlier successful delivery.
 
 The parent folds that report at its next turn boundary as a labeled message.
 The `:subagent_report` event closes the worker's live UI lane. Duplicate report
@@ -177,8 +268,17 @@ child.report                   # terminal report when done
 child.error                    # terminal error when failed
 child.transcript(tail: 20)     # presentation-oriented recent entries
 child.say("Check pricing too") # queues a steer
-child.stop                     # cooperative; requires a lock adapter
+child.stop                     # durable if inactive, cooperative if running
 ```
+
+`read_agent` with `wait: true` waits for a terminal, including across an
+interrupted worker's later queue retry or cancellation. Abort and timeout still
+end the wait in band.
+
+Stopping requires a lock adapter. A queued or interrupted child that has no
+current lease owner is terminalized and reported immediately under a lease. If
+a runner already owns the lease, the cross-process flag requests its
+cooperative abort instead.
 
 Child events forwarded into the parent stream carry an `origin` such as
 `Corgi#ab12cd34`. `session.transcript(include_children: true)` uses the same
@@ -193,12 +293,14 @@ exposing it.
 Several spawn calls in one parent turn are tool calls and can begin
 concurrently. Actual model requests depend on provider instances:
 
-- Calls sharing one built-in provider object serialize through that provider's
-  transport.
-- Give independent children distinct provider instances when their model calls
-  must overlap.
-- A typed Definition with its own model builds a provider for that worker; an
-  inherited provider remains shared.
+- Inline calls sharing one built-in provider object serialize through that
+  provider's transport.
+- A background Runtime factory decides whether children receive independent or
+  deliberately shared providers. Distinct instances are required when their
+  model calls must overlap.
+- An inline typed Definition with its own model builds a provider for that
+  worker. A background typed worker records the model identity and relies on
+  the Runtime factory to construct it.
 
 This distinction avoids promising network fan-out when only tool scheduling is
 parallel.
@@ -267,7 +369,9 @@ generations.
 Queue jobs must therefore keep child work idempotent or reconcilable. A held
 lease suppresses an ordinary redelivery while the first worker is healthy; an
 expired lease allows a retry of a child that appears interrupted. A finished
-child's terminal entry makes later delivery a no-op.
+child's terminal entry makes a later matching delivery a no-op. Calling
+`Child#stop` while the child is interrupted competes for the lease and, when it
+wins, replaces that possible retry with a durable stopped terminal.
 
 Without an adapter:
 

--- a/lib/mistri/child.rb
+++ b/lib/mistri/child.rb
@@ -6,7 +6,7 @@ module Mistri
   # reads the same from any process, while the child runs and forever after.
   #
   #   session.children            # => [#<Mistri::Child Magpie done>, ...]
-  #   child.status                # => :running, :done, :stopped, :failed
+  #   child.status                # queued, running, interrupted, or terminal
   #   child.report                # the terminal entry's report, once finished
   #   child.transcript(tail: 20)  # recent entries, image bytes stripped
   #   child.say("Also check their pricing page")
@@ -20,8 +20,8 @@ module Mistri
     TERMINAL = "subagent_result"
     DISPATCHED = "subagent_dispatched"
     STARTED = "subagent_started"
-    # The states a worker can still be caught in: steerable, stoppable,
-    # worth waiting on.
+    # Work currently scheduled or queued, used for capacity and steering.
+    # Interrupted work is nonterminal but not actively live.
     LIVE = %i[running queued].freeze
 
     attr_reader :name, :session_id
@@ -30,10 +30,11 @@ module Mistri
 
     def self.stop_key(session_id) = "child-stop:#{session_id}"
 
-    def initialize(name:, session_id:, store:)
+    def initialize(name:, session_id:, store:, parent_session_id: nil)
       @name = name
       @session_id = session_id
       @store = store
+      @parent_session_id = parent_session_id
     end
 
     def status
@@ -49,10 +50,9 @@ module Mistri
       :running
     end
 
-    # A terminal entry exists: the child ended as done, stopped, or failed
-    # and will never run again. The question a queue retry asks; its
-    # inverse (started but no terminal) is what makes a crashed child
-    # re-runnable.
+    # A terminal entry exists: the child ended as done, stopped, or failed,
+    # so a later matching delivery must not run it again. The inverse
+    # (started but no terminal) is what makes a crashed child re-runnable.
     def finished?
       !terminal_entry.nil?
     end
@@ -82,17 +82,17 @@ module Mistri
       session.steer(text)
     end
 
-    # Ask a live child to stop, from any process. A running child's runner
-    # sees the flag within a tick and trips its own signal; a queued child
-    # is cancelled outright with a stopped terminal, which the runner
-    # honors by never starting it. Stop is cross-process by nature, so it
-    # needs a lock adapter; without one this returns false. An action that
-    # reports acceptance, not a predicate.
+    # Ask a child to stop, from any process. An inactive dispatched child is
+    # cancelled durably under its lease; an inline or already-running child
+    # receives the stop flag. Repeating stop on a stopped dispatched child
+    # reconciles a missing parent report. Stop is
+    # cross-process by nature, so it needs a lock adapter; without one this
+    # returns false. An action that reports acceptance, not a predicate.
     def stop # rubocop:disable Naming/PredicateMethod
       return false unless Mistri.locks
 
-      session.append(TERMINAL, "status" => "stopped") if status == :queued
-      Mistri.locks.set_flag(self.class.stop_key(@session_id))
+      outcome = cancel_inactive
+      Mistri.locks.set_flag(self.class.stop_key(@session_id)) if outcome == :contended
       true
     end
 
@@ -118,6 +118,62 @@ module Mistri
     end
 
     private
+
+    # Cancellation and a runner compete for the same lease. Acquiring it
+    # proves no unexpired lease is present, so ordinary inactive dispatched
+    # work can end here; a stale holder may still resume under the documented
+    # tokenless lease trade-off. Status cannot be rechecked because our own
+    # lease would read running.
+    def cancel_inactive
+      key = self.class.lease_key(@session_id)
+      lease = Locks.hold(key)
+      return :contended unless lease
+
+      begin
+        log = session.entries
+        terminal = log.reverse_each.find { |entry| entry["type"] == TERMINAL }
+        dispatched = log.any? { |entry| entry["type"] == DISPATCHED }
+        if terminal
+          deliver_cancellation if terminal["status"] == "stopped"
+          :finished
+        elsif dispatched
+          session.append(TERMINAL, "status" => "stopped")
+          deliver_cancellation
+          :cancelled
+        else
+          Mistri.locks.set_flag(self.class.stop_key(@session_id))
+          :signaled
+        end
+      ensure
+        lease.release
+      end
+    end
+
+    # A cancelled queue item may never be delivered, so the lease owner
+    # must route its durable outcome. Current versions trust only the stored
+    # grant; legacy children fall back to the parent link because their
+    # dispatched entry did not retain a spec.
+    def deliver_cancellation
+      dispatched = session.entries.find { |entry| entry["type"] == DISPATCHED }
+      return unless dispatched
+
+      spec = dispatched["spec"]
+      parent_id, label = cancellation_route(spec)
+      return unless parent_id.is_a?(String) && !parent_id.empty?
+      return unless label.is_a?(String) && !label.empty?
+
+      Session.new(store: @store, id: parent_id)
+             .deliver_report(name: label, session_id: @session_id, status: "stopped")
+    end
+
+    def cancellation_route(spec)
+      return [@parent_session_id, @name] if spec.nil?
+      return [nil, nil] unless spec.is_a?(Hash)
+      return [nil, nil] unless spec["spec_version"] == SubAgent::DISPATCH_SPEC_VERSION
+      return [nil, nil] unless spec["session_id"] == @session_id
+
+      [spec["parent_session_id"], spec["name"]]
+    end
 
     def session
       @session ||= Session.new(store: @store, id: @session_id)

--- a/lib/mistri/console.rb
+++ b/lib/mistri/console.rb
@@ -98,15 +98,24 @@ module Mistri
         next Console.unknown(context.session, args["agent"]) unless child
 
         status = child.status
-        if !Child::LIVE.include?(status)
+        if status == :stopped
+          child.stop
+          "#{child.name} is already stopped."
+        elsif !Child::LIVE.include?(status) && status != :interrupted
           "#{child.name} is already #{status}."
         elsif !child.stop
           "Stopping needs a lock adapter (Mistri.locks) and none is configured."
-        elsif status == :queued
-          "Cancelled. #{child.name} had not started and never will."
         else
-          "Stop requested. #{child.name} halts within a second or two; " \
-            "its partial work stays readable through read_agent."
+          stopped = child.status
+          if stopped == :stopped
+            "Cancelled. #{child.name} is marked stopped; ordinary queue delivery " \
+              "will not run it again."
+          elsif %i[done failed].include?(stopped)
+            "#{child.name} finished as #{stopped} before the stop took effect."
+          else
+            "Stop requested. #{child.name}'s runner receives the request promptly " \
+              "and stops at a cooperative boundary; partial work stays readable."
+          end
         end
       end
     end
@@ -133,7 +142,8 @@ module Mistri
     # promptly, never held hostage to the timeout.
     def await(child, timeout, poll, signal = nil)
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
-      while Child::LIVE.include?(status = child.status)
+      until child.finished?
+        status = child.status
         return "The wait was stopped; #{child.name} is still #{status}." if signal&.aborted?
 
         if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline

--- a/lib/mistri/dispatchers.rb
+++ b/lib/mistri/dispatchers.rb
@@ -2,10 +2,9 @@
 
 module Mistri
   # How a background child actually executes. The spawn tool hands every
-  # dispatcher two things: the serializable spec (name, session_id,
-  # parent_session_id, type, instructions, tool_names, model, workspace,
-  # task) and a runner closure that executes the child in this process with
-  # everything already reconstructed.
+  # dispatcher two things: a versioned serializable spec (name, session_id,
+  # parent_session_id, type, instructions, tool_names, model, task) and a
+  # runner closure that invokes the host runtime factory inside this process.
   #
   # In-process dispatchers just call the runner. A queue dispatcher ignores
   # the runner, enqueues the spec, and its job reconstructs the pieces from
@@ -13,12 +12,12 @@ module Mistri
   #
   #   dispatcher: ->(spec, _runner) { ChildRunJob.perform_async(spec) }
   #
-  # The runner closes over the spawn-time event sink, so in-process
-  # children keep streaming to whoever watched the spawn; that sink must
-  # outlive the parent's turn (a broadcast lambda does, a request-scoped
-  # object may not) and hears from the worker's thread, concurrently with
-  # the parent's own events. The gem's sinks tolerate that; a custom one
-  # must too.
+  # The runner invokes the host factory inside the worker and keeps the
+  # spawn-time event sink. In-process children stream to whoever watched the
+  # spawn; that sink must outlive the parent's turn (a broadcast lambda does,
+  # a request-scoped object may not) and hears from the worker's thread,
+  # concurrently with the parent's own events. The gem's sinks tolerate that;
+  # a custom one must too.
   module Dispatchers
     # Runs the child synchronously inside the spawn call and still answers
     # in receipt form: background degrades gracefully where no concurrency
@@ -36,9 +35,9 @@ module Mistri
         ::Thread.new do
           runner.call
         rescue StandardError => e
-          # The runner writes the child's failed terminal before re-raising;
-          # a thread must not die loudly into the process, but it must not
-          # die silently either, or there is no trace to debug from.
+          # Execution failures have a durable terminal before re-raising;
+          # cleanup may raise after a successful terminal. Neither should
+          # make a thread die loudly or disappear without a diagnostic.
           warn "mistri: background runner for #{spec["name"].inspect} crashed: " \
                "#{e.class}: #{e.message}"
         end

--- a/lib/mistri/errors.rb
+++ b/lib/mistri/errors.rb
@@ -11,6 +11,10 @@ module Mistri
   # Missing or contradictory setup: an unknown model, an absent API key.
   class ConfigurationError < Error; end
 
+  # A queue payload is not the grant persisted for its child. The unchanged
+  # delivery is poison: discard and alert instead of retrying it.
+  class DispatchGrantError < ConfigurationError; end
+
   # A provider request failed. Carries the HTTP status and response body when
   # the transport got that far.
   class ProviderError < Error

--- a/lib/mistri/locks.rb
+++ b/lib/mistri/locks.rb
@@ -6,15 +6,15 @@ module Mistri
   # Cross-process coordination for hosts that run loops in more than one
   # process: leases that say "this is alive right now" and flags that carry
   # one-bit requests (stop) between processes. Everything expires on its
-  # own, so a crashed holder never wedges anything; a live holder renews on
-  # a heartbeat, so only dead ones expire.
+  # own, so a crashed holder never wedges anything; a healthy holder renews
+  # on a heartbeat, while a stalled process can still outlive its lease.
   #
   # Configure once at boot:
   #
   #   Mistri.locks = Mistri::Locks::Memory.new          # single process
   #   Mistri.locks = Mistri::Locks::RailsCache.new      # requires opt-in file
   #
-  # An adapter implements six methods: acquire(key, ttl:) -> bool,
+  # An adapter implements seven methods: acquire(key, ttl:) -> bool,
   # renew(key, ttl:), release(key), held?(key), set_flag(key, ttl:),
   # flag?(key), clear_flag(key). With no adapter configured, everything
   # lease-aware degrades gracefully: children read :running instead of

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -109,11 +109,12 @@ module Mistri
     # folds into the transcript at the next turn boundary as a labeled block
     # the model can react to ("[Magpie finished] <report>"), while the typed
     # entry keeps name, status, and the raw text for hosts to render as a
-    # report card rather than a fake user message. One report per child,
-    # ever: a duplicate delivery (a redelivered queue job, a lease race) is
-    # dropped, and the return says which happened. Reports normally arrive
-    # via SubAgent.run_dispatched; call this directly only from a custom
-    # dispatch path.
+    # report card rather than a fake user message. Sequential redelivery of
+    # one child's report is dropped, and the return says which happened.
+    # Concurrent callers need their own serialization; with a lock adapter,
+    # the background runner and inactive cancellation use the child's lease
+    # for that. Reports normally arrive via SubAgent.run_dispatched; call this
+    # directly only from a custom dispatch path.
     def deliver_report(name:, session_id:, status:, text: nil) # rubocop:disable Naming/PredicateMethod
       already = entries.any? do |entry|
         entry["type"] == "subagent_report" && entry["session_id"] == session_id
@@ -150,7 +151,8 @@ module Mistri
       entries.filter_map do |entry|
         next unless entry["type"] == "subagent"
 
-        Child.new(name: entry["name"], session_id: entry["session_id"], store: @store)
+        Child.new(name: entry["name"], session_id: entry["session_id"], store: @store,
+                  parent_session_id: @id)
       end
     end
 

--- a/lib/mistri/spawner.rb
+++ b/lib/mistri/spawner.rb
@@ -3,29 +3,33 @@
 module Mistri
   # Host policy for spawning workers, as one object: the tool pool children
   # may draw from, the curated types, the model allowlist, the headcount
-  # cap, and the dispatcher that makes background mode real. #tool builds
-  # the spawn_agent tool the top-level agent holds; SubAgent.spawner and
+  # cap, and the dispatcher that makes background mode real. A host runtime
+  # factory reconstructs live dependencies after the dispatch boundary;
+  # model text never chooses or proves resource isolation. #tool builds the
+  # spawn_agent tool the top-level agent holds; SubAgent.spawner and
   # SubAgent.pack are the front doors.
   #
   # Every policy violation answers the model in band (unknown type, missing
-  # instructions, over capacity, workspace sharing in background mode);
-  # only host configuration mistakes raise, and they raise at construction.
+  # instructions, over capacity); only host configuration mistakes raise,
+  # and they raise at construction.
   class Spawner
     def initialize(provider:, tools: [], types: {}, models: [], max_children: 4,
-                   dispatcher: nil, needs_approval: false, **agent_options)
-      SubAgent.forbid_gated!(tools)
-      if tools.any? { |tool| tool.name == "spawn_agent" }
-        raise ConfigurationError, "the spawn tool never goes in its own pool"
-      end
+                   dispatcher: nil, runtime_factory: nil, needs_approval: false,
+                   **agent_options)
+      tools = Array.new(tools) if tools.is_a?(Array)
+      models = Array.new(models) if models.is_a?(Array)
+      ChildAgentOptions.validate!(agent_options)
+      validate_configuration!(tools, models, dispatcher, runtime_factory)
 
       @provider = provider
-      @pool = tools
+      @pool = tools.freeze
       # Symbol keys are natural Ruby; the wire speaks strings. One
       # normalization here and lookup, schema, and menu all agree.
-      @types = types.transform_keys(&:to_s)
-      @models = models
+      @types = types.transform_keys(&:to_s).freeze
+      @models = models.map { |model| String.new(model).freeze }.freeze
       @max_children = max_children
       @dispatcher = dispatcher
+      @runtime_factory = runtime_factory
       @needs_approval = needs_approval
       @agent_options = agent_options
       validate_types!
@@ -46,26 +50,62 @@ module Mistri
       worker = resolve_worker(args)
       return worker if worker.is_a?(String)
 
-      if args["mode"] == "background" && @dispatcher
-        if args["workspace"] == "parent"
-          return "A worker sharing your workspace must run inline: a blocked parent " \
-                 "cannot write concurrently, a working one can. Drop workspace or " \
-                 "drop background."
-        end
+      return dispatch(args, worker, context) if args["mode"] == "background" && @dispatcher
 
-        return dispatch(args, worker, context)
-      end
-
-      SubAgent.run_child(label: label_for(args), provider: worker[:provider],
+      SubAgent.run_child(label: label_for(args), provider: provider_for(worker),
                          system: worker[:system], tools: worker[:tools],
-                         task: args.fetch("task"), context: context, **@agent_options)
+                         task: args.fetch("task"), parent_context: context,
+                         agent_options: @agent_options)
     end
 
     private
 
+    def validate_configuration!(tools, models, dispatcher, runtime_factory)
+      validate_tool_pool!(tools)
+      validate_models!(models)
+      validate_dispatcher!(dispatcher, runtime_factory)
+    end
+
+    def validate_tool_pool!(tools)
+      unless tools.is_a?(Array) && tools.all?(Tool)
+        raise ConfigurationError, "the spawn tool pool must contain only Mistri::Tool instances"
+      end
+
+      SubAgent.forbid_gated!(tools)
+      if tools.any? { |tool| tool.name == "spawn_agent" }
+        raise ConfigurationError, "the spawn tool never goes in its own pool"
+      end
+      return if tools.map(&:name).uniq.length == tools.length
+
+      raise ConfigurationError, "the spawn tool pool has duplicate tool names"
+    end
+
+    def validate_models!(models)
+      unless models.is_a?(Array) &&
+             models.all? { |model| model.is_a?(String) && !model.empty? }
+        raise ConfigurationError, "the spawn model allowlist must contain non-empty strings"
+      end
+      return if models.uniq.length == models.length
+
+      raise ConfigurationError, "the spawn model allowlist has duplicate model names"
+    end
+
+    def validate_dispatcher!(dispatcher, runtime_factory)
+      if dispatcher && !dispatcher.respond_to?(:call)
+        raise ConfigurationError, "dispatcher must be callable"
+      end
+      if dispatcher && !runtime_factory.respond_to?(:call)
+        raise ConfigurationError,
+              "a dispatcher requires runtime_factory: to reconstruct background children"
+      end
+      return unless runtime_factory && !dispatcher
+
+      raise ConfigurationError, "runtime_factory: requires a dispatcher"
+    end
+
     # Create the child session and its lifecycle entries, hand the
-    # dispatcher the serializable spec plus an in-process runner closing
-    # over the reconstructed pieces, and answer with a truthful receipt:
+    # dispatcher the serializable spec plus an in-process runner that calls
+    # the host factory inside the worker, and answer with a truthful receipt:
     # what the child's status says after dispatch, not what the mode
     # promised. The runner closes over the spawn-time emit, so in-process
     # dispatchers keep streaming to whoever watched the spawn.
@@ -73,28 +113,37 @@ module Mistri
       store = context.session ? context.session.store : Stores::Memory.new
       child = Session.new(store: store)
       label = label_for(args)
-      context.session&.append("subagent", "name" => label, "session_id" => child.id)
-      child.append(Child::DISPATCHED, {})
       spec = spec_for(args, worker, child, label, context)
+      context.session&.append("subagent", "name" => label, "session_id" => child.id)
+      child.append(Child::DISPATCHED, "spec" => spec)
       emit = context.emit
-      options = @agent_options
+      runtime_factory = @runtime_factory
       runner = lambda do
-        SubAgent.run_dispatched(spec, provider: worker[:provider], system: worker[:system],
-                                      tools: worker[:tools], store: store, emit: emit,
-                                      **options)
+        SubAgent.run_dispatched(spec, runtime_factory: runtime_factory,
+                                      store: store, emit: emit,
+                                      retry_factory_errors: false)
       end
       @dispatcher.call(spec, runner)
       receipt(label, child, store)
     end
 
     def spec_for(args, worker, child, label, context)
-      { "name" => label, "session_id" => child.id,
-        "parent_session_id" => context.session&.id,
-        "type" => args["type"] || "general-purpose",
-        "instructions" => args["instructions"], "task" => args.fetch("task"),
-        "tool_names" => worker[:tools].map(&:name),
-        "model" => (worker[:provider].model if worker[:provider].respond_to?(:model)),
-        "workspace" => args["workspace"] || "own" }
+      model = worker[:model]
+      unless model.is_a?(String) && !model.empty?
+        raise ConfigurationError,
+              "a background child provider must expose a non-empty model identity"
+      end
+      spec = { "spec_version" => SubAgent::DISPATCH_SPEC_VERSION,
+               "name" => label, "session_id" => child.id,
+               "parent_session_id" => context.session&.id,
+               "type" => args["type"] || "general-purpose",
+               "instructions" => args["instructions"], "task" => args.fetch("task"),
+               "tool_names" => worker[:tools].map(&:name),
+               "model" => model }
+      owned, error = ToolArguments.canonicalize(spec)
+      return owned unless error
+
+      raise ConfigurationError, "background child spec is not bounded JSON"
     end
 
     def receipt(label, child, store)
@@ -127,9 +176,9 @@ module Mistri
 
       system = [definition.render, args["instructions"]]
                .reject { |part| part.to_s.strip.empty? }.join("\n\n")
-      chosen = args["tools"].nil? || args["tools"].empty? ? definition.tool_names : args["tools"]
+      chosen = args["tools"].nil? ? definition.tool_names : args["tools"]
       { system: system, tools: pick(chosen),
-        provider: typed_provider(args["model"], definition.model) }
+        **provider_choice(args["model"], definition.model) }
     end
 
     def general_worker(args)
@@ -139,29 +188,29 @@ module Mistri
                "or pick a type."
       end
 
-      { system: system, tools: pick(args["tools"]),
-        provider: child_provider(args["model"]) }
+      { system: system, tools: pick(args["tools"]), **provider_choice(args["model"]) }
     end
 
-    # An explicit model choice goes through the allowlist; otherwise a
-    # typed worker runs on its definition's model, and without one it
-    # inherits the parent's provider. Host-curated definitions are
-    # trusted the way the pool is.
-    def typed_provider(requested, definition_model)
-      return child_provider(requested) unless requested.to_s.empty?
-      return @provider if definition_model.to_s.empty?
+    # A background grant needs only a stable model identity; constructing
+    # its live provider belongs to the worker factory. Inline execution turns
+    # the same choice into a provider immediately before the child starts.
+    def provider_choice(requested, definition_model = nil)
+      if requested.nil? || requested.to_s.empty?
+        return { model: definition_model } unless definition_model.to_s.empty?
 
-      Mistri.provider(definition_model)
-    end
-
-    def child_provider(requested)
-      return @provider if requested.nil? || requested.to_s.empty?
+        model = @provider.model if @provider.respond_to?(:model)
+        return { provider: @provider, model: model }
+      end
       unless @models.include?(requested)
         raise ArgumentError,
               "model #{requested.inspect} is not allowed; available: #{@models.join(", ")}"
       end
 
-      Mistri.provider(requested)
+      { model: requested }
+    end
+
+    def provider_for(worker)
+      worker[:provider] || Mistri.provider(worker.fetch(:model))
     end
 
     def over_capacity(session)
@@ -199,7 +248,10 @@ module Mistri
     end
 
     def pick(names)
-      return @pool if names.nil? || names.empty?
+      return @pool if names.nil?
+      if names.uniq.length != names.length
+        raise ArgumentError, "tool selections cannot contain duplicate names"
+      end
 
       by_name = @pool.to_h { |tool| [tool.name, tool] }
       names.map do |name|
@@ -229,17 +281,15 @@ module Mistri
           string :instructions, "The child's system prompt", required: true
         end
         if pool_names.any?
-          array :tools, "Subset of tools to grant (default: all, or the type's own list)",
-                items: { type: "string", enum: pool_names }
+          array :tools, "Exact tools to grant (omit for all, or the type's own list; " \
+                        "an empty list grants none)",
+                items: { type: "string", enum: pool_names }, uniqueItems: true
         end
         string :model, "Model for the child#{fallback}", enum: models if models.any?
         if dispatcher
           string :mode, "inline blocks until the report; background returns a receipt " \
                         "now and you keep working (default: inline)",
                  enum: %w[inline background]
-          string :workspace, "own gives the worker its own file space; parent shares " \
-                             "yours and requires inline mode (default: own)",
-                 enum: %w[own parent]
         end
       end
     end

--- a/lib/mistri/sub_agent.rb
+++ b/lib/mistri/sub_agent.rb
@@ -23,9 +23,10 @@ module Mistri
   #
   #   spawn = Mistri::SubAgent.spawner(provider:, tools: [fetch_page, search])
   #
-  # Children never receive a spawn tool: delegation is one level deep by
-  # construction. Parallel fan-out costs nothing: several spawn calls in
-  # one turn run concurrently on the executor pool.
+  # The open spawner never grants itself, preventing accidental recursion.
+  # Hosts may deliberately nest fixed specialists. Several spawn calls in
+  # one turn are scheduled concurrently; provider instances decide whether
+  # their network requests overlap.
   #
   # Child events forward into the parent's stream tagged with origin
   # ("researcher#ab12cd34"; nesting of named specialists joins with ">").
@@ -35,6 +36,8 @@ module Mistri
   # runtime is denied and reported in band. Gate the delegation itself
   # instead (needs_approval: on the definition or spawner).
   class SubAgent
+    require_relative "sub_agent/runtime"
+
     SPAWNER_DESCRIPTION =
       "Delegate a self-contained task to a focused child agent with a clean " \
       "context. The child starts blank: give it complete instructions and " \
@@ -50,6 +53,8 @@ module Mistri
     def initialize(name:, description:, provider:, system: nil, tools: [], schema: nil,
                    **agent_options)
       SubAgent.forbid_gated!(tools)
+      @gate = agent_options.delete(:needs_approval) || false
+      ChildAgentOptions.validate!(agent_options)
       @name = name.to_s
       @description = description
       @provider = provider
@@ -57,7 +62,6 @@ module Mistri
       @tools = tools
       @schema = schema
       @agent_options = agent_options
-      @gate = agent_options.delete(:needs_approval) || false
     end
 
     # The delegate tool: each call runs a fresh child and answers with its
@@ -83,8 +87,8 @@ module Mistri
     def run_child(task, context, name: nil)
       SubAgent.run_child(label: SubAgent.sanitize_label(name, fallback: @name),
                          provider: @provider, system: @system,
-                         tools: @tools, task: task, context: context, schema: @schema,
-                         **@agent_options)
+                         tools: @tools, task: task, parent_context: context, schema: @schema,
+                         agent_options: @agent_options)
     end
 
     class << self
@@ -110,79 +114,141 @@ module Mistri
         label.empty? ? fallback : label
       end
 
-      def run_child(label:, provider:, system:, tools:, task:, context:, schema: nil,
-                    **agent_options)
-        store = context.session ? context.session.store : Stores::Memory.new
+      def run_child(label:, provider:, system:, tools:, task:, parent_context:, schema: nil,
+                    agent_options: {})
+        ChildAgentOptions.validate!(agent_options)
+        store = parent_context.session ? parent_context.session.store : Stores::Memory.new
         child = Session.new(store: store)
-        context.session&.append("subagent", "name" => label, "session_id" => child.id)
+        parent_context.session&.append("subagent", "name" => label, "session_id" => child.id)
         # An inline child runs on a signal derived from the parent's: the
         # parent's abort cascades down through the handle, while stopping
         # the child alone leaves the parent running.
-        signal, cascade = context.signal ? context.signal.derive : [AbortSignal.new, nil]
+        signal, cascade = if parent_context.signal
+                            parent_context.signal.derive
+                          else
+                            [AbortSignal.new, nil]
+                          end
         result = begin
           execute_child(child: child, label: label, provider: provider, system: system,
                         tools: tools, task: task, schema: schema, signal: signal,
-                        emit: context.emit, **agent_options)
+                        emit: parent_context.emit, agent_options: agent_options)
+        rescue StandardError => e
+          unless child.entries.any? { |entry| entry["type"] == Child::TERMINAL }
+            child.append(Child::TERMINAL,
+                         "status" => "failed", "error" => "#{e.class}: #{e.message}")
+          end
+          raise
         ensure
-          context.signal&.remove_callback(cascade) if cascade
+          parent_context.signal&.remove_callback(cascade) if cascade
         end
         outcome = answer(result, label, child)
         child.append(Child::TERMINAL, terminal(result))
         outcome
       end
 
-      # The host job's way back in: reconstruct provider, system, and tools
-      # from the spec through host registries, then hand them here. Reopens
-      # the child session the spawn created, runs it exactly like an inline
-      # child (started entry, lease, stop watching, terminals), streams
-      # origin-tagged events to the emit the job supplies, and reports the
-      # outcome back to the parent (see report_back). A background child
-      # runs on its own signal: the parent's turn is long over, so only
-      # stop_agent and the stop flag end it early.
+      # The host job's way back in: a runtime factory turns the durable spec
+      # into live dependencies inside the worker. The compatible direct
+      # provider/system/tools form remains for hosts that already reconstruct
+      # those values in their job. Either form is checked against the spec
+      # before execution. The child then runs exactly like an inline child,
+      # streams origin-tagged events, and reports back to its parent.
       #
-      # The child's lease is the exactly-once fence, so it is taken before
-      # anything else: refused means another process is running this child
-      # right now (a queue redelivered a live job), so leave its owner alone.
-      # Holding it, a terminal decides: present means the child was
-      # cancelled while queued or the queue retried a finished job, so
-      # there is nothing to run; absent means run, and that includes the
-      # child a crashed process left mid-run, which is exactly what queue
-      # retries are for. Either kind of no-op returns nil.
-      def run_dispatched(spec, provider:, system:, tools:, store:, emit: nil, schema: nil,
-                         **agent_options)
+      # The child lease is duplicate suppression, not an exactly-once claim:
+      # a refused delivery leaves the current holder alone. A terminal means
+      # a queued cancellation or finished retry and returns nil. The runner
+      # retains an acquired lease through terminal persistence and reporting,
+      # suppressing ordinary redelivery while that lease remains live.
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity -- ordered dispatch transitions are the safety contract
+      def run_dispatched(spec, store:, emit: nil, runtime_factory: nil,
+                         provider: UNSET_RUNTIME_FIELD, system: UNSET_RUNTIME_FIELD,
+                         tools: UNSET_RUNTIME_FIELD, schema: UNSET_RUNTIME_FIELD,
+                         retry_factory_errors: true, **agent_options)
+        runtime = nil
+        resolved = nil
+        authorized = false
+        terminalize = false
+        factory_failed = false
+        retryable_exit = false
+        primary_error = nil
+        delivery_owned = false
+        spec = RuntimeContract.own_spec(spec)
+        RuntimeContract.validate_identity!(spec)
         child = Session.new(store: store, id: spec.fetch("session_id"))
+        spec = RuntimeContract.bind_spec(child.entries, spec)
+        authorized = true
+        direct = { provider: provider, system: system, tools: tools, schema: schema,
+                   agent_options: agent_options.empty? ? UNSET_RUNTIME_FIELD : agent_options }
+        RuntimeContract.validate_resolution!(factory: runtime_factory, direct: direct)
         signal = AbortSignal.new
+        terminalize = true
+        delivery_owned = true
         lease = Locks.hold(Child.lease_key(child.id),
                            stop_key: Child.stop_key(child.id), signal: signal)
-        return nil if Mistri.locks && lease.nil?
-
-        if Child.new(name: spec.fetch("name"), session_id: child.id, store: store).finished?
-          lease&.release
+        if Mistri.locks && lease.nil?
+          delivery_owned = false
           return nil
         end
 
-        result = execute_child(child: child, label: spec.fetch("name"), provider: provider,
-                               system: system, tools: tools, task: spec.fetch("task"),
-                               schema: schema, signal: signal, emit: emit, lease: lease,
-                               **agent_options)
+        if Child.new(name: spec.fetch("name"), session_id: child.id, store: store).finished?
+          return nil
+        end
+
+        child.append(Child::STARTED, {})
+        RuntimeContract.validate_spec!(spec)
+        signal.abort!("stopped by user") if Mistri.locks&.flag?(Child.stop_key(child.id))
+        unless signal.aborted?
+          runtime = RuntimeContract.resolve(spec, factory: runtime_factory, direct: direct) do
+            factory_failed = true
+          end
+          resolved = RuntimeContract.validate_runtime!(runtime, spec)
+          signal.abort!("stopped by user") if Mistri.locks&.flag?(Child.stop_key(child.id))
+        end
+        result = if signal.aborted?
+                   Result.new(message: nil, status: :aborted)
+                 else
+                   execute_child(child: child, label: spec.fetch("name"),
+                                 provider: resolved.provider, system: resolved.system,
+                                 tools: resolved.tools, task: spec.fetch("task"),
+                                 schema: resolved.schema, signal: signal, emit: emit,
+                                 lease: lease, started: true,
+                                 agent_options: resolved.agent_options)
+                 end
         deny_pending(result, child)
         child.append(Child::TERMINAL, terminal(result))
         result
       rescue StandardError => e
+        primary_error = e
         # Completion is a contract even when the runner dies in the
         # preamble: without this, a raise before the started entry (a lock
         # backend down, say) would leave the child reading :queued forever,
         # with nothing to report and nothing for a retry to heal.
-        if child && !Child.new(name: spec.fetch("name"), session_id: child.id,
-                               store: store).finished?
-          child.append(Child::TERMINAL,
-                       "status" => "failed", "error" => "#{e.class}: #{e.message}")
+        stopped = factory_failed && child_stop_requested?(child, signal)
+        retryable = factory_failed && retry_factory_errors && !stopped
+        retryable_exit = retryable
+        if child && terminalize && !retryable &&
+           !Child.new(name: spec.fetch("name"), session_id: child.id, store: store).finished?
+          terminal = if stopped
+                       { "status" => "stopped" }
+                     else
+                       { "status" => "failed", "error" => "#{e.class}: #{e.message}" }
+                     end
+          child.append(Child::TERMINAL, terminal)
         end
-        lease&.release
         raise
       ensure
-        report_back(spec, store, emit) if child
+        cleanup_error = RuntimeContract.cleanup(runtime)
+        begin
+          report_back(spec, store, emit) if child && authorized && delivery_owned
+        ensure
+          begin
+            Mistri.locks&.clear_flag(Child.stop_key(child.id)) if child && lease && !retryable_exit
+          ensure
+            lease&.release
+          end
+        end
+        raise cleanup_error if cleanup_error && primary_error.nil?
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
       # A child cannot wait for a human, whichever door it entered by: any
       # calls parked for approval are denied AND settled with the denial as
@@ -225,51 +291,18 @@ module Mistri
 
       private
 
-      # The one hardened execution path every child goes through, whichever
-      # door it entered by. From the started entry on, every exit writes a
-      # terminal, setup failures included, or the child would read as
-      # running forever. The lease says "alive right now" to other
-      # processes and its thread watches the child's stop flag; a
-      # dispatched run hands in the lease it already holds (its run-or-not
-      # decision happened under the fence), an inline child acquires its
-      # own here. Either way, this path releases it.
-      def execute_child(child:, label:, provider:, system:, tools:, task:, schema:,
-                        signal:, emit:, lease: nil, **agent_options)
-        child.append(Child::STARTED, {})
-        lease ||= Locks.hold(Child.lease_key(child.id),
-                             stop_key: Child.stop_key(child.id), signal: signal)
-        begin
-          agent = Agent.new(provider: provider, session: child, system: system,
-                            tools: tools, **agent_options)
-          origin = "#{label}##{child.id[0, 8]}"
-          tagged = ->(event) { forward(event, origin, emit) }
-          if schema
-            agent.task(task, schema: schema, signal: signal, &tagged)
-          else
-            agent.run(task, signal: signal, &tagged)
-          end
-        rescue StandardError => e
-          child.append(Child::TERMINAL, "status" => "failed", "error" => "#{e.class}: #{e.message}")
-          raise
-        ensure
-          lease&.release
-          Mistri.locks&.clear_flag(Child.stop_key(child.id))
-        end
+      def child_stop_requested?(child, signal)
+        return false unless child
+
+        signal&.aborted? || Mistri.locks&.flag?(Child.stop_key(child.id))
       end
 
-      def forward(event, origin, emit)
-        return unless emit
-
-        tagged = event.origin ? "#{origin}>#{event.origin}" : origin
-        emit.call(event.with(origin: tagged))
-      end
-
-      # Every terminal outcome reports back, exactly once. The report joins
-      # the parent's inbox (a typed entry that folds at its next turn
-      # boundary, exactly like a steer) and a :subagent_report event
+      # A lease-backed runner reports before releasing the child lease. The
+      # report joins the parent's inbox (a typed entry that folds at its next
+      # turn boundary, exactly like a steer) and a :subagent_report event
       # closes the child's lane in whatever UI watched the spawn. A child
       # that never ran has nothing to say, and the parent session drops a
-      # duplicate delivery, so a redelivered job cannot repeat one.
+      # sequential duplicate delivery. Without locks, the host must serialize.
       def report_back(spec, store, emit)
         facade = Child.new(name: spec.fetch("name"), session_id: spec.fetch("session_id"),
                            store: store)
@@ -322,3 +355,5 @@ module Mistri
     end
   end
 end
+
+require_relative "sub_agent/execution"

--- a/lib/mistri/sub_agent/execution.rb
+++ b/lib/mistri/sub_agent/execution.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Mistri
+  class SubAgent
+    class << self
+      # The hardened execution path every child uses. Inline work acquires
+      # and cleans up its lease here; a dispatched owner supplies its lease
+      # and retains it through terminal persistence and parent reporting.
+      def execute_child(child:, label:, provider:, system:, tools:, task:, schema:,
+                        signal:, emit:, lease: nil, started: false, agent_options: {})
+        ChildAgentOptions.validate!(agent_options)
+        child.append(Child::STARTED, {}) unless started
+        owns_lease = lease.nil?
+        primary_error = nil
+        begin
+          lease ||= Locks.hold(Child.lease_key(child.id),
+                               stop_key: Child.stop_key(child.id), signal: signal)
+          abort_before_child_start!(child, signal, lease)
+          if signal.aborted?
+            Result.new(message: nil, status: :aborted)
+          else
+            run_child_agent(child:, label:, provider:, system:, tools:, task:, schema:,
+                            signal:, emit:, agent_options:)
+          end
+        rescue StandardError => e
+          primary_error = e
+          child.append(Child::TERMINAL, "status" => "failed", "error" => "#{e.class}: #{e.message}")
+          raise
+        ensure
+          cleanup_error = release_inline_lease(child, lease) if owns_lease
+          raise cleanup_error if cleanup_error && primary_error.nil?
+        end
+      end
+
+      def release_inline_lease(child, lease)
+        errors = []
+        begin
+          lease&.release
+        rescue StandardError => e
+          errors << e
+        end
+        begin
+          Mistri.locks&.clear_flag(Child.stop_key(child.id))
+        rescue StandardError => e
+          errors << e
+        end
+        errors.first
+      end
+
+      def abort_before_child_start!(child, signal, lease)
+        return unless Mistri.locks
+        return if lease && !Mistri.locks.flag?(Child.stop_key(child.id))
+
+        signal.abort!("stopped by user")
+      end
+
+      def run_child_agent(child:, label:, provider:, system:, tools:, task:, schema:,
+                          signal:, emit:, agent_options:)
+        agent = Agent.new(provider: provider, session: child, system: system,
+                          tools: tools, **agent_options)
+        origin = "#{label}##{child.id[0, 8]}"
+        tagged = ->(event) { forward(event, origin, emit) }
+        return agent.task(task, schema: schema, signal: signal, &tagged) if schema
+
+        agent.run(task, signal: signal, &tagged)
+      end
+
+      def forward(event, origin, emit)
+        return unless emit
+
+        tagged = event.origin ? "#{origin}>#{event.origin}" : origin
+        emit.call(event.with(origin: tagged))
+      end
+
+      private :abort_before_child_start!, :execute_child, :forward,
+              :release_inline_lease, :run_child_agent
+    end
+  end
+end

--- a/lib/mistri/sub_agent/runtime.rb
+++ b/lib/mistri/sub_agent/runtime.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+module Mistri
+  # Agent options a child may inherit without replacing lifecycle-owned
+  # provider, session, prompt, tools, task, signal, or event state.
+  module ChildAgentOptions
+    ALLOWED = %i[
+      budget max_concurrency transform_context compaction retries skills
+      before_tool after_tool context
+    ].freeze
+    private_constant :ALLOWED
+
+    module_function
+
+    def validate!(options)
+      unsupported = options.keys - ALLOWED
+      return if unsupported.empty?
+
+      raise ConfigurationError,
+            "unsupported sub-agent options: #{unsupported.sort.join(", ")}"
+    end
+  end
+  private_constant :ChildAgentOptions
+
+  class SubAgent
+    DISPATCH_SPEC_VERSION = 1
+    DISPATCH_SPEC_KEYS = %w[
+      spec_version name session_id parent_session_id type instructions task tool_names model
+    ].freeze
+    UNSET_RUNTIME_FIELD = Object.new.freeze
+    private_constant :DISPATCH_SPEC_KEYS, :UNSET_RUNTIME_FIELD
+
+    # The live dependencies a host constructs for one dispatched child.
+    # Mistri verifies the provider and tools against the durable spec; the
+    # host owns tenant scope, backend isolation, and the freshness of every
+    # object placed here.
+    class Runtime
+      attr_reader :provider, :system, :tools, :schema, :agent_options
+
+      def initialize(provider:, system: nil, tools: [], schema: nil, cleanup: nil,
+                     **agent_options)
+        raise ArgumentError, "runtime tools must be an Array" unless tools.is_a?(Array)
+        unless cleanup.nil? || cleanup.respond_to?(:call)
+          raise ArgumentError, "runtime cleanup must be callable"
+        end
+
+        @provider = provider
+        @system = system
+        @tools = Array.new(tools).freeze
+        @schema = schema
+        @cleanup = cleanup
+        @agent_options = agent_options.dup.freeze
+        freeze
+      end
+
+      def close = @cleanup&.call
+    end
+
+    # The fail-closed boundary between a durable dispatch spec and live Ruby
+    # dependencies. Kept separate from SubAgent's execution lifecycle so each
+    # concern stays auditable.
+    class RuntimeContract
+      Resolved = Data.define(:provider, :system, :tools, :schema, :agent_options)
+      private_constant :Resolved
+
+      class << self
+        def own_spec(spec)
+          owned, error = ToolArguments.canonicalize(spec)
+          unless error.nil? && owned.is_a?(Hash)
+            raise ConfigurationError, "dispatched child spec must be a bounded JSON object"
+          end
+
+          owned
+        end
+
+        def validate_identity!(spec)
+          %w[name session_id].each do |field|
+            value = spec[field]
+            unless value.is_a?(String) && !value.empty?
+              raise ConfigurationError, "dispatched child spec needs a non-empty #{field}"
+            end
+          end
+        end
+
+        def bind_spec(entries, supplied)
+          dispatched = entries.find { |entry| entry["type"] == Child::DISPATCHED }
+          raise DispatchGrantError, "child session has no durable dispatch grant" unless dispatched
+
+          stored = dispatched["spec"]
+          return supplied if stored.nil? && supplied["spec_version"].nil?
+          unless stored
+            raise DispatchGrantError, "versioned child is missing its durable dispatch grant"
+          end
+
+          authoritative = own_spec(stored)
+          unless supplied == authoritative
+            raise DispatchGrantError, "queue payload does not match the durable dispatch grant"
+          end
+
+          authoritative
+        end
+
+        def validate_resolution!(factory:, direct:)
+          supplied = direct.values.any? { |value| !value.equal?(UNSET_RUNTIME_FIELD) }
+          if factory
+            raise ArgumentError, "choose runtime_factory or direct runtime fields" if supplied
+            unless factory.respond_to?(:call)
+              raise ConfigurationError, "runtime_factory must be callable"
+            end
+          elsif direct.fetch(:provider).equal?(UNSET_RUNTIME_FIELD)
+            raise ConfigurationError, "run_dispatched needs runtime_factory or provider"
+          end
+        end
+
+        def validate_spec!(spec)
+          version = spec["spec_version"]
+          validate_version!(version)
+          validate_v1_shape!(spec) if version == DISPATCH_SPEC_VERSION
+          validate_task!(spec["task"])
+          validate_model!(spec["model"], version: version)
+          validate_tool_names!(spec["tool_names"])
+        end
+
+        def resolve(spec, factory:, direct:, &factory_failed)
+          return resolve_factory(spec, factory, &factory_failed) if factory
+
+          resolve_direct(direct)
+        end
+
+        def validate_runtime!(runtime, spec)
+          provider = runtime.provider
+          system = runtime.system
+          tools = runtime.tools
+          schema = runtime.schema
+          options = runtime.agent_options
+          validate_provider!(provider, spec["model"])
+          validate_agent_options!(options)
+          ordered = validate_tools!(tools, spec.fetch("tool_names"))
+          Resolved.new(provider: provider, system: system, tools: ordered,
+                       schema: schema, agent_options: options)
+        end
+
+        def cleanup(runtime)
+          runtime&.close
+          nil
+        rescue StandardError => e
+          e
+        end
+
+        private
+
+        def validate_version!(version)
+          return if version.nil? || version == DISPATCH_SPEC_VERSION
+
+          raise ConfigurationError,
+                "unsupported dispatched child spec version #{version.inspect}"
+        end
+
+        def validate_task!(task)
+          return if task.is_a?(String) && !task.empty?
+
+          raise ConfigurationError, "dispatched child spec needs a non-empty task"
+        end
+
+        def validate_v1_shape!(spec)
+          extra = spec.keys - DISPATCH_SPEC_KEYS
+          unless extra.empty?
+            raise ConfigurationError,
+                  "dispatched child spec has unknown fields: #{extra.join(", ")}"
+          end
+          validate_optional_string!(spec["parent_session_id"], "parent_session_id")
+          validate_required_string!(spec["type"], "type")
+          validate_optional_string!(spec["instructions"], "instructions")
+        end
+
+        def validate_model!(model, version:)
+          return if version.nil? && model.nil?
+          return if model.is_a?(String) && !model.empty?
+
+          raise ConfigurationError, "dispatched child spec model must be a non-empty string"
+        end
+
+        def validate_required_string!(value, field)
+          return if value.is_a?(String) && !value.empty?
+
+          raise ConfigurationError,
+                "dispatched child spec #{field} must be a non-empty string"
+        end
+
+        def validate_optional_string!(value, field)
+          return if value.nil? || value.is_a?(String)
+
+          raise ConfigurationError,
+                "dispatched child spec #{field} must be a string or null"
+        end
+
+        def validate_tool_names!(names)
+          valid = names.is_a?(Array) &&
+                  names.all? { |name| name.is_a?(String) && !name.empty? }
+          unless valid
+            raise ConfigurationError,
+                  "dispatched child spec tool_names must be non-empty strings"
+          end
+          return if names.uniq.length == names.length
+
+          raise ConfigurationError, "dispatched child spec has duplicate tool names"
+        end
+
+        def resolve_factory(spec, factory)
+          runtime = begin
+            factory.call(spec)
+          rescue DispatchGrantError
+            yield if block_given?
+            raise ConfigurationError,
+                  "runtime_factory must not raise Mistri::DispatchGrantError; " \
+                  "that class is reserved for queue grant verification"
+          rescue StandardError
+            yield if block_given?
+            raise
+          end
+          return runtime if runtime.instance_of?(Runtime)
+
+          raise ConfigurationError,
+                "runtime_factory must return Mistri::SubAgent::Runtime"
+        end
+
+        def resolve_direct(direct)
+          provider = direct.fetch(:provider)
+          Runtime.new(provider: provider,
+                      system: value_or_nil(direct.fetch(:system)),
+                      tools: value_or(direct.fetch(:tools), []),
+                      schema: value_or_nil(direct.fetch(:schema)),
+                      **value_or(direct.fetch(:agent_options), {}))
+        end
+
+        def value_or(value, fallback)
+          value.equal?(UNSET_RUNTIME_FIELD) ? fallback : value
+        end
+
+        def value_or_nil(value) = value_or(value, nil)
+
+        def validate_provider!(provider, expected_model)
+          unless provider.respond_to?(:stream)
+            raise ConfigurationError, "background runtime provider must respond to stream"
+          end
+          return unless expected_model
+
+          actual = provider.model.to_s if provider.respond_to?(:model)
+          return if actual == expected_model
+
+          raise ConfigurationError,
+                "background runtime model #{actual.inspect} does not match " \
+                "the granted model #{expected_model.inspect}"
+        end
+
+        def validate_agent_options!(options)
+          ChildAgentOptions.validate!(options)
+          return unless options.key?(:skills)
+
+          raise ConfigurationError,
+                "background runtime skills would add tools outside the durable grant"
+        end
+
+        def validate_tools!(tools, expected)
+          unless tools.all?(Tool)
+            raise ConfigurationError, "background runtime tools must be Mistri::Tool instances"
+          end
+
+          names = tools.map(&:name)
+          if names.uniq.length != names.length
+            raise ConfigurationError, "background runtime has duplicate tool names"
+          end
+
+          check_exact_grant!(expected, names)
+          by_name = tools.to_h { |tool| [tool.name, tool] }
+          ordered = expected.map { |name| by_name.fetch(name) }
+          SubAgent.forbid_gated!(ordered)
+          ordered
+        end
+
+        def check_exact_grant!(expected, names)
+          missing = expected - names
+          extra = names - expected
+          return if missing.empty? && extra.empty?
+
+          details = []
+          details << "missing: #{missing.join(", ")}" if missing.any?
+          details << "extra: #{extra.join(", ")}" if extra.any?
+          raise ConfigurationError,
+                "background runtime tools do not match the durable grant " \
+                "(#{details.join("; ")})"
+        end
+      end
+    end
+    private_constant :RuntimeContract
+  end
+end

--- a/test/integration/test_background.rb
+++ b/test/integration/test_background.rb
@@ -21,8 +21,19 @@ class TestBackgroundIntegration < Minitest::Test
       sleep 8
       number.to_s
     end
+    runtime_factory = lambda do |spec|
+      runtime_oracle = Mistri::Tool.define("oracle", "Answers the secret number, slowly.") do
+        sleep 8
+        number.to_s
+      end
+      provider = Mistri.provider(spec.fetch("model"))
+      Mistri::SubAgent::Runtime.new(provider: provider,
+                                    system: spec.fetch("instructions"),
+                                    tools: [runtime_oracle], cleanup: -> { provider.close })
+    end
     tools = Mistri::SubAgent.pack(provider: Mistri.provider(model), tools: [oracle],
-                                  dispatcher: Mistri::Dispatchers::Thread.new)
+                                  dispatcher: Mistri::Dispatchers::Thread.new,
+                                  runtime_factory: runtime_factory)
     parent = Mistri::Agent.new(
       provider: Mistri.provider(model), tools: tools,
       session: Mistri::Session.new(store:),
@@ -68,8 +79,19 @@ class TestBackgroundIntegration < Minitest::Test
       sleep 1
       number.to_s
     end
+    runtime_factory = lambda do |spec|
+      runtime_oracle = Mistri::Tool.define("oracle", "Answers the secret number, slowly.") do
+        sleep 1
+        number.to_s
+      end
+      provider = Mistri.provider(spec.fetch("model"))
+      Mistri::SubAgent::Runtime.new(provider: provider,
+                                    system: spec.fetch("instructions"),
+                                    tools: [runtime_oracle], cleanup: -> { provider.close })
+    end
     tools = Mistri::SubAgent.pack(provider: Mistri.provider(model), tools: [oracle],
-                                  dispatcher: Mistri::Dispatchers::Thread.new)
+                                  dispatcher: Mistri::Dispatchers::Thread.new,
+                                  runtime_factory: runtime_factory)
     parent = Mistri::Agent.new(
       provider: Mistri.provider(model), tools: tools,
       session: Mistri::Session.new(store:),

--- a/test/test_background_mode.rb
+++ b/test/test_background_mode.rb
@@ -12,6 +12,13 @@ class TestBackgroundMode < Minitest::Test
 
   def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
 
+  def runtime_factory(provider, tools: [], system: nil)
+    lambda do |spec|
+      Mistri::SubAgent::Runtime.new(provider: provider, system: system || spec["instructions"],
+                                    tools: tools)
+    end
+  end
+
   def spawn_call(arguments)
     fake({ tool_calls: [{ name: "spawn_agent", arguments: arguments }] },
          { text: "Parent moved on." })
@@ -36,24 +43,26 @@ class TestBackgroundMode < Minitest::Test
     child.status
   end
 
-  def test_workspace_sharing_refuses_background_in_band
-    spawn = Mistri::SubAgent.spawner(provider: fake, dispatcher: Mistri::Dispatchers::Inline.new)
-    parent = spawn_call({ "name" => "Husky", "task" => "t", "instructions" => "You help.",
-                          "mode" => "background", "workspace" => "parent" })
-    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+  def test_a_dispatcher_requires_a_runtime_factory
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.spawner(provider: fake, dispatcher: Mistri::Dispatchers::Inline.new)
+    end
 
-    Mistri::Agent.new(provider: parent, tools: [spawn], session:).run("go")
+    assert_match(/runtime_factory/, error.message)
 
-    refusal = session.messages.select(&:tool?).last
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.spawner(provider: fake, dispatcher: Object.new,
+                               runtime_factory: ->(_spec) {})
+    end
 
-    assert_match(/must run inline/, refusal.text)
-    assert_empty session.children
+    assert_match(/dispatcher must be callable/, error.message)
   end
 
   def test_inline_dispatcher_finishes_during_the_spawn_and_says_so
     child_fake = fake({ text: "The answer is 7." })
     spawn = Mistri::SubAgent.spawner(provider: child_fake,
-                                     dispatcher: Mistri::Dispatchers::Inline.new)
+                                     dispatcher: Mistri::Dispatchers::Inline.new,
+                                     runtime_factory: runtime_factory(child_fake))
     parent = spawn_call({ "name" => "Corgi", "task" => "answer", "instructions" => "Answer.",
                           "mode" => "background" })
     session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
@@ -86,7 +95,8 @@ class TestBackgroundMode < Minitest::Test
     child_fake = fake({ tool_calls: [{ name: "slow", arguments: {} }] },
                       { text: "Finished the slow work." })
     spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [slow],
-                                     dispatcher: Mistri::Dispatchers::Thread.new)
+                                     dispatcher: Mistri::Dispatchers::Thread.new,
+                                     runtime_factory: runtime_factory(child_fake, tools: [slow]))
     parent = spawn_call({ "name" => "Whippet", "task" => "work slowly",
                           "instructions" => "Use slow, then report.",
                           "mode" => "background" })
@@ -117,7 +127,8 @@ class TestBackgroundMode < Minitest::Test
   def test_a_dropped_spec_reads_queued_and_run_dispatched_picks_it_up
     dropper = drop_dispatcher
     child_fake = fake({ text: "Ran from the job." })
-    spawn = Mistri::SubAgent.spawner(provider: child_fake, dispatcher: dropper)
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, dispatcher: dropper,
+                                     runtime_factory: runtime_factory(child_fake))
     parent = spawn_call({ "name" => "Basset", "task" => "do the thing",
                           "instructions" => "You do things.", "mode" => "background" })
     store = Mistri::Stores::Memory.new
@@ -150,7 +161,8 @@ class TestBackgroundMode < Minitest::Test
     child_fake = fake({ tool_calls: [{ name: "slow", arguments: {} }] },
                       { text: "never reached" })
     spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [slow],
-                                     dispatcher: Mistri::Dispatchers::Thread.new)
+                                     dispatcher: Mistri::Dispatchers::Thread.new,
+                                     runtime_factory: runtime_factory(child_fake, tools: [slow]))
     parent = spawn_call({ "name" => "Pointer", "task" => "work",
                           "instructions" => "Use slow.", "mode" => "background" })
     session = Mistri::Session.new(store:)
@@ -164,7 +176,9 @@ class TestBackgroundMode < Minitest::Test
 
   def test_the_console_treats_a_queued_worker_as_live
     dropper = drop_dispatcher
-    spawn = Mistri::SubAgent.spawner(provider: fake, dispatcher: dropper)
+    child_fake = fake
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, dispatcher: dropper,
+                                     runtime_factory: runtime_factory(child_fake))
     parent = spawn_call({ "name" => "Collie", "task" => "t", "instructions" => "You help.",
                           "mode" => "background" })
     store = Mistri::Stores::Memory.new
@@ -192,7 +206,8 @@ class TestBackgroundMode < Minitest::Test
     Mistri.locks = Mistri::Locks::Memory.new
     dropper = drop_dispatcher
     child_fake = fake({ text: "should never run" })
-    spawn = Mistri::SubAgent.spawner(provider: child_fake, dispatcher: dropper)
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, dispatcher: dropper,
+                                     runtime_factory: runtime_factory(child_fake))
     parent = spawn_call({ "name" => "Saluki", "task" => "t", "instructions" => "You help.",
                           "mode" => "background" })
     store = Mistri::Stores::Memory.new
@@ -203,7 +218,7 @@ class TestBackgroundMode < Minitest::Test
 
     cancelled = Mistri::Console.stop_agent.call({ "agent" => "Saluki" }, context)
 
-    assert_match(/Cancelled\. Saluki had not started/, cancelled)
+    assert_match(/Cancelled\. Saluki is marked stopped; ordinary queue delivery/, cancelled)
     assert_equal :stopped, child.status
 
     # The queue delivers late anyway; the runner honors the terminal.
@@ -227,7 +242,10 @@ class TestBackgroundMode < Minitest::Test
     end
     child_fake = fake({ tool_calls: [{ name: "risky", arguments: { "danger" => true } }] })
     dropper = drop_dispatcher
-    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [risky], dispatcher: dropper)
+    spawn = Mistri::SubAgent.spawner(
+      provider: child_fake, tools: [risky], dispatcher: dropper,
+      runtime_factory: runtime_factory(child_fake, tools: [risky])
+    )
     parent = spawn_call({ "name" => "Akita", "task" => "do the risky thing",
                           "instructions" => "Use risky.", "mode" => "background" })
     store = Mistri::Stores::Memory.new
@@ -246,13 +264,16 @@ class TestBackgroundMode < Minitest::Test
                  "no approval request may stay open on a finished child"
   end
 
-  def test_mode_and_workspace_only_exist_with_a_dispatcher
+  def test_only_mode_is_added_to_the_schema_by_a_dispatcher
     bare = Mistri::SubAgent.spawner(provider: fake)
-    dispatched = Mistri::SubAgent.spawner(provider: fake,
-                                          dispatcher: Mistri::Dispatchers::Inline.new)
+    child_fake = fake
+    dispatched = Mistri::SubAgent.spawner(
+      provider: child_fake, dispatcher: Mistri::Dispatchers::Inline.new,
+      runtime_factory: runtime_factory(child_fake)
+    )
 
     refute bare.input_schema["properties"].key?("mode")
     assert dispatched.input_schema["properties"].key?("mode")
-    assert dispatched.input_schema["properties"].key?("workspace")
+    refute dispatched.input_schema["properties"].key?("workspace")
   end
 end

--- a/test/test_background_mode.rb
+++ b/test/test_background_mode.rb
@@ -43,6 +43,15 @@ class TestBackgroundMode < Minitest::Test
     child.status
   end
 
+  def assert_lease_released(child, deadline: 3)
+    key = Mistri::Child.lease_key(child.session_id)
+    ends = Process.clock_gettime(Process::CLOCK_MONOTONIC) + deadline
+    sleep 0.01 while Mistri.locks.held?(key) &&
+                     Process.clock_gettime(Process::CLOCK_MONOTONIC) < ends
+
+    refute Mistri.locks.held?(key), "the runner releases after reporting"
+  end
+
   def test_a_dispatcher_requires_a_runtime_factory
     error = assert_raises(Mistri::ConfigurationError) do
       Mistri::SubAgent.spawner(provider: fake, dispatcher: Mistri::Dispatchers::Inline.new)
@@ -114,7 +123,7 @@ class TestBackgroundMode < Minitest::Test
 
     assert_equal :done, await_status(child, :done)
     assert_equal "Finished the slow work.", child.report
-    refute Mistri.locks.held?(Mistri::Child.lease_key(child.session_id))
+    assert_lease_released(child)
 
     # The parent's run was long over, so the report waits in its inbox.
     ends = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 3

--- a/test/test_background_runtime.rb
+++ b/test/test_background_runtime.rb
@@ -234,6 +234,27 @@ class TestBackgroundRuntime < Minitest::Test # rubocop:disable Metrics/ClassLeng
     assert_match(/non-empty model identity/, tool_result.text)
   end
 
+  def test_background_spec_rejects_a_non_json_parent_identity_before_dispatch
+    dispatcher = drop_dispatcher
+    spawn = Mistri::SubAgent.spawner(
+      provider: fake, dispatcher: dispatcher,
+      runtime_factory: ->(_spec) { raise "the queue owns execution" }
+    )
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new, id: Object.new)
+    parent = spawn_call({ "name" => "Corgi", "task" => "work",
+                          "instructions" => "Work.", "mode" => "background" })
+
+    result = Mistri::Agent.new(provider: parent, tools: [spawn], session: session).run("go")
+
+    assert_predicate result, :completed?
+    assert_nil dispatcher.spec
+    assert_empty session.children
+    tool_result = session.messages.find(&:tool?)
+
+    assert_predicate tool_result, :tool_error?
+    assert_match(/background child spec is not bounded JSON/, tool_result.text)
+  end
+
   def test_an_extra_runtime_tool_fails_before_provider_or_handler_execution
     spec, store, session = queue(selected: [])
     called = false

--- a/test/test_background_runtime.rb
+++ b/test/test_background_runtime.rb
@@ -1,0 +1,1096 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Background runtimes turn a durable capability grant into fresh host-owned
+# objects, then fail closed if the reconstructed model or tools drift.
+class TestBackgroundRuntime < Minitest::Test # rubocop:disable Metrics/ClassLength -- adversarial dispatch invariants share one fixture
+  def teardown
+    Mistri.locks = nil
+  end
+
+  def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
+
+  def spawn_call(arguments)
+    fake({ tool_calls: [{ name: "spawn_agent", arguments: arguments }] },
+         { text: "Parent moved on." })
+  end
+
+  def drop_dispatcher
+    Class.new do
+      attr_reader :spec
+
+      def call(spec, _runner)
+        @spec = spec
+      end
+    end.new
+  end
+
+  def queue(tools: [], selected: nil, store: nil)
+    dispatcher = drop_dispatcher
+    catalog_provider = fake
+    runtime_factory = ->(_spec) { raise "a queue dispatcher must not invoke the local runner" }
+    spawn = Mistri::SubAgent.spawner(provider: catalog_provider, tools: tools,
+                                     dispatcher: dispatcher, runtime_factory: runtime_factory)
+    arguments = { "name" => "Basset", "task" => "work",
+                  "instructions" => "Do the work.", "mode" => "background" }
+    arguments["tools"] = selected unless selected.nil?
+    store ||= Mistri::Stores::Memory.new
+    session = Mistri::Session.new(store: store)
+
+    Mistri::Agent.new(provider: spawn_call(arguments), tools: [spawn], session: session).run("go")
+    [dispatcher.spec, store, session]
+  end
+
+  def await_status(child, wanted, deadline: 3)
+    ends = Process.clock_gettime(Process::CLOCK_MONOTONIC) + deadline
+    while child.status != wanted && Process.clock_gettime(Process::CLOCK_MONOTONIC) < ends
+      sleep 0.05
+    end
+    child.status
+  end
+
+  def blocking_started_store
+    Class.new do
+      attr_reader :entered, :continue
+
+      def initialize
+        @store = Mistri::Stores::Memory.new
+        @entered = Queue.new
+        @continue = Queue.new
+        @block_started = false
+      end
+
+      def block_started! = @block_started = true
+
+      def append(id, entry)
+        if @block_started && entry["type"] == Mistri::Child::STARTED
+          @block_started = false
+          @entered << true
+          @continue.pop
+        end
+        @store.append(id, entry)
+      end
+
+      def load(id) = @store.load(id)
+    end.new
+  end
+
+  def blocking_terminal_store
+    Class.new do
+      attr_reader :entered, :continue
+
+      def initialize
+        @store = Mistri::Stores::Memory.new
+        @entered = Queue.new
+        @continue = Queue.new
+        @block_terminal = false
+      end
+
+      def block_terminal! = @block_terminal = true
+
+      def append(id, entry)
+        if @block_terminal && entry["type"] == Mistri::Child::TERMINAL
+          @block_terminal = false
+          @entered << true
+          @continue.pop
+        end
+        @store.append(id, entry)
+      end
+
+      def load(id) = @store.load(id)
+    end.new
+  end
+
+  def report_observing_store
+    Class.new do
+      attr_accessor :lease_key
+      attr_reader :report_lease_states
+
+      def initialize
+        @store = Mistri::Stores::Memory.new
+        @report_lease_states = []
+      end
+
+      def append(id, entry)
+        @report_lease_states << Mistri.locks&.held?(lease_key) if entry["type"] == "subagent_report"
+        @store.append(id, entry)
+      end
+
+      def load(id) = @store.load(id)
+    end.new
+  end
+
+  def fail_once_report_store
+    Class.new do
+      def initialize
+        @store = Mistri::Stores::Memory.new
+        @fail_report = true
+      end
+
+      def append(id, entry)
+        if @fail_report && entry["type"] == "subagent_report"
+          @fail_report = false
+          raise "parent report unavailable"
+        end
+        @store.append(id, entry)
+      end
+
+      def load(id) = @store.load(id)
+    end.new
+  end
+
+  def valid_spec
+    { "spec_version" => Mistri::SubAgent::DISPATCH_SPEC_VERSION,
+      "name" => "Raw", "session_id" => SecureRandom.uuid, "parent_session_id" => nil,
+      "type" => "general-purpose", "instructions" => "Do the work.",
+      "task" => "work", "tool_names" => [], "model" => "fake-1" }
+  end
+
+  def test_thread_factory_builds_an_isolated_workspace_inside_the_worker
+    Mistri.locks = Mistri::Locks::Memory.new
+    parent_workspace = Mistri::Workspace::Memory.new
+    parent_workspace.write("notes.txt", "parent")
+    declared_write = Mistri::Tools.write_file(parent_workspace)
+    factory_thread = nil
+    child_workspace = nil
+    runtime_factory = lambda do |spec|
+      factory_thread = Thread.current
+      child_workspace = Mistri::Workspace::Memory.new
+      provider = fake(
+        { tool_calls: [{ name: "write_file",
+                         arguments: { "path" => "notes.txt", "content" => "child" } }] },
+        { text: "Wrote the child file." }
+      )
+      Mistri::SubAgent::Runtime.new(
+        provider: provider, system: spec.fetch("instructions"),
+        tools: [Mistri::Tools.write_file(child_workspace)]
+      )
+    end
+    spawn = Mistri::SubAgent.spawner(
+      provider: fake, tools: [declared_write], dispatcher: Mistri::Dispatchers::Thread.new,
+      runtime_factory: runtime_factory
+    )
+    parent = spawn_call({ "name" => "Corgi", "task" => "write the child file",
+                          "instructions" => "Use write_file.", "mode" => "background" })
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+
+    Mistri::Agent.new(provider: parent, tools: [spawn], session: session).run("go")
+
+    assert_equal :done, await_status(session.children.first, :done)
+    refute_equal Thread.current, factory_thread, "construction belongs to the worker thread"
+    assert_equal "parent", parent_workspace.read("notes.txt")
+    assert_equal "child", child_workspace.read("notes.txt")
+  end
+
+  def test_new_specs_are_versioned_immutable_json_without_workspace_claims
+    spec, = queue
+
+    assert_equal Mistri::SubAgent::DISPATCH_SPEC_VERSION, spec["spec_version"]
+    refute spec.key?("workspace")
+    assert_predicate spec, :frozen?
+    assert_predicate spec.fetch("tool_names"), :frozen?
+    assert_equal spec, JSON.parse(JSON.generate(spec))
+  end
+
+  def test_a_selected_background_model_is_only_constructed_by_the_worker
+    dispatcher = drop_dispatcher
+    runtime_factory = ->(_spec) { raise "the queue owns execution" }
+    spawn = Mistri::SubAgent.spawner(provider: fake, models: ["host-worker-v1"],
+                                     dispatcher: dispatcher,
+                                     runtime_factory: runtime_factory)
+    parent = spawn_call({ "name" => "Corgi", "task" => "work",
+                          "instructions" => "Do the work.", "mode" => "background",
+                          "model" => "host-worker-v1" })
+
+    Mistri::Agent.new(provider: parent, tools: [spawn]).run("go")
+
+    assert_equal "host-worker-v1", dispatcher.spec["model"]
+  end
+
+  def test_a_background_default_requires_a_stable_model_identity_before_dispatch
+    catalog = Class.new do
+      def stream(**) = raise("the catalog provider must not run")
+    end.new
+    dispatcher = drop_dispatcher
+    spawn = Mistri::SubAgent.spawner(
+      provider: catalog, dispatcher: dispatcher,
+      runtime_factory: ->(_spec) { raise "the queue owns execution" }
+    )
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+
+    result = Mistri::Agent.new(
+      provider: spawn_call({ "name" => "Corgi", "task" => "work",
+                             "instructions" => "Work.", "mode" => "background" }),
+      tools: [spawn], session: session
+    ).run("go")
+
+    assert_predicate result, :completed?
+    assert_nil dispatcher.spec
+    assert_empty session.children
+    tool_result = session.messages.find(&:tool?)
+
+    assert_predicate tool_result, :tool_error?
+    assert_match(/non-empty model identity/, tool_result.text)
+  end
+
+  def test_an_extra_runtime_tool_fails_before_provider_or_handler_execution
+    spec, store, session = queue(selected: [])
+    called = false
+    danger = Mistri::Tool.define("danger", "Should not run.") do
+      called = true
+      "ran"
+    end
+    provider = fake({ tool_calls: [{ name: "danger", arguments: {} }] })
+    factory = lambda do |_owned_spec|
+      Mistri::SubAgent::Runtime.new(provider: provider, system: "Do the work.", tools: [danger])
+    end
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: factory)
+    end
+
+    assert_match(/extra: danger/, error.message)
+    refute called
+    assert_empty provider.requests
+    assert_equal :failed, session.children.first.status
+    assert_equal "failed", session.pending_inbox.first["status"]
+  end
+
+  def test_a_missing_runtime_tool_fails_closed
+    alpha = Mistri::Tool.define("alpha", "Alpha.") { "a" }
+    beta = Mistri::Tool.define("beta", "Beta.") { "b" }
+    spec, store, = queue(tools: [alpha, beta])
+    provider = fake({ text: "never" })
+    runtime_factory = lambda do |_owned_spec|
+      Mistri::SubAgent::Runtime.new(provider: provider, system: "Do the work.", tools: [alpha])
+    end
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: runtime_factory)
+    end
+
+    assert_match(/missing: beta/, error.message)
+    assert_empty provider.requests
+  end
+
+  def test_runtime_tools_are_reordered_to_the_durable_grant
+    alpha = Mistri::Tool.define("alpha", "Alpha.") { "a" }
+    beta = Mistri::Tool.define("beta", "Beta.") { "b" }
+    spec, store, = queue(tools: [alpha, beta])
+    provider = fake({ text: "done" })
+    runtime_factory = lambda do |_owned_spec|
+      Mistri::SubAgent::Runtime.new(provider: provider, system: "Do the work.",
+                                    tools: [beta, alpha])
+    end
+
+    Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: runtime_factory)
+
+    names = provider.requests.first[:options][:tools].map { |tool| tool.fetch(:name) }
+
+    assert_equal %w[alpha beta], names
+  end
+
+  def test_runtime_model_must_match_the_durable_grant
+    spec, store, = queue
+    wrong_model = Class.new do
+      def model = "other-model"
+      def stream(**) = raise("must not run")
+    end.new
+    runtime_factory = lambda do |_owned_spec|
+      Mistri::SubAgent::Runtime.new(provider: wrong_model, system: "Do the work.")
+    end
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: runtime_factory)
+    end
+
+    assert_match(/does not match the granted model/, error.message)
+  end
+
+  def test_factory_shape_errors_fail_and_report_the_child
+    spec, store, session = queue
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store,
+                                            runtime_factory: ->(_owned_spec) { {} })
+    end
+
+    assert_match(/must return Mistri::SubAgent::Runtime/, error.message)
+    assert_equal :failed, session.children.first.status
+    assert_equal "failed", session.pending_inbox.first["status"]
+  end
+
+  def test_malformed_dispatch_specs_never_reach_the_factory
+    factory_calls = 0
+    factory = lambda do |_spec|
+      factory_calls += 1
+      raise "must not construct"
+    end
+    cases = [
+      ["not an object", /bounded JSON object/],
+      [valid_spec.merge("name" => ""), /non-empty name/],
+      [valid_spec.merge("task" => ""), /non-empty task/],
+      [valid_spec.merge("model" => nil), /model must be a non-empty string/],
+      [valid_spec.merge("model" => 7), /model must be a non-empty string/],
+      [valid_spec.merge("type" => ""), /type must be a non-empty string/],
+      [valid_spec.merge("parent_session_id" => 7), /parent_session_id must be a string or null/],
+      [valid_spec.merge("instructions" => 7), /instructions must be a string or null/],
+      [valid_spec.merge("tool_names" => [nil]), /tool_names must be non-empty strings/],
+      [valid_spec.merge("tool_names" => %w[same same]), /duplicate tool names/]
+    ]
+
+    cases.each do |spec, message|
+      store = Mistri::Stores::Memory.new
+      if spec.is_a?(Hash) && spec["session_id"].is_a?(String)
+        Mistri::Session.new(store: store, id: spec.fetch("session_id"))
+                       .append(Mistri::Child::DISPATCHED, "spec" => spec)
+      end
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::SubAgent.run_dispatched(spec, store: store,
+                                              runtime_factory: factory)
+      end
+      assert_match message, error.message
+    end
+
+    assert_equal 0, factory_calls
+  end
+
+  def test_a_versioned_delivery_requires_its_persisted_grant
+    spec = valid_spec
+    store = Mistri::Stores::Memory.new
+    child = Mistri::Session.new(store: store, id: spec.fetch("session_id"))
+    child.append(Mistri::Child::DISPATCHED, {})
+
+    error = assert_raises(Mistri::DispatchGrantError) do
+      Mistri::SubAgent.run_dispatched(
+        spec, provider: fake({ text: "never" }), system: "Do the work.", tools: [], store: store
+      )
+    end
+
+    assert_match(/missing its durable dispatch grant/, error.message)
+    assert_equal :queued,
+                 Mistri::Child.new(name: spec.fetch("name"), session_id: child.id,
+                                   store: store).status
+    assert(child.entries.none? { |entry| entry["type"] == Mistri::Child::TERMINAL })
+  end
+
+  def test_queue_payload_cannot_widen_the_persisted_tool_grant
+    spec, store, session = queue(selected: [])
+    tampered = JSON.parse(JSON.generate(spec))
+    tampered["tool_names"] = ["danger"]
+    called = false
+    danger = Mistri::Tool.define("danger", "Must not run.") do
+      called = true
+      "ran"
+    end
+    provider = fake({ tool_calls: [{ name: "danger", arguments: {} }] })
+    runtime_factory = lambda do |_owned_spec|
+      Mistri::SubAgent::Runtime.new(provider: provider, system: "Do the work.", tools: [danger])
+    end
+
+    error = assert_raises(Mistri::DispatchGrantError) do
+      Mistri::SubAgent.run_dispatched(tampered, store: store,
+                                                runtime_factory: runtime_factory)
+    end
+
+    assert_match(/does not match the durable dispatch grant/, error.message)
+    refute called
+    assert_empty provider.requests
+    assert_equal :queued, session.children.first.status
+    assert_empty session.pending_inbox
+  end
+
+  def test_tampered_finished_payload_cannot_reroute_a_report
+    spec, store, session = queue
+    Mistri::SubAgent.run_dispatched(spec, provider: fake({ text: "done" }),
+                                          system: "Do the work.", tools: [], store: store)
+    victim = Mistri::Session.new(store: store)
+    tampered = JSON.parse(JSON.generate(spec))
+    tampered["name"] = "Impostor"
+    tampered["parent_session_id"] = victim.id
+
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(tampered, provider: fake({ text: "never" }),
+                                                system: "Do the work.", tools: [], store: store)
+    end
+
+    assert_empty victim.pending_inbox
+    assert_equal 1, session.pending_inbox.length
+  end
+
+  def test_unknown_versioned_fields_never_reach_the_factory
+    spec = valid_spec.merge("tenant_id" => "injected")
+    store = Mistri::Stores::Memory.new
+    child = Mistri::Session.new(store: store, id: spec.fetch("session_id"))
+    child.append(Mistri::Child::DISPATCHED, "spec" => spec)
+    calls = 0
+    factory = lambda do |_owned_spec|
+      calls += 1
+      Mistri::SubAgent::Runtime.new(provider: fake({ text: "never" }))
+    end
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: factory)
+    end
+
+    assert_match(/unknown fields: tenant_id/, error.message)
+    assert_equal 0, calls
+  end
+
+  def test_invalid_runtime_inputs_fail_before_execution
+    alpha = Mistri::Tool.define("alpha", "Alpha.") { "a" }
+    cases = [
+      [->(spec, store) { Mistri::SubAgent.run_dispatched(spec, store: store) },
+       Mistri::ConfigurationError, /needs runtime_factory or provider/, []],
+      [lambda do |spec, store|
+         Mistri::SubAgent.run_dispatched(spec, store: store,
+                                               runtime_factory: Object.new)
+       end,
+       Mistri::ConfigurationError, /runtime_factory must be callable/, []],
+      [lambda do |spec, store|
+         factory = ->(_owned) { Mistri::SubAgent::Runtime.new(provider: fake) }
+         Mistri::SubAgent.run_dispatched(spec, store: store, provider: fake,
+                                               runtime_factory: factory)
+       end,
+       ArgumentError, /choose runtime_factory or direct runtime fields/, []],
+      [lambda do |spec, store|
+         Mistri::SubAgent.run_dispatched(spec, store: store,
+                                               provider: Object.new, tools: [])
+       end,
+       Mistri::ConfigurationError, /provider must respond to stream/, []],
+      [lambda do |spec, store|
+         runtime = ->(_owned) { Mistri::SubAgent::Runtime.new(provider: fake, tools: [Object.new]) }
+         Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: runtime)
+       end,
+       Mistri::ConfigurationError, /tools must be Mistri::Tool instances/, []],
+      [lambda do |spec, store|
+         runtime = lambda do |_owned|
+           Mistri::SubAgent::Runtime.new(provider: fake, tools: [alpha, alpha])
+         end
+         Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: runtime)
+       end,
+       Mistri::ConfigurationError, /duplicate tool names/, [alpha]]
+    ]
+
+    cases.each do |run, error_class, message, declared|
+      spec, store, = queue(tools: declared)
+      error = assert_raises(error_class) { run.call(spec, store) }
+      assert_match message, error.message
+    end
+  end
+
+  def test_runtime_and_spawner_reject_inert_host_configuration
+    error = assert_raises(ArgumentError) do
+      Mistri::SubAgent::Runtime.new(provider: fake, tools: "alpha")
+    end
+    assert_match(/tools must be an Array/, error.message)
+
+    error = assert_raises(ArgumentError) do
+      Mistri::SubAgent::Runtime.new(provider: fake, cleanup: Object.new)
+    end
+    assert_match(/cleanup must be callable/, error.message)
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.spawner(provider: fake, runtime_factory: ->(_spec) {})
+    end
+    assert_match(/requires a dispatcher/, error.message)
+  end
+
+  def test_runtime_skills_cannot_add_an_undeclared_reader_tool
+    spec, store, = queue(selected: [])
+    provider = fake({ tool_calls: [{ name: "read_skill", arguments: { "name" => "secret" } }] })
+    skill = Mistri::Skill.new(name: "secret", description: "Secret.", body: "classified")
+    factory = lambda do |_owned_spec|
+      Mistri::SubAgent::Runtime.new(provider: provider, system: "Do the work.", skills: [skill])
+    end
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: factory)
+    end
+
+    assert_match(/skills would add tools outside the durable grant/, error.message)
+    assert_empty provider.requests
+  end
+
+  def test_runtime_options_cannot_replace_durable_lifecycle_keywords
+    %i[session task signal emit lease child started label].each do |name|
+      spec, store, session = queue
+      other = Mistri::Session.new(store: store)
+      provider = fake({ text: "must not run" })
+      value = name == :session ? other : Object.new
+      factory = lambda do |_owned_spec|
+        Mistri::SubAgent::Runtime.new(provider: provider, **{ name => value })
+      end
+
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: factory)
+      end
+
+      assert_match(/unsupported sub-agent options:.*#{name}/, error.message)
+      assert_empty provider.requests
+      assert_empty other.entries
+      assert_equal :failed, session.children.first.status
+    end
+  end
+
+  def test_transient_factory_failures_remain_retryable
+    Mistri.locks = Mistri::Locks::Memory.new
+    spec, store, session = queue
+
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store,
+                                            runtime_factory: lambda do |_owned|
+                                              raise Mistri::ConfigurationError,
+                                                    "registry unavailable"
+                                            end)
+    end
+
+    child = session.children.first
+
+    assert_equal :interrupted, child.status
+    assert_empty session.pending_inbox
+    child_entries = Mistri::Session.new(store: store, id: child.session_id).entries
+
+    assert(child_entries.none? { |entry| entry["type"] == Mistri::Child::TERMINAL })
+
+    provider = fake({ text: "recovered" })
+    factory = lambda do |_owned|
+      Mistri::SubAgent::Runtime.new(provider: provider, system: "Do the work.")
+    end
+    result = Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: factory)
+
+    assert_predicate result, :completed?
+    assert_equal :done, child.status
+  end
+
+  def test_an_interrupted_factory_retry_can_be_cancelled_durably
+    Mistri.locks = Mistri::Locks::Memory.new
+    spec, store, session = queue
+    assert_raises(RuntimeError) do
+      Mistri::SubAgent.run_dispatched(
+        spec, store: store, runtime_factory: ->(_owned) { raise "database down" }
+      )
+    end
+    child = session.children.first
+
+    assert_equal :interrupted, child.status
+    context = Mistri::ToolContext.new(session: session, signal: nil, emit: nil, app: nil)
+    output = Mistri::Console.stop_agent.call({ "agent" => child.session_id }, context)
+
+    assert_match(/Cancelled.*marked stopped; ordinary queue delivery/, output)
+    assert_equal :stopped, child.status
+    assert_equal "stopped", session.pending_inbox.first["status"]
+    provider = fake({ text: "must not run" })
+    retried = Mistri::SubAgent.run_dispatched(
+      spec, provider: provider, system: "Do the work.", tools: [], store: store
+    )
+
+    assert_nil retried
+    assert_empty provider.requests
+  end
+
+  def test_in_process_factory_failures_end_the_child
+    catalog = fake
+    factory = ->(_owned) { raise "bad local configuration" }
+    spawn = Mistri::SubAgent.spawner(provider: catalog,
+                                     dispatcher: Mistri::Dispatchers::Inline.new,
+                                     runtime_factory: factory)
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+
+    Mistri::Agent.new(
+      provider: spawn_call({ "name" => "Corgi", "task" => "work",
+                             "instructions" => "Work.", "mode" => "background" }),
+      tools: [spawn], session: session
+    ).run("go")
+
+    assert_equal :failed, session.children.first.status
+    assert_match(/bad local configuration/, session.children.first.error)
+  end
+
+  def test_stop_during_factory_construction_never_reaches_the_provider
+    Mistri.locks = Mistri::Locks::Memory.new
+    spec, store, session = queue
+    entered = Queue.new
+    continue = Queue.new
+    provider = fake({ text: "must not run" })
+    factory = lambda do |_owned|
+      entered << true
+      continue.pop
+      Mistri::SubAgent::Runtime.new(provider: provider, system: "Do the work.")
+    end
+    result = nil
+    thread = Thread.new do
+      result = Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: factory)
+    end
+    entered.pop
+
+    assert session.children.first.stop
+    continue << true
+    thread.join
+
+    assert_predicate result, :aborted?
+    assert_empty provider.requests
+    terminals = Mistri::Session.new(store: store, id: spec.fetch("session_id")).entries
+                               .select { |entry| entry["type"] == Mistri::Child::TERMINAL }
+    statuses = terminals.map { |entry| entry["status"] }
+
+    assert_equal ["stopped"], statuses
+  end
+
+  def test_queued_stop_cannot_overtake_a_runner_that_holds_the_lease
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = blocking_started_store
+    dispatcher = drop_dispatcher
+    provider = fake({ text: "must not run" })
+    factory = lambda do |_owned|
+      Mistri::SubAgent::Runtime.new(provider: provider, system: "Do the work.")
+    end
+    spawn = Mistri::SubAgent.spawner(provider: fake, dispatcher: dispatcher,
+                                     runtime_factory: factory)
+    session = Mistri::Session.new(store: store)
+    parent = spawn_call({ "name" => "Corgi", "task" => "work",
+                          "instructions" => "Work.", "mode" => "background" })
+    Mistri::Agent.new(provider: parent, tools: [spawn], session: session).run("go")
+    store.block_started!
+    result = nil
+    thread = Thread.new do
+      result = Mistri::SubAgent.run_dispatched(dispatcher.spec, store: store,
+                                                                runtime_factory: factory)
+    end
+    store.entered.pop
+
+    assert session.children.first.stop
+    store.continue << true
+    thread.join
+
+    assert_predicate result, :aborted?
+    assert_empty provider.requests
+    entries = Mistri::Session.new(store: store,
+                                  id: dispatcher.spec.fetch("session_id")).entries
+    terminals = entries.select { |entry| entry["type"] == Mistri::Child::TERMINAL }
+    statuses = terminals.map { |entry| entry["status"] }
+
+    assert_equal ["stopped"], statuses
+  end
+
+  def test_queued_stop_reports_when_the_only_delivery_loses_the_cancellation_lease
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = blocking_terminal_store
+    dispatcher = drop_dispatcher
+    provider = fake({ text: "must not run" })
+    factory = lambda do |_owned|
+      Mistri::SubAgent::Runtime.new(provider: provider, system: "Do the work.")
+    end
+    spawn = Mistri::SubAgent.spawner(provider: fake, dispatcher: dispatcher,
+                                     runtime_factory: factory)
+    session = Mistri::Session.new(store: store)
+    parent = spawn_call({ "name" => "Corgi", "task" => "work",
+                          "instructions" => "Work.", "mode" => "background" })
+    Mistri::Agent.new(provider: parent, tools: [spawn], session: session).run("go")
+    store.block_terminal!
+    stopped = nil
+    stopper = Thread.new { stopped = session.children.first.stop }
+    store.entered.pop
+
+    delivery = Mistri::SubAgent.run_dispatched(dispatcher.spec, store: store,
+                                                                runtime_factory: factory)
+    store.continue << true
+    stopper.join
+
+    assert stopped
+    assert_nil delivery
+    assert_empty provider.requests
+    assert_equal :stopped, session.children.first.status
+    reports = session.pending_inbox
+
+    assert_equal 1, reports.length
+    assert_equal "stopped", reports.first["status"]
+    assert_equal dispatcher.spec.fetch("session_id"), reports.first["session_id"]
+  end
+
+  def test_legacy_queued_stop_reports_when_its_only_delivery_loses_the_lease
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = blocking_terminal_store
+    parent = Mistri::Session.new(store: store)
+    child = Mistri::Session.new(store: store)
+    parent.append("subagent", "name" => "Legacy", "session_id" => child.id)
+    child.append(Mistri::Child::DISPATCHED, {})
+    spec = { "name" => "Legacy", "session_id" => child.id,
+             "parent_session_id" => parent.id, "task" => "work",
+             "tool_names" => [], "model" => nil }
+    provider = fake({ text: "must not run" })
+    store.block_terminal!
+    stopped = nil
+    stopper = Thread.new { stopped = parent.children.first.stop }
+    store.entered.pop
+
+    delivery = Mistri::SubAgent.run_dispatched(
+      spec, provider: provider, system: "Do the work.", tools: [], store: store
+    )
+    store.continue << true
+    stopper.join
+
+    assert stopped
+    assert_nil delivery
+    assert_empty provider.requests
+    assert_equal :stopped, parent.children.first.status
+    reports = parent.pending_inbox
+
+    assert_equal 1, reports.length
+    assert_equal "stopped", reports.first["status"]
+    assert_equal child.id, reports.first["session_id"]
+  end
+
+  def test_repeated_stop_heals_a_failed_parent_report_write
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = fail_once_report_store
+    _spec, _, session = queue(store: store)
+    child = session.children.first
+
+    error = assert_raises(RuntimeError) { child.stop }
+
+    assert_match(/parent report unavailable/, error.message)
+    assert_equal :stopped, child.status
+    assert_empty session.pending_inbox
+    context = Mistri::ToolContext.new(session: session, signal: nil, emit: nil, app: nil)
+
+    output = Mistri::Console.stop_agent.call({ "agent" => child.session_id }, context)
+    duplicate = Mistri::Console.stop_agent.call({ "agent" => child.session_id }, context)
+
+    assert_match(/already stopped/, output)
+    assert_match(/already stopped/, duplicate)
+    assert_equal 1, session.pending_inbox.length
+    assert_equal "stopped", session.pending_inbox.first["status"]
+  end
+
+  def test_a_stop_is_not_lost_when_the_factory_raises
+    Mistri.locks = Mistri::Locks::Memory.new
+    spec, store, session = queue
+    entered = Queue.new
+    continue = Queue.new
+    error = nil
+    factory = lambda do |_owned|
+      entered << true
+      continue.pop
+      raise "database down"
+    end
+    thread = Thread.new do
+      Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: factory)
+    rescue StandardError => e
+      error = e
+    end
+    entered.pop
+
+    assert session.children.first.stop
+    continue << true
+    thread.join
+
+    assert_match(/database down/, error.message)
+    assert_equal :stopped, session.children.first.status
+    retry_provider = fake({ text: "must not run" })
+    retried = Mistri::SubAgent.run_dispatched(
+      spec, provider: retry_provider, system: "Do the work.", tools: [], store: store
+    )
+
+    assert_nil retried
+    assert_empty retry_provider.requests
+  end
+
+  def test_a_stop_arriving_after_factory_rescue_survives_to_the_retry
+    adapter = Class.new(Mistri::Locks::Memory) do
+      def arm(key, runner)
+        @target = key
+        @runner = runner
+        @reads = 0
+      end
+
+      def flag?(key)
+        return super unless key == @target && Thread.current == @runner
+
+        @reads += 1
+        return super unless @reads == 2
+
+        set_flag(key)
+        false
+      end
+    end.new
+    Mistri.locks = adapter
+    spec, store, session = queue
+    adapter.arm(Mistri::Child.stop_key(spec.fetch("session_id")), Thread.current)
+
+    assert_raises(RuntimeError) do
+      Mistri::SubAgent.run_dispatched(
+        spec, store: store, runtime_factory: ->(_owned) { raise "database down" }
+      )
+    end
+
+    assert_equal :interrupted, session.children.first.status
+    assert_empty session.pending_inbox
+    provider = fake({ text: "must not run" })
+    factory_calls = 0
+    result = Mistri::SubAgent.run_dispatched(
+      spec, store: store, runtime_factory: lambda do |_owned|
+        factory_calls += 1
+        Mistri::SubAgent::Runtime.new(provider: provider)
+      end
+    )
+
+    assert_predicate result, :aborted?
+    assert_equal 0, factory_calls
+    assert_empty provider.requests
+    assert_equal :stopped, session.children.first.status
+    assert_equal "stopped", session.pending_inbox.first["status"]
+  end
+
+  def test_runtime_subclasses_and_array_subclasses_cannot_bypass_validation
+    spec, store, = queue(selected: [])
+    provider = fake({ text: "never" })
+    subclass = Class.new(Mistri::SubAgent::Runtime)
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(
+        spec, store: store, runtime_factory: ->(_owned) { subclass.new(provider: provider) }
+      )
+    end
+
+    assert_match(/must return Mistri::SubAgent::Runtime/, error.message)
+    assert_empty provider.requests
+
+    safe = Mistri::Tool.define("safe", "Safe.") { "safe" }
+    danger_called = false
+    danger = Mistri::Tool.define("danger", "Danger.") do
+      danger_called = true
+      "danger"
+    end
+    spec, store, = queue(tools: [safe])
+    deceptive = Class.new(Array) do
+      def all?(*) = true
+      def map(*) = ["safe"]
+      def to_h(*) = { "safe" => first }
+    end.new([danger])
+    provider = fake({ tool_calls: [{ name: "danger", arguments: {} }] })
+    factory = lambda do |_owned|
+      Mistri::SubAgent::Runtime.new(provider: provider, tools: deceptive)
+    end
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: factory)
+    end
+
+    assert_match(/missing: safe; extra: danger/, error.message)
+    refute danger_called
+    assert_empty provider.requests
+  end
+
+  def test_the_dispatched_lease_is_held_until_the_terminal_is_durable
+    adapter = Class.new(Mistri::Locks::Memory) do
+      attr_accessor :on_release
+
+      def release(key)
+        super
+        callback = on_release
+        self.on_release = nil
+        callback&.call
+      end
+    end.new
+    Mistri.locks = adapter
+    spec, store, session = queue
+    first_provider = fake({ text: "done once" })
+    retry_provider = fake({ text: "must not run" })
+    retried = :not_called
+    adapter.on_release = lambda do
+      retried = Mistri::SubAgent.run_dispatched(spec, provider: retry_provider,
+                                                      system: "Do the work.", tools: [],
+                                                      store: store)
+    end
+
+    result = Mistri::SubAgent.run_dispatched(spec, provider: first_provider,
+                                                   system: "Do the work.", tools: [],
+                                                   store: store)
+
+    assert_predicate result, :completed?
+    assert_nil retried
+    assert_empty retry_provider.requests
+    assert_equal :done, session.children.first.status
+    assert_equal 1, session.pending_inbox.length
+  end
+
+  def test_the_dispatched_lease_is_held_through_parent_report_delivery
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = report_observing_store
+    spec, _, session = queue(store: store)
+    store.lease_key = Mistri::Child.lease_key(spec.fetch("session_id"))
+
+    result = Mistri::SubAgent.run_dispatched(
+      spec, provider: fake({ text: "done" }), system: "Do the work.", tools: [], store: store
+    )
+
+    assert_predicate result, :completed?
+    assert_equal [true], store.report_lease_states
+    assert_equal 1, session.pending_inbox.length
+  end
+
+  def test_a_lease_refused_delivery_does_not_report_for_the_owner
+    Mistri.locks = Mistri::Locks::Memory.new
+    spec, store, session = queue
+    child = Mistri::Session.new(store: store, id: spec.fetch("session_id"))
+    child.append(Mistri::Child::TERMINAL, "status" => "done", "report" => "owned")
+    key = Mistri::Child.lease_key(child.id)
+    Mistri.locks.acquire(key, ttl: 60)
+    events = []
+    provider = fake({ text: "must not run" })
+    emit = ->(event) { events << event }
+    runtime = { provider: provider, system: "Do the work.", tools: [], store: store, emit: emit }
+
+    result = Mistri::SubAgent.run_dispatched(spec, **runtime)
+
+    assert_nil result
+    assert_empty session.pending_inbox
+    assert_empty events
+  ensure
+    Mistri.locks&.release(key) if key
+  end
+
+  def test_factory_cannot_impersonate_a_dispatch_grant_failure
+    Mistri.locks = Mistri::Locks::Memory.new
+    spec, store, session = queue
+    factory = lambda do |_owned|
+      raise Mistri::DispatchGrantError, "not a queue grant failure"
+    end
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: factory)
+    end
+
+    assert_instance_of Mistri::ConfigurationError, error
+    assert_instance_of Mistri::DispatchGrantError, error.cause
+    assert_equal :interrupted, session.children.first.status
+    assert_empty session.pending_inbox
+
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(
+        spec, store: store, runtime_factory: factory, retry_factory_errors: false
+      )
+    end
+
+    assert_equal :failed, session.children.first.status
+    assert_equal "failed", session.pending_inbox.first["status"]
+  end
+
+  def test_runtime_cleanup_runs_once_without_masking_the_primary_error
+    declared = Mistri::Tool.define("declared", "Declared.") { "ok" }
+    extra = Mistri::Tool.define("extra", "Extra.") { "no" }
+    spec, store, = queue(tools: [declared])
+    cleanup_calls = 0
+    factory = lambda do |_owned|
+      Mistri::SubAgent::Runtime.new(
+        provider: fake({ text: "never" }), system: "Do the work.", tools: [declared, extra],
+        cleanup: lambda {
+          cleanup_calls += 1
+          raise "cleanup failed"
+        }
+      )
+    end
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: factory)
+    end
+
+    assert_match(/extra: extra/, error.message)
+    refute_match(/cleanup failed/, error.message)
+    assert_equal 1, cleanup_calls
+  end
+
+  def test_successful_runtime_cleanup_failure_is_visible_after_completion
+    spec, store, session = queue
+    factory = lambda do |_owned|
+      Mistri::SubAgent::Runtime.new(provider: fake({ text: "done" }),
+                                    system: "Do the work.",
+                                    cleanup: -> { raise "cleanup failed" })
+    end
+
+    error = assert_raises(RuntimeError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: factory)
+    end
+
+    assert_match(/cleanup failed/, error.message)
+    assert_equal :done, session.children.first.status
+    assert_equal "done", session.pending_inbox.first["status"]
+  end
+
+  def test_unknown_spec_versions_fail_closed
+    store = Mistri::Stores::Memory.new
+    future = valid_spec
+    future["spec_version"] = Mistri::SubAgent::DISPATCH_SPEC_VERSION + 1
+    child_session = Mistri::Session.new(store: store, id: future.fetch("session_id"))
+    child_session.append(Mistri::Child::DISPATCHED, "spec" => future)
+    provider = fake({ text: "never" })
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(future, provider: provider,
+                                              system: "Do the work.", tools: [], store: store)
+    end
+
+    assert_match(/unsupported dispatched child spec version/, error.message)
+    assert_empty provider.requests
+    terminal = child_session.entries.reverse.find do |entry|
+      entry["type"] == Mistri::Child::TERMINAL
+    end
+
+    assert_equal "failed", terminal["status"]
+  end
+
+  def test_reconstructed_approval_gates_are_rechecked
+    declared = Mistri::Tool.define("risky", "Declared without a gate.") { "ok" }
+    spec, store, = queue(tools: [declared])
+    gated = Mistri::Tool.define("risky", "Runtime gate.", needs_approval: true) { "no" }
+    provider = fake({ text: "never" })
+    runtime_factory = lambda do |_owned_spec|
+      Mistri::SubAgent::Runtime.new(provider: provider, system: "Do the work.", tools: [gated])
+    end
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.run_dispatched(spec, store: store, runtime_factory: runtime_factory)
+    end
+
+    assert_match(/approval-gated tools/, error.message)
+    assert_empty provider.requests
+  end
+
+  def test_a_finished_redelivery_does_not_construct_another_runtime
+    spec, store, = queue
+    provider = fake({ text: "done" })
+    Mistri::SubAgent.run_dispatched(spec, provider: provider, system: "Do the work.",
+                                          tools: [], store: store)
+    calls = 0
+    runtime_factory = lambda do |_owned_spec|
+      calls += 1
+      raise "must not construct"
+    end
+
+    result = Mistri::SubAgent.run_dispatched(spec, store: store,
+                                                   runtime_factory: runtime_factory)
+
+    assert_nil result
+    assert_equal 0, calls
+  end
+
+  def test_legacy_specs_with_workspace_remain_executable
+    store = Mistri::Stores::Memory.new
+    child_session = Mistri::Session.new(store: store)
+    child_session.append(Mistri::Child::DISPATCHED, {})
+    legacy = valid_spec.merge("session_id" => child_session.id, "workspace" => "own")
+    legacy.delete("spec_version")
+    provider = fake({ text: "legacy ran" })
+
+    result = Mistri::SubAgent.run_dispatched(legacy, provider: provider,
+                                                     system: "Do the work.", tools: [],
+                                                     store: store)
+
+    assert_predicate result, :completed?
+    child = Mistri::Child.new(name: "Raw", session_id: child_session.id, store: store)
+
+    assert_equal :done, child.status
+  end
+end

--- a/test/test_child_stop.rb
+++ b/test/test_child_stop.rb
@@ -211,6 +211,40 @@ class TestChildStop < Minitest::Test
     assert_equal 1, terminals.length
   end
 
+  def test_inline_stop_flag_cleanup_failure_still_writes_a_failed_terminal
+    broken = Class.new(Mistri::Locks::Memory) do
+      def clear_flag(key)
+        raise "stop flag cleanup failed" if key.start_with?("child-stop:")
+
+        super
+      end
+    end.new
+    Mistri.locks = broken
+    store = Mistri::Stores::Memory.new
+    child_provider = fake({ text: "Child answered." })
+    worker = Mistri::SubAgent.new(name: "worker", description: "Works.",
+                                  provider: child_provider)
+    parent_provider = fake(
+      { tool_calls: [{ name: "worker", arguments: { "task" => "work" } }] },
+      { text: "Parent recovered." }
+    )
+    session = Mistri::Session.new(store: store)
+
+    result = Mistri::Agent.new(provider: parent_provider, tools: [worker.tool],
+                               session: session).run("go")
+
+    assert_predicate result, :completed?
+    assert_equal 1, child_provider.requests.length
+    child = session.children.first
+
+    assert_equal :failed, child.status
+    assert_match(/stop flag cleanup failed/, child.error)
+    terminals = Mistri::Session.new(store: store, id: child.session_id).entries
+                               .select { |entry| entry["type"] == Mistri::Child::TERMINAL }
+
+    assert_equal 1, terminals.length
+  end
+
   def test_stopping_the_parent_stops_a_running_child_through_the_cascade
     store = Mistri::Stores::Memory.new
     parent_signal = Mistri::AbortSignal.new

--- a/test/test_child_stop.rb
+++ b/test/test_child_stop.rb
@@ -13,6 +13,30 @@ class TestChildStop < Minitest::Test
 
   def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
 
+  def blocking_link_store
+    Class.new do
+      attr_reader :entered, :continue
+
+      def initialize
+        @store = Mistri::Stores::Memory.new
+        @entered = Queue.new
+        @continue = Queue.new
+        @block = true
+      end
+
+      def append(id, entry)
+        @store.append(id, entry)
+        return unless @block && entry["type"] == "subagent"
+
+        @block = false
+        @entered << true
+        @continue.pop
+      end
+
+      def load(id) = @store.load(id)
+    end.new
+  end
+
   def test_derive_cascades_down_and_never_up
     parent = Mistri::AbortSignal.new
     child, _handle = parent.derive
@@ -82,8 +106,109 @@ class TestChildStop < Minitest::Test
 
     assert_match(/was stopped/, tool_message.text)
     assert_predicate tool_message, :tool_error?
+    assert_empty session.pending_inbox, "an inline stop must not invent a background report"
     refute Mistri.locks.flag?(Mistri::Child.stop_key(child.session_id)),
            "the stop flag clears when the child ends"
+  end
+
+  def test_stopping_an_inline_child_before_its_lease_prevents_execution
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = blocking_link_store
+    child_provider = fake({ text: "must not run" })
+    worker = Mistri::SubAgent.new(name: "worker", description: "Works.",
+                                  provider: child_provider)
+    parent_provider = fake(
+      { tool_calls: [{ name: "worker", arguments: { "task" => "work" } }] },
+      { text: "Parent continued." }
+    )
+    session = Mistri::Session.new(store: store)
+    result = nil
+    runner = Thread.new do
+      result = Mistri::Agent.new(provider: parent_provider, tools: [worker.tool],
+                                 session: session).run("go")
+    end
+    store.entered.pop
+    child = session.children.first
+
+    assert_equal :interrupted, child.status
+    assert child.stop
+    store.continue << true
+    runner.join
+
+    assert_predicate result, :completed?
+    assert_empty child_provider.requests
+    assert_equal :stopped, child.status
+    terminals = Mistri::Session.new(store: store, id: child.session_id).entries
+                               .select { |entry| entry["type"] == Mistri::Child::TERMINAL }
+
+    assert_equal 1, terminals.length
+    assert_empty session.pending_inbox
+  end
+
+  def test_inline_lease_setup_failure_still_writes_a_failed_terminal
+    broken = Class.new do
+      def held?(_key) = false
+      def acquire(*) = raise("lock backend down")
+      def clear_flag(_key) = nil
+    end.new
+    Mistri.locks = broken
+    store = Mistri::Stores::Memory.new
+    child_provider = fake({ text: "must not run" })
+    worker = Mistri::SubAgent.new(name: "worker", description: "Works.",
+                                  provider: child_provider)
+    parent_provider = fake(
+      { tool_calls: [{ name: "worker", arguments: { "task" => "work" } }] },
+      { text: "Parent recovered." }
+    )
+    session = Mistri::Session.new(store: store)
+
+    result = Mistri::Agent.new(provider: parent_provider, tools: [worker.tool],
+                               session: session).run("go")
+
+    assert_predicate result, :completed?
+    assert_empty child_provider.requests
+    child = session.children.first
+
+    assert_equal :failed, child.status
+    assert_match(/lock backend down/, child.error)
+    terminals = Mistri::Session.new(store: store, id: child.session_id).entries
+                               .select { |entry| entry["type"] == Mistri::Child::TERMINAL }
+
+    assert_equal 1, terminals.length
+  end
+
+  def test_inline_lease_cleanup_failure_still_writes_a_failed_terminal
+    broken = Class.new(Mistri::Locks::Memory) do
+      def release(key)
+        raise "lock release failed" if key.start_with?("child:")
+
+        super
+      end
+    end.new
+    Mistri.locks = broken
+    store = Mistri::Stores::Memory.new
+    child_provider = fake({ text: "Child answered." })
+    worker = Mistri::SubAgent.new(name: "worker", description: "Works.",
+                                  provider: child_provider)
+    parent_provider = fake(
+      { tool_calls: [{ name: "worker", arguments: { "task" => "work" } }] },
+      { text: "Parent recovered." }
+    )
+    session = Mistri::Session.new(store: store)
+
+    result = Mistri::Agent.new(provider: parent_provider, tools: [worker.tool],
+                               session: session).run("go")
+
+    assert_predicate result, :completed?
+    assert_equal 1, child_provider.requests.length
+    child = session.children.first
+
+    assert_equal :failed, child.status
+    assert_match(/lock release failed/, child.error)
+    terminals = Mistri::Session.new(store: store, id: child.session_id).entries
+                               .select { |entry| entry["type"] == Mistri::Child::TERMINAL }
+
+    assert_equal 1, terminals.length
   end
 
   def test_stopping_the_parent_stops_a_running_child_through_the_cascade

--- a/test/test_children.rb
+++ b/test/test_children.rb
@@ -50,26 +50,13 @@ class TestChildren < Minitest::Test
     assert_match(/no scripted turns/, terminal["error"])
   end
 
-  def test_a_child_that_fails_setup_still_ends_with_a_failed_terminal
-    store = Mistri::Stores::Memory.new
+  def test_a_duplicate_spawn_pool_fails_at_construction
     duplicate = Mistri::Tool.define("lookup", "Looks up.") { "42" }
-    # Two tools with one name make Agent.new itself raise, after the link
-    # entry exists but before the child ever runs.
-    spawn = Mistri::SubAgent.spawner(provider: fake, tools: [duplicate, duplicate])
-    parent = fake({ tool_calls: [{ name: "spawn_agent",
-                                   arguments: { "name" => "Basset", "task" => "go",
-                                                "instructions" => "You are a finder." } }] },
-                  { text: "Moving on." })
-    session = Mistri::Session.new(store:)
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.spawner(provider: fake, tools: [duplicate, duplicate])
+    end
 
-    Mistri::Agent.new(provider: parent, tools: [spawn], session:).run("go")
-
-    child = session.children.first
-
-    assert_equal :failed, child.status
-    terminal = Mistri::Session.new(store:, id: child.session_id).entries.last
-
-    assert_match(/duplicate tool names/, terminal["error"])
+    assert_match(/duplicate tool names/, error.message)
   end
 
   def test_status_derives_from_hand_written_entries

--- a/test/test_console.rb
+++ b/test/test_console.rb
@@ -13,6 +13,8 @@ class TestConsole < Minitest::Test
     Mistri::ToolContext.new(session: session, signal: nil, emit: nil, app: nil)
   end
 
+  def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
+
   def link(parent, store, name)
     child = Mistri::Session.new(store:)
     parent.append("subagent", "name" => name, "session_id" => child.id)
@@ -129,6 +131,34 @@ class TestConsole < Minitest::Test
                             .call({ "agent" => "Husky", "wait" => true }, context_for(parent))
 
     assert_match(/still running/, output)
+  end
+
+  def test_read_agent_waits_across_an_interrupted_workers_retry
+    Mistri.locks = Mistri::Locks::Memory.new
+    store = Mistri::Stores::Memory.new
+    parent = Mistri::Session.new(store: store)
+    child = link(parent, store, "Husky")
+    child.append(Mistri::Child::DISPATCHED, {})
+    child.append(Mistri::Child::STARTED, {})
+    spec = { "name" => "Husky", "session_id" => child.id,
+             "parent_session_id" => parent.id, "task" => "recover",
+             "tool_names" => [], "model" => nil }
+
+    assert_equal :interrupted, parent.children.first.status
+
+    runner = Thread.new do
+      sleep 0.05
+      Mistri::SubAgent.run_dispatched(
+        spec, provider: fake({ text: "Recovered." }), system: "Recover.", tools: [], store: store
+      )
+    end
+    output = Mistri::Console.read_agent(timeout: 1, poll: 0.01)
+                            .call({ "agent" => "Husky", "wait" => true },
+                                  context_for(parent))
+    runner.join
+
+    assert_match(/Husky done/, output)
+    assert_match(/Recovered/, output)
   end
 
   def test_steer_agent_queues_on_a_running_worker_and_refuses_a_finished_one

--- a/test/test_console.rb
+++ b/test/test_console.rb
@@ -196,6 +196,28 @@ class TestConsole < Minitest::Test
     assert_match(/already done/, already)
   end
 
+  def test_stop_agent_reports_a_worker_that_finishes_during_the_request
+    finishing_locks = Class.new(Mistri::Locks::Memory) do
+      attr_writer :on_stop
+
+      def set_flag(key, ttl: 300)
+        @on_stop.call
+        super
+      end
+    end.new
+    Mistri.locks = finishing_locks
+    _store, parent, _done, running = setup_family
+    Mistri.locks.acquire(Mistri::Child.lease_key(running.id), ttl: 60)
+    finishing_locks.on_stop = lambda do
+      running.append(Mistri::Child::TERMINAL, "status" => "done", "report" => "finished")
+    end
+
+    output = Mistri::Console.stop_agent.call({ "agent" => "Husky" }, context_for(parent))
+
+    assert_match(/finished as done before the stop took effect/, output)
+    assert_equal :done, parent.children.last.status
+  end
+
   def test_stop_agent_without_an_adapter_answers_in_band
     _store, parent, _done, _running = setup_family
     output = Mistri::Console.stop_agent.call({ "agent" => "Husky" }, context_for(parent))

--- a/test/test_errors.rb
+++ b/test/test_errors.rb
@@ -4,7 +4,8 @@ require_relative "test_helper"
 
 class TestErrors < Minitest::Test
   def test_every_error_rescues_as_mistri_error
-    [Mistri::ConfigurationError, Mistri::ProviderError, Mistri::AuthenticationError,
+    [Mistri::ConfigurationError, Mistri::DispatchGrantError,
+     Mistri::ProviderError, Mistri::AuthenticationError,
      Mistri::RateLimitError, Mistri::OverloadedError, Mistri::ServerError,
      Mistri::ResponseTooLargeError, Mistri::ResponseTooComplexError,
      Mistri::AmbiguousDeliveryError,

--- a/test/test_report_delivery.rb
+++ b/test/test_report_delivery.rb
@@ -2,16 +2,23 @@
 
 require_relative "test_helper"
 
-# Report delivery: a background child's terminal outcome reaches its parent
-# exactly once (a typed inbox entry that folds like a steer, plus an event
-# that closes the child's lane), and the lease fences dispatched runs so
-# queue retries heal crashes without ever double-running a child.
+# Report delivery: a background child's terminal outcome reaches its parent as
+# a typed inbox entry that folds like a steer, plus an event that closes the
+# child's lane. Sequential retries deduplicate; a configured lease suppresses
+# a concurrent live delivery while queue retries can heal a crashed child.
 class TestReportDelivery < Minitest::Test
   def teardown
     Mistri.locks = nil
   end
 
   def fake(*turns) = Mistri::Providers::Fake.new(turns: turns)
+
+  def runtime_factory(provider, tools: [], system: nil)
+    lambda do |spec|
+      Mistri::SubAgent::Runtime.new(provider: provider, system: system || spec["instructions"],
+                                    tools: tools)
+    end
+  end
 
   def spawn_call(arguments)
     fake({ tool_calls: [{ name: "spawn_agent", arguments: arguments }] },
@@ -38,7 +45,10 @@ class TestReportDelivery < Minitest::Test
   # deterministic and the spec is exactly what a queue would carry.
   def dispatch(child_fake, name: "Basset", tools: [])
     dropper = drop_dispatcher
-    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: tools, dispatcher: dropper)
+    spawn = Mistri::SubAgent.spawner(
+      provider: child_fake, tools: tools, dispatcher: dropper,
+      runtime_factory: runtime_factory(child_fake, tools: tools)
+    )
     parent = spawn_call({ "name" => name, "task" => "t", "instructions" => "You help.",
                           "mode" => "background" })
     store = Mistri::Stores::Memory.new
@@ -137,7 +147,8 @@ class TestReportDelivery < Minitest::Test
     end
     child_fake = fake({ tool_calls: [{ name: "slow", arguments: {} }] }, { text: "never" })
     spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [slow],
-                                     dispatcher: Mistri::Dispatchers::Thread.new)
+                                     dispatcher: Mistri::Dispatchers::Thread.new,
+                                     runtime_factory: runtime_factory(child_fake, tools: [slow]))
     parent = spawn_call({ "name" => "Pointer", "task" => "work",
                           "instructions" => "Use slow.", "mode" => "background" })
     session = Mistri::Session.new(store:)
@@ -154,7 +165,7 @@ class TestReportDelivery < Minitest::Test
     assert_nil report["report"]
   end
 
-  def test_delivery_is_idempotent_and_labels_unknown_statuses_honestly
+  def test_sequential_redelivery_is_deduplicated_and_labels_unknown_statuses_honestly
     session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
 
     first = session.deliver_report(name: "Corgi", session_id: "abc", status: "done", text: "42")

--- a/test/test_spawn_types.rb
+++ b/test/test_spawn_types.rb
@@ -132,6 +132,24 @@ class TestSpawnTypes < Minitest::Test
     assert_match(/duplicate model names/, error.message)
   end
 
+  def test_invalid_capability_registries_fail_at_construction
+    recursive = Mistri::Tool.define("spawn_agent", "Must not recurse.") { "never" }
+    cases = [
+      [{ tools: Object.new }, /pool must contain only Mistri::Tool instances/],
+      [{ tools: [recursive] }, /spawn tool never goes in its own pool/],
+      [{ models: Object.new }, /model allowlist must contain non-empty strings/],
+      [{ models: [""] }, /model allowlist must contain non-empty strings/]
+    ]
+
+    cases.each do |options, message|
+      error = assert_raises(Mistri::ConfigurationError) do
+        Mistri::SubAgent.spawner(provider: fake, **options)
+      end
+
+      assert_match message, error.message
+    end
+  end
+
   def test_a_general_purpose_worker_without_instructions_answers_in_band
     spawn = Mistri::SubAgent.spawner(provider: fake)
     parent_fake = spawn_call({ "name" => "Husky", "task" => "do something" })

--- a/test/test_spawn_types.rb
+++ b/test/test_spawn_types.rb
@@ -47,6 +47,91 @@ class TestSpawnTypes < Minitest::Test
     assert_equal :done, session.children.first.status
   end
 
+  def test_an_empty_typed_definition_grants_no_pool_tools
+    unused = Mistri::Tool.define("danger", "Must remain unavailable.") { "ran" }
+    definition = Mistri::Definition.new(name: "observer", config: {}, body: "Observe only.")
+    child_fake = fake({ text: "Observed." })
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [unused],
+                                     types: { "observer" => definition })
+    parent_fake = spawn_call({ "name" => "Corgi", "type" => "observer", "task" => "look" })
+
+    Mistri::Agent.new(provider: parent_fake, tools: [spawn]).run("go")
+
+    assert_empty child_fake.requests.first[:options][:tools]
+  end
+
+  def test_an_explicit_empty_list_overrides_typed_defaults
+    child_fake = fake({ text: "No tools needed." })
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [archive],
+                                     types: { "researcher" => researcher_type })
+    parent_fake = spawn_call({ "name" => "Corgi", "type" => "researcher", "task" => "think",
+                               "tools" => [] })
+
+    Mistri::Agent.new(provider: parent_fake, tools: [spawn]).run("go")
+
+    assert_empty child_fake.requests.first[:options][:tools]
+  end
+
+  def test_an_explicit_empty_list_grants_a_general_worker_no_tools
+    child_fake = fake({ text: "No tools needed." })
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [archive])
+    parent_fake = spawn_call({ "name" => "Corgi", "task" => "think",
+                               "instructions" => "Think only.", "tools" => [] })
+
+    Mistri::Agent.new(provider: parent_fake, tools: [spawn]).run("go")
+
+    assert_empty child_fake.requests.first[:options][:tools]
+  end
+
+  def test_spawner_owns_its_tool_pool_and_model_allowlist
+    declared = archive
+    pool = [declared]
+    model_name = +"host-model-v1"
+    models = [model_name]
+    child_fake = fake({ text: "done" })
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: pool, models: models)
+
+    pool.clear
+    models.clear
+    model_name.replace("tampered")
+    parent_fake = spawn_call({ "name" => "Corgi", "task" => "work",
+                               "instructions" => "Use the declared tools." })
+
+    Mistri::Agent.new(provider: parent_fake, tools: [spawn]).run("go")
+
+    sent = child_fake.requests.first[:options][:tools].map { |tool| tool.fetch(:name) }
+
+    assert_equal ["archive"], sent
+    assert_equal ["host-model-v1"],
+                 spawn.input_schema.dig("properties", "model", "enum")
+  end
+
+  def test_duplicate_model_selected_tools_are_refused_before_a_child_exists
+    child_fake = fake({ text: "never" })
+    spawn = Mistri::SubAgent.spawner(provider: child_fake, tools: [archive])
+    parent_fake = spawn_call({ "name" => "Corgi", "task" => "work",
+                               "instructions" => "Work.",
+                               "tools" => %w[archive archive] })
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+
+    Mistri::Agent.new(provider: parent_fake, tools: [spawn], session: session).run("go")
+
+    result = session.messages.select(&:tool?).last
+
+    assert_predicate result, :tool_error?
+    assert_match(/duplicate/, result.text)
+    assert_empty session.children
+    assert_empty child_fake.requests
+  end
+
+  def test_duplicate_model_allowlist_entries_fail_at_construction
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::SubAgent.spawner(provider: fake, models: %w[gpt-5-nano gpt-5-nano])
+    end
+
+    assert_match(/duplicate model names/, error.message)
+  end
+
   def test_a_general_purpose_worker_without_instructions_answers_in_band
     spawn = Mistri::SubAgent.spawner(provider: fake)
     parent_fake = spawn_call({ "name" => "Husky", "task" => "do something" })

--- a/test/test_sub_agent.rb
+++ b/test/test_sub_agent.rb
@@ -117,6 +117,46 @@ class TestSubAgent < Minitest::Test
     end
   end
 
+  def test_child_agent_options_cannot_replace_lifecycle_keywords
+    fixed = %i[session task signal emit child started label lease]
+    spawned = %i[session system schema task signal emit child started label lease]
+    cases = fixed.map do |name|
+      [name, lambda do
+        Mistri::SubAgent.new(name: "a", description: "d", provider: fake,
+                             **{ name => Object.new })
+      end]
+    end
+    cases.concat(spawned.map do |name|
+      [name, -> { Mistri::SubAgent.spawner(provider: fake, **{ name => Object.new }) }]
+    end)
+
+    cases.each do |name, build|
+      error = assert_raises(Mistri::ConfigurationError, &build)
+      assert_match(/unsupported sub-agent options:.*#{name}/, error.message)
+    end
+  end
+
+  def test_child_agent_context_reaches_tools_without_replacing_the_parent_context
+    observed = nil
+    inspect_context = Mistri::Tool.define(
+      "inspect_context", "Reads app context."
+    ) do |_args, context|
+      observed = context.app.fetch(:actor)
+      "read it"
+    end
+    child = fake({ tool_calls: [{ name: "inspect_context", arguments: {} }] },
+                 { text: "done" })
+    worker = Mistri::SubAgent.new(name: "worker", description: "Works.", provider: child,
+                                  tools: [inspect_context], context: { actor: "host" })
+    parent = fake({ tool_calls: [{ name: "worker", arguments: { "task" => "inspect" } }] },
+                  { text: "complete" })
+
+    result = Mistri::Agent.new(provider: parent, tools: [worker.tool]).run("go")
+
+    assert_predicate result, :completed?
+    assert_equal "host", observed
+  end
+
   def test_a_runtime_suspended_child_is_denied_and_reported
     risky = Mistri::Tool.define("pay", "Pays.",
                                 needs_approval: ->(args) { args["amount"].to_i > 10 },


### PR DESCRIPTION
## Summary

Background dispatch now crosses a versioned, data-only capability boundary:

- persist a bounded canonical dispatch spec before enqueueing and compare the complete queue copy on delivery
- require a worker-local `runtime_factory:` that returns `Mistri::SubAgent::Runtime`
- verify the reconstructed provider model and exact unique tool grant before any provider call or tool side effect
- keep the child lease through runtime construction, execution, cleanup, terminal persistence, and parent reporting
- make queued/interrupted cancellation durable and reconcile transient report failures
- remove the model-facing `workspace` selector, which never proved resource isolation
- retain the compatible direct `run_dispatched` form and legacy unversioned 0.5 payload support

A mismatched versioned queue payload raises the new public `Mistri::DispatchGrantError`. It is a poison-delivery signal for the host to discard and alert on, without mutating the legitimate child.

## Why

The old in-process runner closed over live provider, Tool, Agent-option, and workspace state. That shape worked for a thread, but it was not a truthful durable-queue contract and could not prove that a worker reconstructed the capability set the host granted at spawn time.

The design follows the durable boundary established by [Sidekiq's JSON job format](https://github.com/sidekiq/sidekiq/wiki/Job-Format), [Pydantic AI's exclusion of live capability objects from serialized Temporal context](https://pydantic.dev/docs/ai/api/pydantic-ai/durable_exec/), and [Temporal Ruby's worker-side activity construction](https://ruby.temporal.io/), then adds Mistri-specific stored-grant binding and provider-neutral model/tool verification.

## Public contract

- `dispatcher:` now requires `runtime_factory:`.
- The factory receives one immutable JSON spec and constructs live dependencies inside the worker.
- Runtime Agent options are allowlisted so they cannot replace Session, task, signal, event, provider, or tool lifecycle state.
- Background skills are rejected because they would add an undeclared `read_skill` tool.
- `tools: []` grants no tools; omission keeps the general pool or typed defaults.
- Factory construction errors remain queue-retryable by default. `retry_factory_errors: false` terminalizes the final attempt before re-raising.
- The lease remains documented as best-effort duplicate suppression, not an exactly-once fence.
- Migration steps and legacy limitations are explicit in `UPGRADING.md` and the sub-agent guide.

There are no new runtime dependencies. Dispatch adds one bounded spec ownership/comparison and one linear capability-name check per child, outside provider streaming paths.

## Validation

- Hermetic suite: 961 runs, 5,178 assertions, 0 failures/errors
- Coverage: 98.43% line, 88.67% branch; every added executable production line is exercised
- RuboCop: 191 files, no offenses
- Installed-gem isolation smoke: 17 assertions, green
- GitHub Actions: Ruby 3.2, 3.3, 3.4, head, lint, Codecov project, and Codecov patch checks all green
- Ruby 3.2 scheduling seam: 20 repeated focused runs plus the complete suite
- Live background matrix: Anthropic `claude-haiku-4-5-20251001`, OpenAI `gpt-5.6-terra`, and Gemini `gemini-2.5-flash`; 6 runs, 48 assertions
- Independent blocker reviews covered concurrency/lifecycle ordering, cancellation, retry ownership, report delivery, compatibility, documentation truthfulness, package contents, and coverage-contract quality

The live harness reconstructs a fresh provider and Tool inside each worker and exercises receipt, wait, autonomous report delivery, cleanup, and durable terminal state.