### PR TITLE
Mark document tool failures explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Built-in document reads, searches, and edits now return an explicitly failed
+  `ToolResult` when the document is missing or a requested replacement cannot
+  be applied. The same actionable text still reaches the model, but lifecycle
+  events, persisted tool messages, and provider-supported error signaling no
+  longer misclassify an expected document-tool failure as success. Tool names,
+  schemas, and successful results are unchanged.
 - Background dispatch now crosses a versioned, deeply owned JSON capability
   boundary instead of closing over the spawn-time provider, Tool objects, Agent
   options, and workspace state. Every `dispatcher:` requires a host

--- a/lib/mistri/tools.rb
+++ b/lib/mistri/tools.rb
@@ -23,7 +23,12 @@ module Mistri
 
     def with_document(workspace, args)
       content = workspace.read(args["path"])
-      return "No document at #{args["path"].inspect}. Use list_files to see paths." if content.nil?
+      if content.nil?
+        return ToolResult.new(
+          content: "No document at #{args["path"].inspect}. Use list_files to see paths.",
+          error: true
+        )
+      end
 
       yield content
     end

--- a/lib/mistri/tools/edit_file.rb
+++ b/lib/mistri/tools/edit_file.rb
@@ -30,7 +30,7 @@ module Mistri
           "Replaced #{result.count} occurrence(s) in #{args["path"]}"
         end
       rescue EditError => e
-        "edit_file failed: #{e.message}"
+        ToolResult.new(content: "edit_file failed: #{e.message}", error: true)
       end
     end
   end

--- a/test/integration/test_documents.rb
+++ b/test/integration/test_documents.rb
@@ -28,4 +28,52 @@ class TestDocumentsIntegration < Minitest::Test
     refute_includes document, "Placeholder Headline"
     assert_includes document, '<p class="tagline">Ship faster.</p>', "collateral damage"
   end
+
+  Integration.scenario(self, :repairs_a_stale_document_edit) do |model|
+    headline = Integration.codename
+    document = +<<~HTML
+      <main>
+        <h1>Placeholder Headline</h1>
+        <p>Keep this paragraph.</p>
+      </main>
+    HTML
+    mutex = Mutex.new
+    write = ->(text) { mutex.synchronize { document.replace(text) } }
+    read_workspace = Mistri::Workspace::Single.new(
+      path: "page.html",
+      read: -> { mutex.synchronize { document.dup } },
+      write:
+    )
+    first_edit = true
+    edit_workspace = Mistri::Workspace::Single.new(
+      path: "page.html",
+      read: lambda {
+        mutex.synchronize do
+          if first_edit
+            first_edit = false
+            document.sub!("Placeholder Headline", "Concurrent human draft")
+            document.sub!("</main>", "  <aside data-human=\"keep\">Preserve me.</aside>\n</main>")
+          end
+          document.dup
+        end
+      },
+      write:
+    )
+    agent = Mistri::Agent.new(
+      provider: Mistri.provider(model),
+      tools: [Mistri::Tools.read_file(read_workspace), Mistri::Tools.edit_file(edit_workspace)],
+      max_concurrency: 1,
+      system: "Read page.html before editing it. Use edit_file, preserve every other element, " \
+              "and recover from a stale edit by reading the current document."
+    )
+
+    result = agent.run("Change the h1 headline to exactly: #{headline}")
+
+    assert_predicate result, :completed?
+    assert(agent.session.messages.any? { |message| message.tool? && message.tool_error? },
+           "the model never exercised the failed-edit repair path")
+    assert Integration.saw?(document, headline), "the repaired edit never landed"
+    assert_includes document, 'data-human="keep"', "the concurrent edit was overwritten"
+    assert_includes document, "Keep this paragraph.", "unrelated content changed"
+  end
 end

--- a/test/test_file_tools.rb
+++ b/test/test_file_tools.rb
@@ -53,8 +53,9 @@ class TestFileTools < Minitest::Test
                                        "old_string" => "<h1>Welcom</h1>",
                                        "new_string" => "x" })
 
-    assert_match(/\Aedit_file failed:/, reply)
-    assert_match(/Closest region/, reply)
+    assert_predicate reply, :error?
+    assert_match(/\Aedit_file failed:/, reply.content)
+    assert_match(/Closest region/, reply.content)
   end
 
   def test_find_in_file_returns_numbered_matches_with_context
@@ -74,9 +75,48 @@ class TestFileTools < Minitest::Test
     assert_equal "hello", @workspace.read("notes/a.txt")
   end
 
-  def test_a_missing_document_reads_as_guidance_not_an_error
+  def test_a_missing_document_is_an_actionable_error
     reply = @tools["read_file"].call({ "path" => "nope.html" })
 
-    assert_match(/No document at "nope.html"/, reply)
+    assert_predicate reply, :error?
+    assert_match(/No document at "nope.html"/, reply.content)
+  end
+
+  def test_a_search_for_a_missing_document_is_an_actionable_error
+    reply = @tools["find_in_file"].call({ "path" => "nope.html", "query" => "title" })
+
+    assert_predicate reply, :error?
+    assert_match(/No document at "nope.html"/, reply.content)
+  end
+
+  def test_an_edit_to_a_missing_document_is_an_actionable_error
+    reply = @tools["edit_file"].call({ "path" => "nope.html",
+                                       "old_string" => "old", "new_string" => "new" })
+
+    assert_predicate reply, :error?
+    assert_match(/No document at "nope.html"/, reply.content)
+  end
+
+  def test_built_in_edit_failures_stay_typed_through_the_agent
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "edit_file",
+                                                              arguments: {
+                                                                path: "hero.html",
+                                                                old_string: "missing",
+                                                                new_string: "new"
+                                                              } }] },
+                                             { text: "recovered" }
+                                           ])
+    events = []
+    agent = Mistri::Agent.new(provider:, tools: @tools.values)
+
+    agent.run("edit it") { |event| events << event }
+
+    event = events.find { |item| item.type == :tool_result }
+    persisted = agent.session.messages.find(&:tool?)
+
+    assert event.tool_error
+    assert_predicate persisted, :tool_error?
+    assert_match(/edit_file failed:/, persisted.text)
   end
 end


### PR DESCRIPTION
## Summary

- return `ToolResult(error: true)` when a built-in document read, search, or edit cannot operate
- preserve the existing actionable error text, tool names, schemas, and successful results
- add a deterministic live repair scenario where a document changes after the model reads it

## Why

Missing documents and rejected replacements already returned useful guidance in band, but they were recorded and emitted as successful tool results. That made the model-facing text disagree with the lifecycle, persisted session, and provider-supported error signal.

This PR uses the structured result contract already owned by the executor. It intentionally does not redesign the editing schema or add workspace concurrency primitives; optimistic compare-and-write will follow as a separate storage-contract change.

## Validation

- `bundle exec rake test`: 964 runs, 5,195 assertions, 0 failures, 35 skips
- `bundle exec rubocop`: 191 files, no offenses
- live stale-edit repair on `claude-haiku-4-5-20251001`, `gpt-5.6-terra`, and `gemini-2.5-flash`: 3 runs, 24 assertions, 0 failures
- existing live document-edit scenario passed on the same three providers
- two independent adversarial reviews completed; the one test-determinism finding was fixed and re-reviewed

Successful calls take the identical path. Only an expected failure allocates the `ToolResult` that carries its error bit.