### PR TITLE
Prepare the 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-12
+
 - Synchronous event subscribers now propagate the exact exception object even
   when its class also names an internal failure: provider `Mistri::Error`
   values, transport I/O and timeout errors, SSE `JSON::ParserError`, hook
@@ -66,10 +68,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   one exact committed-byte comparison, and one conditional commit to the
   ordinary edit path; Memory also returns an owned read copy. Conflicts add at
   most two complete reapplications. Active Record capability adds cached schema
-  inspection when the workspace is first bound, outside the edit path. No
-  provider streaming path changes. Dedicated
-  MySQL 8.4/InnoDB and PostgreSQL CI jobs prove real locking, readback, and
-  unique-create behavior while the gem retains zero runtime dependencies.
+  inspection on the first capability check, outside the edit path. No
+  provider streaming path changes. Dedicated MySQL 8.4/InnoDB and PostgreSQL CI
+  jobs prove real locking, readback, and unique-create behavior while the gem
+  retains zero runtime dependencies.
 - Built-in document reads, searches, and edits now return an explicitly failed
   `ToolResult` when the document is missing or a requested replacement cannot
   be applied. The same actionable text still reaches the model, but lifecycle
@@ -870,4 +872,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Reserved the gem name.
 
+[Unreleased]: https://github.com/mcheemaa/mistri/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/mcheemaa/mistri/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/mcheemaa/mistri/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/mcheemaa/mistri/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/mcheemaa/mistri/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/mcheemaa/mistri/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/mcheemaa/mistri/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/mcheemaa/mistri/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mcheemaa/mistri/releases/tag/v0.1.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,9 +17,9 @@ Gemini providers preserve ordinary 0.5 sessions, including the repeated
 occurrence settled. There is no blanket session rewrite step.
 
 Hosts that used implicit tool schemas, mutated arguments, supplied custom
-providers or Session stores, dispatched background children, generated MCP
-OAuth models, stored sessions in MySQL, or configured cost budgets need to
-review the sections below.
+providers or Session stores, dispatched background children, used document
+workspaces, generated MCP OAuth models, stored sessions in MySQL, or configured
+cost budgets need to review the sections below.
 
 ### Checklist
 
@@ -29,6 +29,8 @@ review the sections below.
       genuinely part of the contract.
 - [ ] Make event subscribers tolerate new event types and read `tool_error`
       structurally.
+- [ ] Audit synchronous event subscribers: their exact exceptions now escape
+      `run` or `resume` and may follow durable facts or external side effects.
 - [ ] Ensure at most one `run` or `resume` is active per Session across all
       processes.
 - [ ] Treat each approval as single-assignment; resolve quorum or multi-reviewer
@@ -46,6 +48,12 @@ review the sections below.
 - [ ] Add a runtime factory to every background spawner and queue worker.
 - [ ] Review queued child specs and ensure their exact `tool_names` grant is
       still intended before executing them under 0.6.
+- [ ] Keep qualifying Active Record workspaces outside host transactions and
+      assert `atomic_writes?` at boot when lost-update protection is required.
+- [ ] Replace mutation of values returned by `Workspace::Memory#read` with an
+      explicit `write`.
+- [ ] Use anchored `edit_file`, not blind `write_file`, when concurrent changes
+      must be preserved.
 - [ ] Exercise active persisted sessions, approvals, tool failures, compaction,
       and one real call per configured provider in staging.
 
@@ -280,6 +288,14 @@ Custom sinks must be thread-safe. Code that manually constructs a
 `:tool_result` `Mistri::Event` must now supply a boolean `tool_error` matching
 the Message.
 
+An exception from a synchronous subscriber now propagates unchanged from
+`run` or `resume`. Mistri does not retry it or reinterpret it as a provider,
+transport, hook, tool, parse, or compaction failure. Delivery is not a
+transaction: some events follow durable Session appends, and handler progress
+can follow an external side effect. Catch subscriber failures at the host
+boundary, reconcile the Session and the tool's domain idempotency state, and
+retry only under host policy. See [Reliability](docs/reliability.md#events-and-sinks).
+
 Update exhaustive event switches to ignore unknown future members:
 
 ```ruby
@@ -297,6 +313,10 @@ end
 
 Do not decide failure by matching prefixes such as `"Error:"`. Human denial is
 an expected control result and is not marked as execution failure.
+
+Missing documents in `read_file`, `find_in_file`, and `edit_file`, plus an
+`edit_file` replacement that cannot be applied, now carry `tool_error: true`.
+Their actionable model-facing text is unchanged.
 
 The error fact never authorizes mechanical replay. A handler can commit a side
 effect before it raises.
@@ -405,6 +425,41 @@ handler-commit/result-append gap.
 `Session#entries` and serialized usage are extensible records. Raw host readers
 must ignore unknown entry types and keys. This release adds lifecycle, approval
 provenance, unpriced-attempt, and `cost.known` data.
+
+## Workspace editing and conditional writes
+
+`edit_file` now uses conditional writes when a workspace explicitly advertises
+`atomic_writes?`. Existing custom workspaces that implement only `read`,
+`write`, `delete`, and `list` keep their 0.5 behavior. A custom workspace must
+claim atomic support only when its `snapshot` and `compare_and_write` methods
+satisfy the complete contract in
+[Context and workspaces](docs/context-and-workspaces.md#workspaces-and-document-tools).
+
+Only anchored `edit_file` uses this protocol. `write_file` remains an
+intentional blind whole-document replacement, and deletion has no conditional
+form. Use an anchored edit or a host tool with a stronger domain contract when
+concurrent writers must preserve unrelated changes.
+
+A qualifying `Mistri::Workspace::ActiveRecord` now takes the conditional path
+on PostgreSQL, or on an InnoDB table through MySQL2 or Trilogy. It verifies the
+primary key, non-null path, content, and scope columns, and an exact unique
+scope/path index before advertising the capability. Atomic snapshots and edits
+reject when the connection already has an open host transaction, because the
+adapter cannot safely join that transaction's isolation and lock lifetime. Run
+the Agent outside the host transaction. Unsupported storage retains the legacy
+path; assert `workspace.atomic_writes?` at boot rather than accepting that
+fallback when lost-update protection is required.
+
+`Mistri::Workspace::Memory#read` now returns an owned copy. Call `write` to
+persist a changed value; mutating a previously returned String no longer changes
+workspace state. Its conditional writes protect only threads sharing that
+Memory instance, not separate processes.
+
+`Mistri::Workspace::Single` opts in only when given `synchronize:`. That
+callback must cover the complete current read, revision check, write, and
+committed read for every competing writer. It must also refuse an already-open
+Active Record transaction when it uses an Active Record lock. Without the
+callback, Single keeps its legacy four-method behavior.
 
 ## MCP changes
 
@@ -565,7 +620,9 @@ At minimum:
 6. Run a write tool with an idempotency key and simulate failure before result
    persistence in the host test harness.
 7. Reconnect and refresh one MCP OAuth connection.
-8. Run the provider-specific live tests and integration matrix with every
+8. For a workspace that requires concurrent edit preservation, assert
+   `atomic_writes?` and race two anchored edits against its real backend.
+9. Run the provider-specific live tests and integration matrix with every
    expected key present.
 
 ```console
@@ -578,5 +635,5 @@ $ bundle exec rake integration
 Missing provider keys skip live coverage. Read the output and verify the models
 that actually ran.
 
-For exact behavior and latency notes, read the [Unreleased](CHANGELOG.md#unreleased)
-changelog entry.
+For exact behavior and latency notes, read the
+[0.6.0 changelog entry](CHANGELOG.md#060---2026-07-12).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -629,11 +629,12 @@ At minimum:
 $ bundle exec rake test
 $ bundle exec rubocop
 $ MISTRI_LIVE=1 bundle exec rake test
-$ bundle exec rake integration
+$ MISTRI_INTEGRATION_STRICT=1 bundle exec rake integration
 ```
 
-Missing provider keys skip live coverage. Read the output and verify the models
-that actually ran.
+Ordinary integration runs skip missing provider keys and an unreachable public
+MCP fixture. Strict mode fails when a matrix key is absent or that fixture is
+unavailable, so use it for release verification.
 
 For exact behavior and latency notes, read the
 [0.6.0 changelog entry](CHANGELOG.md#060---2026-07-12).

--- a/docs/context-and-workspaces.md
+++ b/docs/context-and-workspaces.md
@@ -196,6 +196,11 @@ committed and must read the document again. Custom four-method workspaces keep
 their existing behavior unless they explicitly return true from
 `atomic_writes?` and implement both methods.
 
+The conditional protocol is used by `edit_file`. `write_file` remains an
+intentional blind whole-document replacement, and deletion has no conditional
+form. When concurrent writers must preserve unrelated changes, use an anchored
+edit or provide a host tool with a stronger domain contract.
+
 Bind one to the built-in read, write, edit, find, and list tools:
 
 ```ruby
@@ -299,10 +304,10 @@ unique scope/path index. The adapter copies and freezes the scope Hash plus
 nested Hash, Array, Range, and String values at construction; atomic mode's
 narrower scalar contract keeps its tenant identity stable.
 
-Storage and schema capability are inspected once when the workspace is first
-bound to a tool and then cached off the edit path. Keep that model on the same
-database role and shard, and do not change its table or indexes during the
-workspace's lifetime.
+Storage and schema capability are inspected on the first capability check and
+cached thereafter, off the edit path. Bind the workspace before concurrent use,
+keep its model on the same database role and shard, and do not change its table
+or indexes during the workspace's lifetime.
 
 Unsupported storage deliberately keeps the adapter's legacy read/write behavior.
 If lost-update protection is mandatory for your host, assert the capability at

--- a/lib/mistri/version.rb
+++ b/lib/mistri/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mistri
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/test/integration/test_background.rb
+++ b/test/integration/test_background.rb
@@ -12,28 +12,16 @@ class TestBackgroundIntegration < Minitest::Test
 
   Integration.scenario(self, :model_backgrounds_a_worker_and_collects_its_report) do |model|
     Mistri.locks = Mistri::Locks::Memory.new
-    number = rand(100..900)
+    secret = Integration.marker
+    release = Queue.new
+    released = false
+    child = nil
+    cleanup_attempted = false
     store = Mistri::Stores::Memory.new
-    # Slow enough that the parent's receipt turn reliably finishes first;
-    # a faster oracle folds its report mid-run and the parent, correctly,
-    # answers with the number instead of the scripted acknowledgement.
-    oracle = Mistri::Tool.define("oracle", "Answers the secret number, slowly.") do
-      sleep 8
-      number.to_s
-    end
-    runtime_factory = lambda do |spec|
-      runtime_oracle = Mistri::Tool.define("oracle", "Answers the secret number, slowly.") do
-        sleep 8
-        number.to_s
-      end
-      provider = Mistri.provider(spec.fetch("model"))
-      Mistri::SubAgent::Runtime.new(provider: provider,
-                                    system: spec.fetch("instructions"),
-                                    tools: [runtime_oracle], cleanup: -> { provider.close })
-    end
+    oracle = oracle_tool(secret)
     tools = Mistri::SubAgent.pack(provider: Mistri.provider(model), tools: [oracle],
                                   dispatcher: Mistri::Dispatchers::Thread.new,
-                                  runtime_factory: runtime_factory)
+                                  runtime_factory: runtime_factory(secret, release))
     parent = Mistri::Agent.new(
       provider: Mistri.provider(model), tools: tools,
       session: Mistri::Session.new(store:),
@@ -41,31 +29,51 @@ class TestBackgroundIntegration < Minitest::Test
               "wait for it before answering; collect reports with read_agent."
     )
 
-    first = parent.run(
-      "Spawn a background worker named Beagle (instructions: call the oracle " \
-      "tool and report its answer) with the task of fetching the secret " \
-      "number. Then, without waiting for Beagle, reply with exactly: receipt " \
-      "acknowledged."
-    )
+    begin
+      first = parent.run(
+        "Spawn a background worker named Beagle (instructions: call the oracle " \
+        "tool and report its exact SECRET_VALUE) with the task of fetching the " \
+        "secret value. Then, without waiting for Beagle, reply with exactly: " \
+        "receipt acknowledged."
+      )
 
-    assert_predicate first, :completed?
-    assert Integration.saw?(first.text, "receipt acknowledged"),
-           "the parent must answer while the worker runs: #{first.text}"
+      assert_predicate first, :completed?
+      assert Integration.saw?(first.text, "receipt acknowledged"),
+             "the parent must answer while the worker runs: #{first.text}"
 
-    second = parent.run(
-      "Now read Beagle with read_agent using wait true, and tell me the " \
-      "secret number in one sentence."
-    )
+      child = parent.session.children.first
 
-    assert_predicate second, :completed?
-    assert Integration.saw?(second.text, number.to_s),
-           "the report never surfaced: #{second.text}"
+      refute_nil child, "the background worker was never linked"
+      refute_predicate child, :finished?, "the worker did not remain in the background"
 
-    child = parent.session.children.first
+      reports = []
+      second = parent.run(
+        "Now read Beagle with read_agent using wait true, and tell me its exact " \
+        "SECRET_VALUE in one sentence."
+      ) do |event|
+        if event.type == :tool_started && event.tool_call.name == "read_agent"
+          release << true
+          released = true
+        elsif event.type == :tool_result && event.tool_call.name == "read_agent"
+          reports << event.message.text
+        end
+      end
 
-    assert_equal "Beagle", child.name
-    assert_equal :done, child.status
-    assert_equal :done, child.status, "terminal entry persists"
+      assert_predicate second, :completed?
+      assert(reports.any? { |report| Integration.carried?(report, secret) },
+             "read_agent never returned the report: #{reports.inspect}")
+
+      reopened = Mistri::Session.new(store:, id: parent.session.id).children.first
+
+      assert_equal "Beagle", reopened.name
+      assert_equal :done, reopened.status, "the terminal did not survive a fresh session read"
+      cleanup_attempted = true
+
+      assert drain_worker(child), "the background worker did not release its lease"
+    ensure
+      release << true unless released
+      drain_worker(child) if child && !cleanup_attempted
+    end
   end
 
   # The report arrives on its own: no read_agent, no waiting. The worker
@@ -73,25 +81,16 @@ class TestBackgroundIntegration < Minitest::Test
   # answers from it.
   Integration.scenario(self, :a_workers_report_arrives_without_being_asked_for) do |model|
     Mistri.locks = Mistri::Locks::Memory.new
-    number = rand(100..900)
+    secret = Integration.marker
+    release = Queue.new
+    released = false
+    child = nil
+    cleanup_attempted = false
     store = Mistri::Stores::Memory.new
-    oracle = Mistri::Tool.define("oracle", "Answers the secret number, slowly.") do
-      sleep 1
-      number.to_s
-    end
-    runtime_factory = lambda do |spec|
-      runtime_oracle = Mistri::Tool.define("oracle", "Answers the secret number, slowly.") do
-        sleep 1
-        number.to_s
-      end
-      provider = Mistri.provider(spec.fetch("model"))
-      Mistri::SubAgent::Runtime.new(provider: provider,
-                                    system: spec.fetch("instructions"),
-                                    tools: [runtime_oracle], cleanup: -> { provider.close })
-    end
+    oracle = oracle_tool(secret)
     tools = Mistri::SubAgent.pack(provider: Mistri.provider(model), tools: [oracle],
                                   dispatcher: Mistri::Dispatchers::Thread.new,
-                                  runtime_factory: runtime_factory)
+                                  runtime_factory: runtime_factory(secret, release))
     parent = Mistri::Agent.new(
       provider: Mistri.provider(model), tools: tools,
       session: Mistri::Session.new(store:),
@@ -99,28 +98,92 @@ class TestBackgroundIntegration < Minitest::Test
               "when they finish."
     )
 
-    first = parent.run(
-      "Spawn a background worker named Terrier (instructions: call the oracle " \
-      "tool and report its answer) to fetch the secret number. Then, without " \
-      "waiting for Terrier, reply with exactly: receipt acknowledged."
-    )
+    begin
+      first = parent.run(
+        "Spawn a background worker named Terrier (instructions: call the oracle " \
+        "tool and report its exact SECRET_VALUE) to fetch the secret value. Then, " \
+        "without waiting for Terrier, reply with exactly: receipt acknowledged."
+      )
 
-    assert_predicate first, :completed?
+      assert_predicate first, :completed?
+      assert Integration.saw?(first.text, "receipt acknowledged"),
+             "the parent must answer while the worker runs: #{first.text}"
 
-    # The typed entry lands in the parent session whether the report folded
-    # mid-run or still waits in the inbox, so this await is race-free.
-    ends = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 60
-    until parent.session.entries.any? { |entry| entry["type"] == "subagent_report" } ||
-          Process.clock_gettime(Process::CLOCK_MONOTONIC) > ends
-      sleep 0.2
+      child = parent.session.children.first
+
+      refute_nil child, "the background worker was never linked"
+      refute_predicate child, :finished?, "the worker did not remain in the background"
+
+      release << true
+      released = true
+      report = wait_for_report(parent.session)
+
+      assert Integration.carried?(report["report"], secret),
+             "the durable report lost the secret: #{report.inspect}"
+
+      session = Mistri::Session.new(store:, id: parent.session.id)
+      reader = Mistri::Agent.new(
+        provider: Mistri.provider(model), tools: [], session:,
+        system: "A worker report appears in context before the current request. " \
+                "Return its exact SECRET_VALUE when asked."
+      )
+      second = reader.run("What exact SECRET_VALUE did Terrier report? Answer with only it.")
+
+      assert_predicate second, :completed?
+      assert Integration.carried?(second.text, secret),
+             "the folded report never reached the model: #{second.text}"
+      assert session.entries.any? { |entry| entry["report_id"] == report["id"] },
+             "the durable report was never folded into the conversation"
+      assert_equal :done, session.children.first.status
+      cleanup_attempted = true
+
+      assert drain_worker(child), "the background worker did not release its lease"
+    ensure
+      release << true unless released
+      drain_worker(child) if child && !cleanup_attempted
     end
+  end
 
-    assert_predicate parent.session.children.first, :finished?
+  private
 
-    second = parent.run("What number did your worker report? Answer with just the number.")
+  def oracle_tool(secret, release = nil)
+    Mistri::Tool.define("oracle", "Returns the exact SECRET_VALUE.") do
+      release&.pop
+      "SECRET_VALUE=#{secret}"
+    end
+  end
 
-    assert_predicate second, :completed?
-    assert Integration.saw?(second.text, number.to_s),
-           "the folded report never reached the model: #{second.text}"
+  def runtime_factory(secret, release)
+    lambda do |spec|
+      provider = Mistri.provider(spec.fetch("model"))
+      Mistri::SubAgent::Runtime.new(
+        provider:, system: spec.fetch("instructions"),
+        tools: [oracle_tool(secret, release)], cleanup: -> { provider.close }
+      )
+    end
+  end
+
+  def wait_for_report(session)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 60
+    loop do
+      report = session.entries.find { |entry| entry["type"] == "subagent_report" }
+      return report if report
+
+      flunk "the background report did not arrive" if
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+      sleep 0.05
+    end
+  end
+
+  def drain_worker(child)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 60
+    loop do
+      held = Mistri.locks&.held?(Mistri::Child.lease_key(child.session_id))
+      return true if child.finished? && !held
+      return false if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+      sleep 0.05
+    end
   end
 end

--- a/test/integration/test_console.rb
+++ b/test/integration/test_console.rb
@@ -27,7 +27,7 @@ class TestConsoleIntegration < Minitest::Test
     )
 
     assert_predicate result, :completed?
-    assert Integration.saw?(result.text, number.to_s),
+    assert Integration.number?(result.text, number),
            "the number never surfaced: #{result.text}"
     assert_match(/done|complete|finish/, result.text.to_s.downcase,
                  "the status never surfaced: #{result.text}")
@@ -36,6 +36,11 @@ class TestConsoleIntegration < Minitest::Test
 
     assert_equal "Beagle", child.name
     assert_equal :done, child.status
+    child_session = Mistri::Session.new(store:, id: child.session_id)
+
+    assert(child_session.messages.any? do |message|
+      message.tool? && message.tool_name == "oracle"
+    end, "the worker never called its oracle")
 
     tool_names = parent.session.messages.select(&:assistant?)
                        .flat_map(&:tool_calls).map(&:name)

--- a/test/integration/test_context_management.rb
+++ b/test/integration/test_context_management.rb
@@ -7,7 +7,7 @@ require_relative "../support/integration"
 # skills load on demand, and memory persists what it is told.
 class TestContextManagementIntegration < Minitest::Test
   Integration.scenario(self, :one_run_survives_two_compactions) do |model|
-    secret = Integration.codename
+    secret = Integration.marker
     token = "continue-#{SecureRandom.hex(12)}"
     padding = ("checkpoint context " * 80).strip
     opened = 0
@@ -56,26 +56,31 @@ class TestContextManagementIntegration < Minitest::Test
     assert_equal(2, events.count { |event| event.type == :compaction })
     refute_includes compactions.first["summary"], secret
     assert_includes compactions.last["summary"], secret
-    assert Integration.saw?(result.text, secret),
+    assert Integration.carried?(result.text, secret),
            "the final answer lost the secret: #{result.text.inspect}"
 
     durable = session.entries.find do |entry|
       entry["type"] == "message" && entry.dig("message", "tool_name") == "open_checkpoint"
     end
 
-    assert_includes Mistri::Message.from_h(durable["message"]).text, secret
+    durable_message = Mistri::Message.from_h(durable["message"])
+
+    assert_includes durable_message.text, secret
 
     replay_before_answer = session.messages[0...-1]
-    carriers = replay_before_answer.select do |message|
-      JSON.generate(message.to_h).include?(secret)
-    end
+    summary = replay_before_answer.first
 
-    assert_equal [replay_before_answer.first], carriers,
-                 "the compacted replay should carry the secret only in its visible summary"
+    assert summary.text.start_with?(Mistri::Compaction::SUMMARY_PREFACE)
+    assert_includes summary.text, secret
+    refute_includes replay_before_answer.drop(1), durable_message,
+                    "the original secret-bearing tool result should be outside compacted replay"
+    refute(replay_before_answer.any? do |message|
+      message.tool? && message.tool_name == "open_checkpoint"
+    end, "the compacted replay still contains the original checkpoint result")
   end
 
   Integration.scenario(self, :skills_load_on_demand_and_bind) do |model|
-    suffix = Integration.codename
+    suffix = Integration.marker
     skills = [Mistri::Skill.new(
       name: "brand-voice",
       description: "Rules for writing any customer-facing copy or taglines.",
@@ -90,12 +95,13 @@ class TestContextManagementIntegration < Minitest::Test
       reads << e.tool_call.name if e.type == :tool_result
     end
 
+    assert_predicate result, :completed?
     assert_includes reads, "read_skill", "the model never pulled the skill body"
-    assert Integration.saw?(result.text, suffix), "the skill's rule never applied"
+    assert Integration.carried?(result.text, suffix), "the skill's rule never applied"
   end
 
   Integration.scenario(self, :memory_persists_what_it_is_told) do |model|
-    mascot = Integration.codename
+    mascot = Integration.marker
     saved = +""
     memory = Mistri::Memory.new(read: -> { saved }, write: ->(text) { saved.replace(text) })
     agent = Mistri::Agent.new(provider: Mistri.provider(model),
@@ -105,6 +111,6 @@ class TestContextManagementIntegration < Minitest::Test
     result = agent.run("Record in memory that the project mascot is named #{mascot}.")
 
     assert_predicate result, :completed?
-    assert Integration.saw?(saved, mascot), "memory never got the fact: #{saved.inspect}"
+    assert Integration.carried?(saved, mascot), "memory never got the fact: #{saved.inspect}"
   end
 end

--- a/test/integration/test_control_surfaces.rb
+++ b/test/integration/test_control_surfaces.rb
@@ -34,13 +34,13 @@ class TestControlSurfacesIntegration < Minitest::Test
                                   session: Mistri::Session.new(store:, id: session.id)).resume
 
       assert_predicate resumed, :completed?
-      assert Integration.saw?(sent.first, recipient), "the tool never got the recipient"
+      assert_equal recipient, sent.first, "the tool never got the exact recipient"
       assert Integration.saw?(resumed.text, recipient), "the answer lost the recipient"
     end
   end
 
   Integration.scenario(self, :steering_lands_mid_run) do |model|
-    keyword = Integration.codename
+    keyword = Integration.marker
     store = Mistri::Stores::Memory.new
     session = Mistri::Session.new(store:)
     theme = Mistri::Tool.define("lookup_theme", "The site theme to use.") do
@@ -55,14 +55,14 @@ class TestControlSurfacesIntegration < Minitest::Test
     result = agent.run("Write a one-line tagline for the landing page.")
 
     assert_predicate result, :completed?
-    assert Integration.saw?(result.text, keyword), "the steer never reached the model"
+    assert Integration.carried?(result.text, keyword), "the steer never reached the model"
   end
 
   # A crash between the assistant turn and its tool results leaves calls
   # unanswered, which providers reject on every later turn. Healing must
   # make the resumed context acceptable to the real API.
   Integration.scenario(self, :a_crashed_run_resumes_healed) do |model|
-    venue = Integration.codename
+    venue = Integration.marker
     store = Mistri::Stores::Memory.new
     session = Mistri::Session.new(store:)
     calls = [Mistri::ToolCall.new(id: "call_1", name: "book_venue",
@@ -78,7 +78,7 @@ class TestControlSurfacesIntegration < Minitest::Test
                        "the venue name it returns back to me.")
 
     assert_predicate result, :completed?
-    assert Integration.saw?(result.text, venue),
+    assert Integration.carried?(result.text, venue),
            "the healed session never recovered: #{result.text}"
   end
 end

--- a/test/integration/test_core_loop.rb
+++ b/test/integration/test_core_loop.rb
@@ -6,13 +6,18 @@ require_relative "../support/integration"
 # the answer, and the ui side-channel must reach the host and never the model.
 class TestCoreLoopIntegration < Minitest::Test
   Integration.scenario(self, :tools_carry_generated_facts) do |model|
-    founder = Integration.codename
-    city = Integration.codename
-    founder_tool = Mistri::Tool.define("founder_name", "The company founder's name.") { founder }
-    hq_tool = Mistri::Tool.define("hq_city", "The company's HQ city name.") { city }
+    founder = Integration.marker
+    city = Integration.marker
+    founder_tool = Mistri::Tool.define(
+      "founder_name", "Returns the exact FOUNDER_NAME value."
+    ) { "FOUNDER_NAME=#{founder}" }
+    hq_tool = Mistri::Tool.define(
+      "hq_city", "Returns the exact HQ_CITY value."
+    ) { "HQ_CITY=#{city}" }
     agent = Mistri::Agent.new(provider: Mistri.provider(model),
                               tools: [founder_tool, hq_tool],
-                              system: "Answer strictly from the tools.")
+                              system: "Call both tools. Answer only from their labeled values, " \
+                                      "copying each value exactly without changing its spelling.")
     events = []
 
     result = agent.run("Who founded the company and what city is HQ in? One sentence.") do |event|
@@ -25,8 +30,8 @@ class TestCoreLoopIntegration < Minitest::Test
     assert_empty events.first.partial.content
     assert_stream_boundaries(events)
     assert_predicate events.last, :terminal?
-    assert Integration.saw?(result.text, founder), "founder fact never flowed: #{result.text}"
-    assert Integration.saw?(result.text, city), "city fact never flowed: #{result.text}"
+    assert Integration.carried?(result.text, founder), "founder fact never flowed: #{result.text}"
+    assert Integration.carried?(result.text, city), "city fact never flowed: #{result.text}"
   end
 
   def assert_stream_boundaries(events)
@@ -44,8 +49,10 @@ class TestCoreLoopIntegration < Minitest::Test
     refute open, "the final provider stream never terminated"
   end
 
-  Integration.scenario(self, :ui_channel_reaches_host_not_model) do |model|
-    revision = Integration.codename
+  # Serializer tests prove ui never reaches provider input; this live path
+  # proves host delivery and keeps the final response as a leakage canary.
+  Integration.scenario(self, :ui_channel_reaches_host) do |model|
+    revision = Integration.marker
     save = Mistri::Tool.define("save_page", "Saves the current page draft.") do
       Mistri::ToolResult.new(content: "Saved.", ui: { "revision" => revision })
     end
@@ -64,7 +71,7 @@ class TestCoreLoopIntegration < Minitest::Test
   end
 
   Integration.scenario(self, :tool_failure_round_trips_as_data) do |model|
-    code = Integration.codename
+    code = Integration.marker
     diagnose = Mistri::Tool.define("diagnose_service", "Runs one service diagnostic.") do
       Mistri::ToolResult.new(
         content: "The diagnostic failed permanently with code #{code}. Do not retry it.",
@@ -81,13 +88,15 @@ class TestCoreLoopIntegration < Minitest::Test
       failures << event.tool_error if event.type == :tool_result
     end
 
+    assert_predicate result, :completed?
     refute_empty failures, "the live tool was never called"
     assert_predicate failures, :all?, "the live lifecycle lost its error fact"
-    assert Integration.saw?(result.text, code), "the failed result never replayed: #{result.text}"
+    assert Integration.carried?(result.text, code),
+           "the failed result never replayed: #{result.text}"
   end
 
   Integration.scenario(self, :invalid_tool_arguments_are_corrected_before_execution) do |model|
-    correction = Integration.codename
+    correction = Integration.marker
     validated = []
     handled = []
     submit = Mistri::Tool.define(
@@ -116,6 +125,7 @@ class TestCoreLoopIntegration < Minitest::Test
       calls << event.tool_call if event.type == :toolcall_end
     end
 
+    assert_predicate result, :completed?
     assert_operator validated.length, :>=, 2, "the model never exercised the rejected path"
     refute_equal correction, validated.first, "the first call skipped validation correction"
     refute_empty handled, "the corrected call never reached the handler"
@@ -123,7 +133,7 @@ class TestCoreLoopIntegration < Minitest::Test
     assert errors.first, "the rejection lost its error type"
     refute errors.last, "the accepted call stayed mislabeled as an error"
     assert_equal handled.length, errors.count(false), "a valid handler outcome was mislabeled"
-    assert Integration.saw?(result.text, correction), "the corrected result never landed"
+    assert Integration.carried?(result.text, correction), "the corrected result never landed"
     if model.start_with?("gemini-3")
       ids = calls.map(&:provider_call_id)
 

--- a/test/integration/test_delegation.rb
+++ b/test/integration/test_delegation.rb
@@ -9,7 +9,7 @@ class TestDelegationIntegration < Minitest::Test
     year = rand(1890..1990)
     company = Integration.codename
     store = Mistri::Stores::Memory.new
-    archive = Mistri::Tool.define("company_archive", "Company facts lookup.",
+    archive = Mistri::Tool.define("company_archive", "Authoritative fictional-company facts.",
                                   schema: lambda {
                                     string :query, "What to look up", required: true
                                   }) do
@@ -18,7 +18,9 @@ class TestDelegationIntegration < Minitest::Test
     researcher = Mistri::SubAgent.new(name: "researcher",
                                       description: "Researches companies, reports facts.",
                                       provider: Mistri.provider(model),
-                                      system: "Use company_archive. Report tersely.",
+                                      system: "Call company_archive for the requested fictional " \
+                                              "company. Never use memory or public sources. " \
+                                              "Report tersely.",
                                       tools: [archive])
     origins = []
     parent = Mistri::Agent.new(provider: Mistri.provider(model), tools: [researcher.tool],
@@ -26,12 +28,13 @@ class TestDelegationIntegration < Minitest::Test
                                system: "Never answer company questions from memory: " \
                                        "call the researcher and relay what it reports.")
 
-    result = parent.run("What year was #{company} founded? One sentence.") do |e|
+    result = parent.run("For the fictional company #{company}, use the researcher to find " \
+                        "its founding year. One sentence.") do |e|
       origins << e.origin if e.origin
     end
 
     assert_predicate result, :completed?
-    assert Integration.saw?(result.text, year.to_s), "the year never flowed up: #{result.text}"
+    assert Integration.number?(result.text, year), "the year never flowed up: #{result.text}"
     lanes = origins.uniq
 
     assert_equal 1, lanes.length, "one worker, one lane: #{lanes.inspect}"
@@ -42,29 +45,44 @@ class TestDelegationIntegration < Minitest::Test
     child = Mistri::Session.new(store:, id: link.fetch("session_id"))
 
     assert_operator child.messages.length, :>=, 3, "the child transcript should persist"
+    assert(child.messages.any? do |message|
+      message.tool? && message.tool_name == "company_archive"
+    end, "the specialist never called its archive")
   end
 
   Integration.scenario(self, :spawner_delegates_with_written_instructions) do |model|
     company = Integration.codename
     count = rand(40..900)
-    archive = Mistri::Tool.define("company_archive", "Company facts lookup.") do
+    archive = Mistri::Tool.define(
+      "company_archive",
+      "The authoritative source for generated company facts; call it instead of public sources."
+    ) do
       "#{company} has #{count} employees."
     end
     spawn = Mistri::SubAgent.spawner(provider: Mistri.provider(model), tools: [archive])
     parent = Mistri::Agent.new(provider: Mistri.provider(model), tools: [spawn],
-                               system: "Delegate lookups via spawn_agent; keep your " \
-                                       "own context clean.")
+                               system: "Delegate company lookups via spawn_agent. Grant " \
+                                       "company_archive to the child and instruct it to call " \
+                                       "that archive; never answer from memory or public " \
+                                       "sources. Keep your own context clean.")
     origins = []
 
-    result = parent.run("Using a sub-agent named headcount-scout, find how many " \
-                        "employees #{company} has. One sentence.") do |e|
+    result = parent.run("Using a sub-agent named headcount-scout, use company_archive to " \
+                        "find how many employees #{company} has. One sentence.") do |e|
       origins << e.origin if e.origin
     end
 
     assert_predicate result, :completed?
     assert(parent.session.entries.any? { |e| e["type"] == "subagent" }, "nothing spawned")
-    assert Integration.saw?(result.text, count.to_s), "the count never flowed: #{result.text}"
+    assert Integration.number?(result.text, count), "the count never flowed: #{result.text}"
     assert(origins.any? { |o| o.start_with?("headcount-scout#") },
            "the chosen name never reached the origin channel: #{origins.uniq}")
+
+    link = parent.session.messages.select(&:tool?).last.ui
+    child = Mistri::Session.new(store: parent.session.store, id: link.fetch("session_id"))
+
+    assert(child.messages.any? do |message|
+      message.tool? && message.tool_name == "company_archive"
+    end, "the spawned worker never called its archive")
   end
 end

--- a/test/integration/test_documents.rb
+++ b/test/integration/test_documents.rb
@@ -7,7 +7,7 @@ require "monitor"
 # Workspace::Single, edited in place through the document tools.
 class TestDocumentsIntegration < Minitest::Test
   Integration.scenario(self, :edits_a_single_document_headline) do |model|
-    headline = Integration.codename
+    headline = Integration.marker
     document = +<<~HTML
       <header>
         <h1>Placeholder Headline</h1>
@@ -25,13 +25,13 @@ class TestDocumentsIntegration < Minitest::Test
     result = agent.run("Change the h1 headline to exactly: #{headline}")
 
     assert_predicate result, :completed?
-    assert Integration.saw?(document, headline), "the document never changed"
+    assert Integration.carried?(document, headline), "the document never changed"
     refute_includes document, "Placeholder Headline"
     assert_includes document, '<p class="tagline">Ship faster.</p>', "collateral damage"
   end
 
   Integration.scenario(self, :repairs_a_stale_document_edit) do |model|
-    headline = Integration.codename
+    headline = Integration.marker
     document = +<<~HTML
       <main>
         <h1>Placeholder Headline</h1>
@@ -73,13 +73,13 @@ class TestDocumentsIntegration < Minitest::Test
     assert_predicate result, :completed?
     assert(agent.session.messages.any? { |message| message.tool? && message.tool_error? },
            "the model never exercised the failed-edit repair path")
-    assert Integration.saw?(document, headline), "the repaired edit never landed"
+    assert Integration.carried?(document, headline), "the repaired edit never landed"
     assert_includes document, 'data-human="keep"', "the concurrent edit was overwritten"
     assert_includes document, "Keep this paragraph.", "unrelated content changed"
   end
 
   Integration.scenario(self, :rebases_an_unrelated_document_edit) do |model|
-    headline = Integration.codename
+    headline = Integration.marker
     document = +<<~HTML
       <main>
         <h1>Placeholder Headline</h1>
@@ -115,7 +115,7 @@ class TestDocumentsIntegration < Minitest::Test
     assert_predicate result, :completed?
     refute(agent.session.messages.any? { |message| message.tool? && message.tool_error? },
            "the internal storage retry leaked out as a failed tool call")
-    assert Integration.saw?(document, headline), "the rebased edit never landed"
+    assert Integration.carried?(document, headline), "the rebased edit never landed"
     assert_includes document, 'data-human="keep"', "the concurrent edit was overwritten"
     assert_includes document, "Keep this paragraph.", "unrelated content changed"
   end

--- a/test/integration/test_mcp.rb
+++ b/test/integration/test_mcp.rb
@@ -11,7 +11,9 @@ class TestMcpIntegration < Minitest::Test
     begin
       begin
         client.connect
-      rescue Mistri::Error => e
+      rescue Mistri::ProviderError => e
+        raise unless Integration.mcp_unreachable?(e) && !Integration.strict?
+
         skip "DeepWiki MCP unreachable: #{e.message}"
       end
 
@@ -20,18 +22,24 @@ class TestMcpIntegration < Minitest::Test
       assert_includes names, "read_wiki_structure"
 
       called = []
+      errors = []
       bridged = Mistri::MCP.tools(client, allow: ["read_wiki_structure"], prefix: "deepwiki")
       agent = Mistri::Agent.new(provider: Mistri.provider(model), tools: bridged,
                                 system: "Use the deepwiki tool to answer. Be brief.")
 
       result = agent.run("What documentation topics exist for the " \
                          "modelcontextprotocol/ruby-sdk repo? Name two.") do |event|
-        called << event.tool_call.name if event.type == :tool_result
+        if event.type == :tool_result
+          called << event.tool_call.name
+          errors << event.tool_error
+        end
       end
 
       assert_predicate result, :completed?
       assert_includes called, "deepwiki__read_wiki_structure",
                       "the agent never used the live MCP tool"
+      refute_empty errors, "the live MCP result never reached the agent"
+      assert_predicate errors, :none?, "the live MCP call returned an error result"
       assert_operator result.text.to_s.length, :>, 20
     ensure
       client.close

--- a/test/integration/test_structured_output.rb
+++ b/test/integration/test_structured_output.rb
@@ -11,14 +11,14 @@ class TestStructuredOutputIntegration < Minitest::Test
              required: %w[project launch_year] }.freeze
 
   Integration.scenario(self, :task_extracts_into_the_schema) do |model|
-    project = Integration.codename
+    project = Integration.marker
     agent = Mistri::Agent.new(provider: Mistri.provider(model))
 
     result = agent.task("The project #{project} launches in 2031. Extract the details.",
                         schema: SCHEMA)
 
     assert_empty Mistri::Schema.violations(result.output, SCHEMA)
-    assert Integration.saw?(result.output["project"], project)
+    assert_equal project, result.output["project"]
     assert_equal 2031, result.output["launch_year"]
   end
 
@@ -32,22 +32,26 @@ class TestStructuredOutputIntegration < Minitest::Test
                              "summary" => { type: "string" } },
                required: %w[temperature_c summary] }
     agent = Mistri::Agent.new(provider: Mistri.provider(model), tools: [thermo])
+    calls = []
 
-    result = agent.task("Use the thermometer and report the reading.", schema: schema)
+    result = agent.task("Use the thermometer and report the reading.", schema: schema) do |event|
+      calls << event.tool_call.name if event.type == :tool_result
+    end
 
     assert_empty Mistri::Schema.violations(result.output, schema)
+    assert_includes calls, "read_thermometer", "the task never called its data source"
     assert_equal degrees, result.output["temperature_c"],
                  "the answer must carry the tool's exact reading"
   end
 
   Integration.scenario(self, :scalar_and_tuple_tasks_survive_provider_schema_differences) do |model|
-    scalar = Integration.codename
+    scalar = Integration.marker
     scalar_result = Mistri::Agent.new(provider: Mistri.provider(model)).task(
       "Return the exact JSON string #{scalar.inspect}.",
       schema: { type: "string", enum: [scalar] }
     )
 
-    tuple_value = Integration.codename
+    tuple_value = Integration.marker
     tuple_schema = {
       type: "array",
       prefixItems: [{ type: "string", enum: [tuple_value] },

--- a/test/support/integration.rb
+++ b/test/support/integration.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
+require "securerandom"
 require_relative "../test_helper"
 
-# The live integration harness: every scenario runs the full loop against
-# real provider APIs, once per model in the matrix. Every assertion checks
-# that a GENERATED codename flowed through the machinery: a coined ghostly
-# word like Spectramoor exists in no training data, so its presence in an
-# answer proves the tool result, summary, or child transcript carried it.
+# The live integration harness runs the full loop against real provider APIs,
+# once per model in the matrix. Scenarios pair generated values with structural
+# assertions. Opaque markers prove exact data flow; pronounceable synthetic
+# names keep entity prompts natural without relying on a real company or person.
 #
 #   bundle exec rake integration
+#   MISTRI_INTEGRATION_STRICT=1 bundle exec rake integration
 #   MISTRI_INTEGRATION_MODELS=claude-opus-4-8 bundle exec rake integration
 #   bundle exec rake integration N=/compaction/
 module Integration
@@ -24,23 +25,47 @@ module Integration
     ENV.fetch("MISTRI_INTEGRATION_MODELS", DEFAULT_MODELS).split(",").map(&:strip)
   end
 
-  # A single coined specter of a word no model has ever seen; only our
-  # machinery can deliver it into an answer.
+  # A pronounceable name for fictional entities supplied in the prompt.
   def codename
     "#{STARTS.sample}#{MIDDLES.sample}#{ENDS.sample}"
+  end
+
+  # A fresh opaque value only the scenario can place in the model's context.
+  def marker
+    "MISTRI_#{SecureRandom.hex(8)}"
   end
 
   def saw?(text, code)
     text.to_s.downcase.include?(code.downcase)
   end
 
-  # Defines one live test per model in the matrix; each skips itself when
-  # its provider's key is absent.
+  def carried?(text, value)
+    text.to_s.include?(value.to_s)
+  end
+
+  def number?(text, value)
+    text.to_s.match?(/(?<!\d)#{Regexp.escape(value.to_s)}(?!\d)/)
+  end
+
+  def strict?
+    ENV["MISTRI_INTEGRATION_STRICT"] == "1"
+  end
+
+  def mcp_unreachable?(error)
+    error.instance_of?(Mistri::ProviderError) && error.status.nil? &&
+      error.message.match?(/\A(?:connection failed|request timed out):/)
+  end
+
+  # Defines one live test per model in the matrix. Local runs skip absent
+  # keys; release verification fails instead.
   def scenario(klass, name, &body)
     models.each do |model|
       klass.define_method("test_#{name}_on_#{model.gsub(/[^a-z0-9]/i, "_")}") do
         key = Mistri::API_KEY_ENV.fetch(Mistri.provider_name(model))
-        skip "#{key} not set" if ENV[key].to_s.empty?
+        if ENV[key].to_s.empty?
+          message = "#{key} not set"
+          Integration.strict? ? flunk(message) : skip(message)
+        end
         instance_exec(model, &body)
       end
     end


### PR DESCRIPTION
## Summary

- set the gem version to 0.6.0 and move the complete safety-focused change set into a dated changelog release
- finish the 0.5-to-0.6 upgrade contract, including subscriber propagation, approval single-assignment, document workspace concurrency, and strict release verification
- replace stochastic live-test assumptions with causal assertions: Queue-gated background workers, exact opaque markers, numeric boundaries, child transcript checks, durable report folding, and narrow MCP failure handling

## Why

The runtime work for 0.6.0 is merged, but publishing it safely requires the package metadata and migration guidance to describe the shipped contracts exactly. Release validation also exposed several harness defects: sleep-based background ordering, model-dependent prose assertions, low-entropy synthetic names, and an MCP rescue broad enough to turn protocol failures into skips. These changes make a green release matrix mean that every configured provider and the live MCP path actually ran.

No production hot path changes in this PR. The integration changes affect test and release verification only.

## Validation

- `COVERAGE=1 bundle exec rake test`: 1,036 runs, 5,560 assertions, 0 failures; 98.45% line and 88.93% branch coverage
- `bundle exec rubocop`: 200 files, no offenses
- release verifier: 12 runs, 53 assertions, 0 failures
- isolated package install/load: 1 run, 17 assertions, 0 failures
- `MISTRI_LIVE=1 bundle exec rake test`: 1,036 runs, 5,831 assertions, 0 failures, 0 skips
- `MISTRI_INTEGRATION_STRICT=1 bundle exec rake integration`: 66 runs, 534 assertions, 0 failures, 0 skips
- independent package, publishing-pipeline, documentation, integration-determinism, and adversarial diff audits approved

The `v0.6.0` tag is intentionally not created here. After merge, the full `main` CI matrix must pass before tagging the exact merged commit and approving the protected trusted-publishing environment.