### PR TITLE
Make approval decisions single-assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Approval decisions now behave as a write-once register over the Session
+  store's durable order. The first valid decision is authoritative; repeating
+  that value is idempotent, while a conflicting caller receives
+  `Mistri::ConfigurationError`. Concurrent stale writers may both reach append,
+  but every later well-formed decision for that approval request is an inert
+  losing occurrence, including one that lands after the approved handler has
+  already returned. It cannot revoke the winner, alter settlement, or
+  permanently poison `open_approvals`, `resume`, replay, or compaction. The first
+  note remains authoritative.
+  Malformed decisions, decisions without a matching request, duplicate
+  requests, and ambiguous legacy reused-call approvals still fail closed or
+  interrupt conservatively. A newly appended decision adds one linear
+  control-state re-read to tell a racing loser that it lost; already-visible
+  idempotent retries do not append. No provider streaming path changes.
 - Anchored `edit_file` changes now compose safely with concurrent writers when
   their Workspace advertises atomic conditional writes. The new optional
   contract is `atomic_writes?`, `snapshot(path)`, and
@@ -116,9 +130,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   approval stores the reviewed prepared call plus an explicit provenance
   marker. Resume verifies pairing metadata and revalidates the exact approved
   arguments without rerunning the normalizer. Requests must follow the exact
-  assistant call, decisions must follow one request and carry an exact boolean,
-  and duplicate or late control records fail closed. Legacy requests remain
-  valid only when they exactly mirror the source call.
+  assistant call, and decisions must follow one request and carry an exact
+  boolean. Duplicate requests and malformed or mismatched controls fail closed.
+  The first valid durable decision wins; later well-formed decisions for that
+  approval request are inert. Legacy requests remain valid only when they
+  exactly mirror the source call.
   Persisted tool results require one prior call with the exact name, settle in
   assistant-call order within each direct or approval phase, and cannot cross
   an unresolved approval; compaction may neither hide an open approval nor

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,9 +17,9 @@ Gemini providers preserve ordinary 0.5 sessions, including the repeated
 occurrence settled. There is no blanket session rewrite step.
 
 Hosts that used implicit tool schemas, mutated arguments, supplied custom
-providers, dispatched background children, generated MCP OAuth models, stored
-sessions in MySQL, or configured cost budgets need to review the sections
-below.
+providers or Session stores, dispatched background children, generated MCP
+OAuth models, stored sessions in MySQL, or configured cost budgets need to
+review the sections below.
 
 ### Checklist
 
@@ -31,6 +31,10 @@ below.
       structurally.
 - [ ] Ensure at most one `run` or `resume` is active per Session across all
       processes.
+- [ ] Treat each approval as single-assignment; resolve quorum or multi-reviewer
+      policy in the host before calling `approve` or `deny`.
+- [ ] Verify every successful custom Session-store append is visible to later
+      loads in the same stable per-session order.
 - [ ] Audit custom provider tool-call IDs, names, arguments, and metadata.
 - [ ] Widen Active Record session payloads to LONGTEXT on MySQL or Trilogy.
 - [ ] Update generated MCP OAuth models to persist issuer and share egress
@@ -344,6 +348,27 @@ If an old custom log contains malformed IDs that cannot be paired safely, keep
 the old application version available long enough to complete or retire that
 session according to host policy. Do not invent replacement IDs in replay; they
 would corrupt tool-result correlation.
+
+## Approval decisions are single-assignment
+
+The first valid approval decision in the Session store's durable order is
+final. Repeating the same `approve` or `deny` call is idempotent and does not add
+another entry once the winner is visible. The first note also wins. A later
+conflicting call raises `Mistri::ConfigurationError`; it cannot revoke the
+winner.
+
+Two callers can still read the parked request before either appends. Both
+attempts may therefore appear in the raw append-only log. Mistri re-reads the
+ordered history after append so the winner returns normally and a conflicting
+loser raises. Losing entries are validated but inert, including a stale loser
+that arrives after the tool result. They no longer make the Session require a
+repair step.
+
+This is single-assignment, not quorum. If two people must agree, or a denial
+must outrank an approval, implement that policy transactionally in the host and
+call Session only after the host has one final decision. A custom Session store
+must make a successful append visible to subsequent loads while preserving its
+stable total order.
 
 ## Session stores
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -48,11 +48,12 @@ append(session_id, entry_hash) # append one JSON-shaped entry
 load(session_id)               # return entries in append order
 ```
 
-The store must preserve each append as one entry and provide a total order per
-session. Values returned by `load` must not let caller mutation rewrite durable
-history: return fresh decoded copies or deeply immutable snapshots. Mistri does
-not rely on Ruby object identity. `Session#append` normalizes entries through
-JSON, so store implementations see string keys and JSON values.
+The store must preserve each append as one entry, provide a stable total order
+per session, and make a successful append visible to subsequent loads. Values
+returned by `load` must not let caller mutation rewrite durable history: return
+fresh decoded copies or deeply immutable snapshots. Mistri does not rely on
+Ruby object identity. `Session#append` normalizes entries through JSON, so store
+implementations see string keys and JSON values.
 
 Built-in stores are:
 
@@ -169,7 +170,18 @@ schema, and runs `before_tool` again. It does not renormalize or reevaluate the
 approval predicate.
 
 `Session#open_approvals` derives every still-open call and its decision from the
-log. Duplicate, late, malformed, or mismatched control entries fail closed.
+log. A decision is single-assignment: the first valid decision in durable store
+order wins, repeating that winning value is idempotent, and a conflicting caller
+receives `Mistri::ConfigurationError`. Concurrent losing attempts can remain in
+the raw append-only log, but they are inert and cannot revoke the winner or
+corrupt the Session. The first note wins. Duplicate requests and malformed,
+orphaned, or mismatched controls still fail closed.
+
+Mistri does not implement quorum or denial precedence. Resolve multi-reviewer
+policy in the host before recording its one final Session decision. A host that
+must prevent losing attempts from reaching the raw log also needs to serialize
+its decision endpoint; the two-method store contract reconciles concurrent
+appends rather than conditionally preventing them.
 
 Denial is returned to the model as an expected result so it can choose another
 path. It is not marked as a tool execution error.

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -269,7 +269,7 @@ module Mistri
       interrupt_ambiguous_reused_approvals!(states)
       approvals = open_approval_states(states)
       validate_compaction!(audit, approvals, latest_compaction)
-      { tool_call_ids: reserved, approvals: }
+      { tool_call_ids: reserved, approvals:, call_states: calls }
     end
 
     # Control entries can authorize side effects, so every message in the
@@ -425,26 +425,19 @@ module Mistri
       problem = required_string_problem(id, "approval decision call IDs")
       raise ConfigurationError, "session contains #{problem}" if problem
 
+      unless entry["approved"].equal?(true) || entry["approved"].equal?(false)
+        raise ConfigurationError, "session contains an approval decision whose approved " \
+                                  "value is not true or false"
+      end
+
       state = calls[id]
       unless state && state[:approval]
         raise ConfigurationError, "session contains an approval decision without a prior " \
                                   "matching approval request"
       end
-      if state[:status] == :answered
-        raise ConfigurationError, "session contains an approval decision for an already " \
-                                  "answered tool call"
-      end
-      if state[:status] == :decided
-        raise ConfigurationError, "session contains a duplicate approval decision"
-      end
-      unless state[:status] == :approval_requested
-        raise ConfigurationError, "session contains an approval decision without a prior " \
-                                  "matching approval request"
-      end
-      unless entry["approved"].equal?(true) || entry["approved"].equal?(false)
-        raise ConfigurationError, "session contains an approval decision whose approved " \
-                                  "value is not true or false"
-      end
+      # Store order is the write-once register. A stale loser can append after
+      # execution, so it must not revoke the winner or corrupt the real result.
+      return if state[:approval][:decision]
 
       state[:approval][:decision] = entry
       state[:status] = :decided
@@ -709,15 +702,39 @@ module Mistri
 
     def decide(call_id, approved:, note:)
       open = open_approvals.find { |approval| approval[:call].id == call_id }
-      raise ConfigurationError, "no open approval for #{call_id.inspect}" unless open
+      unless open
+        winner = recorded_approval_decision(call_id)
+        return nil if winner && winner["approved"] == approved
+        if winner
+          raise ConfigurationError, "approval for #{call_id.inspect} has already been decided"
+        end
+
+        raise ConfigurationError, "no open approval for #{call_id.inspect}"
+      end
 
       if open[:decision]
+        return nil if open[:decision]["approved"] == approved
+
         raise ConfigurationError, "approval for #{call_id.inspect} has already been decided"
       end
 
       entry = { "call_id" => call_id, "approved" => approved }
       entry["note"] = note if note
       append("approval_decision", entry)
+
+      # The two-method Store contract cannot combine the precheck and append.
+      # Re-read its total order so a racing conflicting caller learns it lost.
+      winner = recorded_approval_decision(call_id)
+      return nil if winner && winner["approved"] == approved
+
+      raise ConfigurationError, "approval for #{call_id.inspect} has already been decided"
+    end
+
+    def recorded_approval_decision(call_id)
+      state = audit_history(entries).fetch(:call_states)[call_id]
+      return nil if state&.fetch(:ambiguous_approval, false)
+
+      state&.dig(:approval, :decision)
     end
 
     def own_json(value)

--- a/test/test_approval_decision_races.rb
+++ b/test/test_approval_decision_races.rb
@@ -1,0 +1,285 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Approval decisions are a write-once register over the store's durable order.
+class TestApprovalDecisionRaces < Minitest::Test
+  class RacingStore
+    def initialize
+      @store = Mistri::Stores::Memory.new
+      @barrier_mutex = Mutex.new
+      @barrier_cv = ConditionVariable.new
+      @read_barrier = nil
+      @gate_mutex = Mutex.new
+      @decision_gate = nil
+    end
+
+    def append(id, entry)
+      gate = gated_decision(entry)
+      if gate
+        gate.fetch(:waiting) << true
+        gate.fetch(:release).pop
+      end
+      @store.append(id, entry)
+    end
+
+    def load(id)
+      snapshot = @store.load(id)
+      wait_at_read_barrier
+      snapshot
+    end
+
+    def race_next_loads(count)
+      @barrier_mutex.synchronize do
+        raise "read barrier is already active" if @read_barrier
+
+        @read_barrier = { remaining: count }
+      end
+    end
+
+    def pause_next_decision(approved)
+      gate = { approved:, waiting: Queue.new, release: Queue.new }
+      @gate_mutex.synchronize do
+        raise "decision gate is already active" if @decision_gate
+
+        @decision_gate = gate
+      end
+      gate
+    end
+
+    private
+
+    def gated_decision(entry)
+      @gate_mutex.synchronize do
+        gate = @decision_gate
+        return unless gate && entry["type"] == "approval_decision"
+        return unless entry["approved"] == gate.fetch(:approved)
+
+        @decision_gate = nil
+        gate
+      end
+    end
+
+    def wait_at_read_barrier
+      @barrier_mutex.synchronize do
+        barrier = @read_barrier
+        return unless barrier
+
+        barrier[:remaining] -= 1
+        if barrier[:remaining].zero?
+          @read_barrier = nil
+          @barrier_cv.broadcast
+        else
+          @barrier_cv.wait(@barrier_mutex) while @read_barrier.equal?(barrier)
+        end
+      end
+    end
+  end
+
+  def test_concurrent_agreement_is_idempotent_and_executes_once
+    [true, false].each do |approved|
+      store = RacingStore.new
+      agent, call, writes = parked_agent(store)
+      store.race_next_loads(2)
+      action = approved ? :approve : :deny
+
+      outcomes = concurrently(
+        -> { fresh_session(agent).public_send(action, call.id, note: "operator a") },
+        -> { fresh_session(agent).public_send(action, call.id, note: "operator b") }
+      )
+
+      assert_equal(2, outcomes.count { |status, _| status == :ok }, action.to_s)
+      decisions = approval_decisions(agent.session)
+
+      assert_equal 2, decisions.length, "both stale writers reached append"
+      durable = agent.session.open_approvals.fetch(0).fetch(:decision)
+
+      assert_equal approved, durable["approved"]
+      assert_equal decisions.first["note"], durable["note"],
+                   "the first note remains authoritative"
+
+      result = agent.resume
+
+      assert_predicate result, :completed?
+      assert_equal(approved ? 1 : 0, writes.length)
+      assert_empty agent.session.open_approvals
+    end
+  end
+
+  def test_concurrent_conflict_reports_the_loser_and_follows_durable_order
+    assert_conflict_follows(true)
+    assert_conflict_follows(false)
+  end
+
+  def test_a_stale_conflict_after_execution_cannot_poison_the_session
+    store = RacingStore.new
+    agent, call, writes = parked_agent(store)
+    gate = store.pause_next_decision(false)
+    stale = Thread.new { capture { fresh_session(agent).deny(call.id, note: "late") } }
+    gate.fetch(:waiting).pop
+
+    approve_and_resume(agent, call, writes)
+
+    gate.fetch(:release) << true
+    status, error = stale.value
+
+    assert_equal :error, status
+    assert_instance_of Mistri::ConfigurationError, error
+    assert_settled_session_is_usable(agent, call)
+  ensure
+    gate&.fetch(:release)&.push(true) if gate&.fetch(:release)&.empty?
+    stale&.join
+  end
+
+  def test_a_stale_approval_after_denial_cannot_launder_the_winner
+    store = RacingStore.new
+    agent, call, writes = parked_agent(store)
+    gate = store.pause_next_decision(true)
+    stale = Thread.new { capture { fresh_session(agent).approve(call.id, note: "late") } }
+    gate.fetch(:waiting).pop
+
+    agent.session.deny(call.id, note: "winner")
+    result = agent.resume
+
+    assert_predicate result, :completed?
+    assert_empty writes
+
+    gate.fetch(:release) << true
+    status, error = stale.value
+
+    assert_equal :error, status
+    assert_instance_of Mistri::ConfigurationError, error
+    assert_empty agent.session.open_approvals
+    tool_result = agent.session.messages.select(&:tool?).fetch(0)
+
+    assert_match(/denied this tool call: winner/, tool_result.text)
+  ensure
+    gate&.fetch(:release)&.push(true) if gate&.fetch(:release)&.empty?
+    stale&.join
+  end
+
+  private
+
+  def assert_conflict_follows(winner)
+    agent, writes, outcomes, decisions = raced_conflict(winner)
+
+    assert_equal winner, decisions.fetch(0).fetch("approved")
+    assert_equal 2, decisions.length
+    assert_equal :ok, outcomes.fetch(winner).fetch(0)
+    loser = outcomes.fetch(!winner)
+
+    assert_equal :error, loser.fetch(0)
+    assert_instance_of Mistri::ConfigurationError, loser.fetch(1)
+    assert_match(/already been decided/, loser.fetch(1).message)
+
+    result = agent.resume
+
+    assert_predicate result, :completed?
+    assert_equal(winner ? 1 : 0, writes.length)
+    assert_empty agent.session.open_approvals
+  end
+
+  def approve_and_resume(agent, call, writes)
+    agent.session.approve(call.id, note: "winner")
+    result = agent.resume
+
+    assert_predicate result, :completed?
+    assert_equal 1, writes.length
+  end
+
+  def assert_settled_session_is_usable(agent, call)
+    assert_empty agent.session.open_approvals
+    assert_equal "written", agent.session.messages.select(&:tool?).fetch(0).text
+    before_retry = agent.session.entries.length
+
+    assert_nil agent.session.approve(call.id, note: "network retry")
+    assert_raises(Mistri::ConfigurationError) { agent.session.deny(call.id) }
+    assert_equal before_retry, agent.session.entries.length
+    assert_stale_loser_does_not_block_compaction(agent)
+
+    continued = agent.run("Continue after the settled approval.")
+
+    assert_predicate continued, :completed?
+  end
+
+  def assert_stale_loser_does_not_block_compaction(agent)
+    3.times do |index|
+      text = "history #{index} " * 20
+      agent.session.append_message(Mistri::Message.user(text))
+      agent.session.append_message(Mistri::Message.assistant(content: "acknowledged #{index}"))
+    end
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "durable checkpoint" }])
+    result = Mistri::Compactor.call(
+      session: agent.session, provider:, settings: Mistri::Compaction.new(keep_recent: 10)
+    )
+
+    assert_equal "durable checkpoint", result.fetch(:summary)
+    assert_equal "durable checkpoint", agent.session.last_compaction.fetch("summary")
+  end
+
+  def parked_agent(store)
+    writes = []
+    tool = Mistri::Tool.define("write", "Writes once.", needs_approval: true) do
+      writes << :written
+      "written"
+    end
+    turns = [
+      { tool_calls: [{ name: "write", arguments: {} }] },
+      { text: "settled" },
+      { text: "continued" }
+    ]
+    provider = Mistri::Providers::Fake.new(turns:)
+    session = Mistri::Session.new(store:)
+    agent = Mistri::Agent.new(provider:, tools: [tool], session:)
+    call = agent.run("go").pending.fetch(0)
+    [agent, call, writes]
+  end
+
+  def raced_conflict(winner)
+    store = RacingStore.new
+    agent, call, writes = parked_agent(store)
+    store.race_next_loads(2)
+    gate = store.pause_next_decision(!winner)
+    attempts = {
+      true => Thread.new { capture { fresh_session(agent).approve(call.id) } },
+      false => Thread.new { capture { fresh_session(agent).deny(call.id) } }
+    }
+    gate.fetch(:waiting).pop
+    wait_until { approval_decisions(agent.session).length == 1 }
+    gate.fetch(:release) << true
+    outcomes = attempts.transform_values(&:value)
+    [agent, writes, outcomes, approval_decisions(agent.session)]
+  ensure
+    gate&.fetch(:release)&.push(true) if gate&.fetch(:release)&.empty?
+    attempts&.each_value(&:join)
+  end
+
+  def concurrently(*operations)
+    operations.map { |operation| Thread.new { capture(&operation) } }.map(&:value)
+  end
+
+  def capture
+    [:ok, yield]
+  rescue StandardError => e
+    [:error, e]
+  end
+
+  def fresh_session(agent)
+    Mistri::Session.new(store: agent.session.store, id: agent.session.id)
+  end
+
+  def wait_until
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+    until yield
+      raise "timed out waiting for the durable winner" if Process.clock_gettime(
+        Process::CLOCK_MONOTONIC
+      ) >= deadline
+
+      Thread.pass
+    end
+  end
+
+  def approval_decisions(session)
+    session.entries.select { |entry| entry["type"] == "approval_decision" }
+  end
+end

--- a/test/test_session_approval_audit.rb
+++ b/test/test_session_approval_audit.rb
@@ -191,30 +191,58 @@ class TestSessionApprovalAudit < Minitest::Test # rubocop:disable Metrics/ClassL
     end
   end
 
-  def test_an_approval_request_can_have_only_one_decision
-    session = approval_session
-    session.append("approval_decision", "call_id" => "write-1", "approved" => true)
-    session.append("approval_decision", "call_id" => "write-1", "approved" => false)
+  def test_the_first_valid_approval_decision_wins_in_raw_history
+    [true, false].each do |winner|
+      session = approval_session
+      session.append("approval_decision", "call_id" => "write-1", "approved" => winner,
+                                          "note" => "first")
+      session.append("approval_decision", "call_id" => "write-1", "approved" => !winner,
+                                          "note" => "loser")
 
-    assert_rejected_history(session, /duplicate approval decision/)
+      decision = session.open_approvals.fetch(0).fetch(:decision)
+
+      assert_equal winner, decision["approved"]
+      assert_equal "first", decision["note"]
+    end
   end
 
-  def test_a_settled_tool_call_cannot_be_reopened_or_decided_again
+  def test_a_late_losing_decision_cannot_corrupt_a_settled_approval
     request_then_answer = approval_session
     request_then_answer.append("approval_decision", "call_id" => "write-1",
                                                     "approved" => true)
     append_tool_result(request_then_answer)
     request_then_answer.append("approval_decision", "call_id" => "write-1",
-                                                    "approved" => true)
+                                                    "approved" => false)
 
-    assert_rejected_history(request_then_answer, /already answered tool call/)
+    assert_empty request_then_answer.open_approvals
+    assert_equal "written", request_then_answer.messages.select(&:tool?).fetch(0).text
+  end
 
+  def test_a_losing_decision_before_a_real_result_cannot_hide_that_result
+    session = approval_session
+    session.append("approval_decision", "call_id" => "write-1", "approved" => true)
+    session.append("approval_decision", "call_id" => "write-1", "approved" => false)
+    append_tool_result(session)
+
+    assert_empty session.open_approvals
+    assert_equal "written", session.messages.select(&:tool?).fetch(0).text
+  end
+
+  def test_a_settled_tool_call_cannot_be_reopened
     answer_then_request = Mistri::Session.new(store: Mistri::Stores::Memory.new)
     call = append_assistant_call(answer_then_request, "write-1")
     append_tool_result(answer_then_request)
     answer_then_request.append("approval_request", "call" => call.to_h)
 
     assert_rejected_history(answer_then_request, /already answered tool call/)
+  end
+
+  def test_a_malformed_losing_decision_still_fails_closed
+    session = approval_session
+    session.append("approval_decision", "call_id" => "write-1", "approved" => true)
+    session.append("approval_decision", "call_id" => "write-1", "approved" => "true")
+
+    assert_rejected_history(session, /approved value is not true or false/)
   end
 
   def test_tool_results_require_a_unique_prior_call_with_the_same_name
@@ -406,16 +434,24 @@ class TestSessionApprovalAudit < Minitest::Test # rubocop:disable Metrics/ClassL
     assert_rejected_history(session, /splits a tool call from its result/)
   end
 
-  def test_the_public_decision_api_rejects_a_second_decision_without_writing_it
+  def test_the_public_decision_api_is_idempotent_only_for_the_winning_value
     session = approval_session
-    session.approve("write-1")
+    session.approve("write-1", note: "first")
     before = session.entries.length
+
+    assert_nil session.approve("write-1", note: "retry")
+    assert_equal before, session.entries.length
 
     error = assert_raises(Mistri::ConfigurationError) { session.deny("write-1") }
 
     assert_match(/already been decided/, error.message)
     assert_equal before, session.entries.length
     assert session.open_approvals.first[:decision]["approved"]
+    assert_equal "first", session.open_approvals.first[:decision]["note"]
+
+    missing = assert_raises(Mistri::ConfigurationError) { session.approve("other") }
+
+    assert_match(/no open approval/, missing.message)
   end
 
   def test_open_approval_decisions_do_not_alias_the_store


### PR DESCRIPTION
## Why

Two workers can read the same parked approval before either appends a decision. The former audit treated the second durable decision as corruption, permanently blocking open_approvals, resume, replay, and compaction.

## What changed

- Treat the first valid decision in stable Session-store order as authoritative.
- Make retries of the winning value idempotent and reject conflicting callers with Mistri::ConfigurationError.
- Keep well-formed losing log entries inert, including a stale loser that lands after tool execution.
- Preserve fail-closed handling for malformed, orphaned, mismatched, and ambiguous legacy controls.
- Document the store visibility requirement and the boundary between Mistri single-assignment and host-owned quorum policy.

This does not claim exactly-once writes. A newly appended decision performs one linear control-history reread so a racing caller learns whether it won. Already-visible retries do not append, and provider streaming paths are unchanged.

## Validation

- `COVERAGE=1 mise exec -- bundle exec rake test` - 1,024 runs, 5,480 assertions, 0 failures/errors; 98.41% line and 88.86% branch coverage
- `mise exec -- bundle exec rubocop` - 197 files, no offenses
- Deterministic approval race suite under 100 seeds
- Adversarial review of both durable conflict orders, post-settlement losers, compaction, legacy IDs, and malformed controls
- `git diff --check`