### PR TITLE
Read past the host's query cache in the ActiveRecord store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [0.6.1] - 2026-07-21
-
-- The ActiveRecord store reads past the host's query cache. Rails keeps the
-  cache on for a job's whole span and serves repeated identical queries from
-  it, so a parent polling for a child's report inside a job never saw the
-  report land and every wait ran to its timeout.
+- The ActiveRecord store and workspace read past the host's query cache.
+  Rails keeps the cache on for a job's whole span and serves repeated
+  identical queries from it, so a parent polling for a child's report inside
+  a job never saw the report land and every wait ran to its timeout, and a
+  workspace read could serve a stale document. Reads bypass only Rails'
+  cache: an open REPEATABLE READ transaction still pins its snapshot, so do
+  not poll from inside one.
 
 ## [0.6.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-21
+
+- The ActiveRecord store reads past the host's query cache. Rails keeps the
+  cache on for a job's whole span and serves repeated identical queries from
+  it, so a parent polling for a child's report inside a job never saw the
+  report land and every wait ran to its timeout.
+
 ## [0.6.0] - 2026-07-12
 
 - Synchronous event subscribers now propagate the exact exception object even

--- a/lib/mistri/stores/active_record.rb
+++ b/lib/mistri/stores/active_record.rb
@@ -55,6 +55,8 @@ module Mistri
       # Other processes append to a session by design, and hosts poll these
       # reads inside jobs where Rails caches repeated identical queries, so
       # a cached read would never see a child's report land. Read past it.
+      # Only past Rails' cache: an open REPEATABLE READ transaction still
+      # pins its snapshot, so never poll from inside one.
       def load(id)
         @model.uncached do
           @model.where(session_id: id).pluck(:position, :payload)

--- a/lib/mistri/stores/active_record.rb
+++ b/lib/mistri/stores/active_record.rb
@@ -52,10 +52,15 @@ module Mistri
         end
       end
 
+      # Other processes append to a session by design, and hosts poll these
+      # reads inside jobs where Rails caches repeated identical queries, so
+      # a cached read would never see a child's report land. Read past it.
       def load(id)
-        @model.where(session_id: id).pluck(:position, :payload)
-              .sort_by(&:first)
-              .map { |_position, payload| JSON.parse(payload) }
+        @model.uncached do
+          @model.where(session_id: id).pluck(:position, :payload)
+                .sort_by(&:first)
+                .map { |_position, payload| JSON.parse(payload) }
+        end
       end
     end
   end

--- a/lib/mistri/version.rb
+++ b/lib/mistri/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mistri
-  VERSION = "0.6.1"
+  VERSION = "0.6.0"
 end

--- a/lib/mistri/version.rb
+++ b/lib/mistri/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mistri
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end

--- a/lib/mistri/workspace/active_record.rb
+++ b/lib/mistri/workspace/active_record.rb
@@ -20,6 +20,11 @@ module Mistri
     #     t.timestamps
     #   end
     #   add_index :mistri_documents, [:session_id, :path], unique: true
+    #
+    # Reads run uncached: other processes write documents by design, and a
+    # cached read inside a job would serve the job's first snapshot forever.
+    # Uncached only defeats Rails' cache; an open REPEATABLE READ transaction
+    # still pins what reads see, so do not read from inside one.
     class ActiveRecord
       MYSQL_ADAPTERS = %w[Mysql2 Trilogy].freeze
       private_constant :MYSQL_ADAPTERS
@@ -42,7 +47,7 @@ module Mistri
       end
 
       def read(path)
-        @model.where(**@scope, path: path.to_s).pick(:content)
+        @model.uncached { @model.where(**@scope, path: path.to_s).pick(:content) }
       end
 
       def write(path, content)
@@ -60,7 +65,7 @@ module Mistri
 
       def snapshot(path)
         verify_atomic_context!
-        content = relation(path).pick(:content)
+        content = @model.uncached { relation(path).pick(:content) }
         content.nil? ? nil : Snapshot.for(content.to_s)
       end
 
@@ -90,7 +95,7 @@ module Mistri
       end
 
       def list(prefix = nil)
-        paths = @model.where(**@scope).pluck(:path).sort
+        paths = @model.uncached { @model.where(**@scope).pluck(:path) }.sort
         prefix ? paths.select { |p| p.start_with?(prefix.to_s) } : paths
       end
 

--- a/test/test_stores.rb
+++ b/test/test_stores.rb
@@ -86,6 +86,14 @@ if defined?(Mistri::Stores::ActiveRecord)
       @rows = []
       @mutex = Mutex.new
       @before_insert = nil
+      @read_uncached = false
+    end
+
+    attr_reader :read_uncached
+
+    def uncached
+      @read_uncached = true
+      yield
     end
 
     # Runs inside the insert lock, before uniqueness is checked: a hook a
@@ -129,10 +137,22 @@ if defined?(Mistri::Stores::ActiveRecord)
   # The optimistic append: writers that collide on the unique index retry
   # at the next position, because sessions have concurrent appenders by
   # design (the loop, a steer from another process, a child's report).
+  #
+  # Loads must bypass the host's query cache: a parent awaiting a child's
+  # report polls the same query for minutes, and Rails would serve the
+  # first snapshot for a job's whole span.
   class TestActiveRecordStore < Minitest::Test
     def setup
       @model = FakeEntryModel.new
       @store = Mistri::Stores::ActiveRecord.new(@model)
+    end
+
+    def test_load_reads_past_the_query_cache
+      @store.append("s", { "type" => "message" })
+
+      @store.load("s")
+
+      assert @model.read_uncached
     end
 
     def test_appends_and_loads_in_position_order

--- a/test/test_stores.rb
+++ b/test/test_stores.rb
@@ -86,14 +86,27 @@ if defined?(Mistri::Stores::ActiveRecord)
       @rows = []
       @mutex = Mutex.new
       @before_insert = nil
-      @read_uncached = false
+      @caching = false
+      @cache = nil
     end
 
-    attr_reader :read_uncached
+    # Simulates Rails' per-job query cache: while caching, identical reads
+    # are served from the first snapshot until a write through this model
+    # clears it or an uncached window bypasses it.
+    def cache
+      @caching = true
+      yield
+    ensure
+      @caching = false
+      @cache = nil
+    end
 
     def uncached
-      @read_uncached = true
+      was_caching = @caching
+      @caching = false
       yield
+    ensure
+      @caching = was_caching
     end
 
     # Runs inside the insert lock, before uniqueness is checked: a hook a
@@ -103,11 +116,19 @@ if defined?(Mistri::Stores::ActiveRecord)
     end
 
     def where(session_id:)
+      if @caching
+        @cache ||= {}
+        rows = @cache[session_id] ||=
+          @mutex.synchronize { @rows.select { |row| row.session_id == session_id }.dup }
+        return Scope.new(rows)
+      end
+
       rows = @mutex.synchronize { @rows.select { |row| row.session_id == session_id }.dup }
       Scope.new(rows)
     end
 
     def create!(session_id:, position:, payload:)
+      @cache = nil
       @mutex.synchronize do
         if (hook = @before_insert)
           @before_insert = nil
@@ -147,12 +168,16 @@ if defined?(Mistri::Stores::ActiveRecord)
       @store = Mistri::Stores::ActiveRecord.new(@model)
     end
 
-    def test_load_reads_past_the_query_cache
+    def test_load_sees_appends_from_other_processes_despite_the_query_cache
       @store.append("s", { "type" => "message" })
 
-      @store.load("s")
+      @model.cache do
+        assert_equal 1, @store.load("s").size
 
-      assert @model.read_uncached
+        @model.insert_bare("s", 2)
+
+        assert_equal 2, @store.load("s").size
+      end
     end
 
     def test_appends_and_loads_in_position_order

--- a/test/test_workspace_active_record.rb
+++ b/test/test_workspace_active_record.rb
@@ -105,6 +105,11 @@ if defined?(Mistri::Workspace::ActiveRecord)
 
     def where(**criteria) = Relation.new(self, criteria)
     def lock = Locked.new(self)
+
+    def uncached
+      yield
+    end
+
     def table_name = "atomic_documents"
     def primary_key = "id"
 
@@ -456,6 +461,91 @@ if defined?(Mistri::Workspace::ActiveRecord)
       assert_match(/cannot join an open transaction/, error.message)
     ensure
       @model.connection.transaction_open = false
+    end
+  end
+end
+
+if defined?(Mistri::Workspace::ActiveRecord)
+  # The smallest model that can lie the way Rails' query cache lies: while
+  # caching, identical reads serve the first snapshot until an uncached
+  # window bypasses it. Writes here stand for another process's writes, so
+  # they do not clear the cache.
+  class CachingDocumentModel
+    class Relation
+      def initialize(rows) = @rows = rows
+
+      def pick(column) = @rows.first&.fetch(column, nil)
+
+      def pluck(column) = @rows.map { |row| row.fetch(column) }
+    end
+
+    def initialize
+      @rows = []
+      @caching = false
+      @cache = nil
+    end
+
+    def insert_out_of_band(path, content)
+      @rows << { path: path, content: content }
+    end
+
+    def cache
+      @caching = true
+      yield
+    ensure
+      @caching = false
+      @cache = nil
+    end
+
+    def uncached
+      was_caching = @caching
+      @caching = false
+      yield
+    ensure
+      @caching = was_caching
+    end
+
+    def where(**criteria)
+      if @caching
+        @cache ||= {}
+        return Relation.new(@cache[criteria] ||= select_rows(criteria))
+      end
+
+      Relation.new(select_rows(criteria))
+    end
+
+    private
+
+    def select_rows(criteria)
+      path = criteria[:path]
+      path ? @rows.select { |row| row[:path] == path }.dup : @rows.dup
+    end
+  end
+
+  class TestWorkspaceQueryCache < Minitest::Test
+    def setup
+      @model = CachingDocumentModel.new
+      @workspace = Mistri::Workspace::ActiveRecord.new(@model)
+    end
+
+    def test_read_sees_writes_from_other_processes_despite_the_query_cache
+      @model.cache do
+        assert_nil @workspace.read("index.html")
+
+        @model.insert_out_of_band("index.html", "<h1>Draft</h1>")
+
+        assert_equal "<h1>Draft</h1>", @workspace.read("index.html")
+      end
+    end
+
+    def test_list_sees_writes_from_other_processes_despite_the_query_cache
+      @model.cache do
+        assert_empty @workspace.list
+
+        @model.insert_out_of_band("notes.md", "notes")
+
+        assert_equal ["notes.md"], @workspace.list
+      end
     end
   end
 end


### PR DESCRIPTION
## What

`Stores::ActiveRecord#load` and the `Workspace::ActiveRecord` read paths (`read`, `list`, `snapshot`) now run inside `Model.uncached`, so every session and document read sees rows the moment another process commits them. The changelog notes the fix under Unreleased; a release PR cuts 0.6.1 separately, matching how 0.6.0 shipped.

## Why

Sessions and workspaces have concurrent writers by design: the loop, a steer from a web process, a child's report or document from a job. But hosts run everything inside jobs, and Rails keeps the query cache on for a job's whole span, serving repeated identical queries from the first snapshot. A parent awaiting a child's report polls the same query for minutes and never sees the report land, so every wait runs to its timeout; a workspace read can serve a stale document the same way.

Measured in a host app: the child finished and committed its report at 22:21:35 while the parent kept polling until its 300 second deadline at 22:25:18, and the same read returned 0 entries cached and 1 uncached in a direct experiment.

One documented limit: uncached defeats only Rails' cache. An open REPEATABLE READ transaction still pins its snapshot, so polling from inside one still hangs; both adapters now say so.

## Testing

Full suite. The store and workspace fakes now simulate the query cache itself (identical reads pinned to the first snapshot until a write through the model or an uncached window), and new tests prove reads stay fresh against out-of-band writes; they fail if uncached becomes a no-op.