### PR TITLE
Add the logging sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `Mistri.logger` and `Mistri::Sinks::Logger`: assign any Logger-compatible
   object and every run logs its story as one scannable line per beat, tagged
   by session (sub-agents get their worker label): the input, each tool call
-  and result with a short pairing id, arguments, duration, and payload size,
-  each turn's token usage, retries, compaction, approvals, worker reports,
-  and a closing line with the run's outcome, elapsed time, turn count, and
-  dollar cost when pricing is known. `task` logs one frame around all its
-  fix passes. Deltas never log; origin-tagged events are skipped so every
-  agent, in any process, logs its own events exactly once. `level:` floors
-  the ordinary lines (warnings and errors keep their own levels), `color:`
+  and result with a short pairing id, arguments, duration, and result size,
+  each turn's token usage with cached prompt tokens called out, retries,
+  compaction, approvals (carrying the full call id `Session#approve` takes),
+  worker reports wherever a sink watched the spawn, and a closing line with
+  the run's outcome, elapsed time, turn count, and dollar cost whenever
+  pricing is known, a known $0.0000 included. `task` logs one frame around
+  all its fix passes, and the frame covers the whole public method, so store
+  and audit failures get a crash line too. Payloads log in full by default;
+  `content: false` keeps the same story as metadata only. `level:` floors
+  the ordinary lines (warnings and errors keep their own levels, and
+  expected stops such as cancels and budget ceilings log calmly), `color:`
   and `truncate:` are per-sink options, and a preconfigured sink can be
-  assigned directly; a wrong assignment raises `ConfigurationError` at
-  assignment time. Logging failures warn once per run and the run's sink
-  goes quiet: they never raise into the run or replace a host exception,
-  including on invalid byte sequences. Cached prompt tokens count toward
-  the tokens in and are called out (`900 in (890 cached)`); expected stops
-  log calmly (a cancel at info, a budget stop at warn, and a synthetic
-  budget stop never counts as a turn) so only real failures log at error;
-  non-printing bytes render as visible escapes so untrusted output cannot
-  steer a terminal. With no logger assigned the event path is untouched
-  (one nil check per run, nothing per event); with one assigned, delta
-  events short-circuit without allocating and per-line string work is
-  bounded by the truncation limit, not the payload.
+  assigned directly; wrong assignments and options raise at configuration
+  time. Sinks the Agent builds skip origin-tagged events so every agent, in
+  any process, logs its own events exactly once; a sink composed directly
+  per run renders forwarded child events with their origin instead. Logging
+  never breaks a run: sink construction and every write are contained,
+  failures warn once per run and the run's sink goes quiet, host exceptions
+  are never replaced (invalid byte sequences included), and hidden bytes in
+  payloads, names, ids, and labels render as visible escapes so untrusted
+  output cannot forge lines or steer a terminal. With no logger assigned
+  the event path is untouched (one nil check per run, nothing per event);
+  with one assigned, delta events short-circuit without allocating,
+  formatting is skipped when the floor level is disabled, and per-line
+  string work, tool arguments included, is bounded by the truncation limit,
+  not the payload.
 
 ## [0.6.1] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `Mistri.logger` and `Mistri::Sinks::Logger`: assign any Logger-compatible
   object and every run logs its story as one scannable line per beat, tagged
-  with its session: the input, each tool call with its arguments, each
-  result with its duration, each turn's token usage, retries, compaction,
-  approvals, worker reports, and a closing line with the run's outcome,
-  elapsed time, and dollar cost when pricing is known. Deltas never log;
-  origin-tagged events are skipped so every agent (sub-agents included, in
-  any process) logs its own events exactly once. Assign a preconfigured
-  `Sinks::Logger` for options (`color:`, `truncate:`), or compose one per
-  run like any sink. A logging failure warns once and goes quiet; it never
-  breaks a run. With no logger assigned, nothing changes.
+  by session (sub-agents get their worker label): the input, each tool call
+  and result with a short pairing id, arguments, duration, and payload size,
+  each turn's token usage, retries, compaction, approvals, worker reports,
+  and a closing line with the run's outcome, elapsed time, turn count, and
+  dollar cost when pricing is known. `task` logs one frame around all its
+  fix passes. Deltas never log; origin-tagged events are skipped so every
+  agent, in any process, logs its own events exactly once. `level:` floors
+  the ordinary lines (warnings and errors keep their own levels), `color:`
+  and `truncate:` are per-sink options, and a preconfigured sink can be
+  assigned directly; a wrong assignment raises `ConfigurationError` at
+  assignment time. Logging failures warn once per run and the run's sink
+  goes quiet: they never raise into the run or replace a host exception,
+  including on invalid byte sequences. With no logger assigned the event
+  path is untouched (one nil check per run, nothing per event); with one
+  assigned, delta events short-circuit without allocating.
 
 ## [0.6.1] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   pricing is known, a known $0.0000 included. `task` logs one frame around
   all its fix passes, and the frame covers the whole public method, so store
   and audit failures get a crash line too. Payloads log in full by default;
-  `content: false` keeps the same story as metadata only. `level:` floors
+  `content: false` keeps the same story as metadata only, error, crash, and
+  retry free text included, since exception messages can echo payloads. `level:` floors
   the ordinary lines (warnings and errors keep their own levels, and
   expected stops such as cancels and budget ceilings log calmly), `color:`
-  and `truncate:` are per-sink options, and a preconfigured sink can be
-  assigned directly; wrong assignments and options raise at configuration
-  time. Sinks the Agent builds skip origin-tagged events so every agent, in
+  and `truncate:` are per-sink options, and a preconfigured `Sinks::Logger`
+  (subclasses included) can be assigned directly; wrong assignments and
+  options raise at configuration time. Sinks the Agent builds skip origin-tagged events so every agent, in
   any process, logs its own events exactly once; a sink composed directly
   per run renders forwarded child events with their origin instead. Logging
   never breaks a run: sink construction and every write are contained,
@@ -32,8 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the event path is untouched (one nil check per run, nothing per event);
   with one assigned, delta events short-circuit without allocating,
   formatting is skipped when the floor level is disabled, and per-line
-  string work, tool arguments included, is bounded by the truncation limit,
-  not the payload.
+  string work, tool argument keys and values included, is bounded by the
+  truncation limit, not the payload.
 
 ## [0.6.1] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   assigned directly; a wrong assignment raises `ConfigurationError` at
   assignment time. Logging failures warn once per run and the run's sink
   goes quiet: they never raise into the run or replace a host exception,
-  including on invalid byte sequences. With no logger assigned the event
-  path is untouched (one nil check per run, nothing per event); with one
-  assigned, delta events short-circuit without allocating.
+  including on invalid byte sequences. Cached prompt tokens count toward
+  the tokens in and are called out (`900 in (890 cached)`); expected stops
+  log calmly (a cancel at info, a budget stop at warn, and a synthetic
+  budget stop never counts as a turn) so only real failures log at error;
+  non-printing bytes render as visible escapes so untrusted output cannot
+  steer a terminal. With no logger assigned the event path is untouched
+  (one nil check per run, nothing per event); with one assigned, delta
+  events short-circuit without allocating and per-line string work is
+  bounded by the truncation limit, not the payload.
 
 ## [0.6.1] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- `Mistri.logger` and `Mistri::Sinks::Logger`: assign any Logger-compatible
+  object and every run logs its story as one scannable line per beat, tagged
+  with its session: the input, each tool call with its arguments, each
+  result with its duration, each turn's token usage, retries, compaction,
+  approvals, worker reports, and a closing line with the run's outcome,
+  elapsed time, and dollar cost when pricing is known. Deltas never log;
+  origin-tagged events are skipped so every agent (sub-agents included, in
+  any process) logs its own events exactly once. Assign a preconfigured
+  `Sinks::Logger` for options (`color:`, `truncate:`), or compose one per
+  run like any sink. A logging failure warns once and goes quiet; it never
+  breaks a run. With no logger assigned, nothing changes.
+
 ## [0.6.1] - 2026-07-21
 
 - The ActiveRecord store and workspace read past the host's query cache.

--- a/README.md
+++ b/README.md
@@ -241,28 +241,43 @@ Mistri.logger = Rails.logger   # or any Logger-compatible object
 
 ```text
 [mistri 0a1b2c3d] run "What is 2 plus 3?" (gpt-5.6, 3 tools)
-[mistri 0a1b2c3d] tool add {"a":2,"b":3}
-[mistri 0a1b2c3d] tool add ok 12ms "5"
 [mistri 0a1b2c3d] turn 1 done tool_use (312 in / 48 out)
+[mistri 0a1b2c3d] tool add#7f3a {"a":2,"b":3}
+[mistri 0a1b2c3d] tool add#7f3a ok 12ms "5"
 [mistri 0a1b2c3d] text "The sum is 5."
 [mistri 0a1b2c3d] turn 2 done stop (410 in / 22 out)
 [mistri 0a1b2c3d] done completed in 1.2s, 2 turns, 722 in / 70 out, $0.0042
 ```
 
-Failed tools and retries log at warn, provider errors at error, and the
-closing line reports suspension, abort, or budget stops just as plainly.
-Sub-agents log under their own session tags exactly once, whichever process
-runs them, so concurrent workers interleave without garbling. Assign a
-preconfigured sink for options, or compose one per run like any other sink:
+A turn line lands when the model finishes speaking, so it precedes the tool
+executions that turn requested. The short `#id` on tool lines pairs
+concurrent same-name calls and is the handle `session.approve` needs when an
+`approval needed` line appears. Failed tools and retries log at warn,
+provider errors at error, and the closing line reports suspension, abort, or
+budget stops just as plainly. Sub-agents log under their own worker label
+(`[mistri researcher#89bb20de]`) exactly once, whichever process runs them;
+interleaved lines stay whole as long as the logger serializes writes, which
+stdlib `Logger` and Rails' do. A `task` logs one frame around all its fix
+passes.
+
+Assign a preconfigured sink for options. `level: :debug` floors the ordinary
+lines so a production logger sitting at `:info` stays clean, `truncate`
+bounds quoted values, and a wrong assignment raises at assignment time
+rather than leaving the log silently empty:
 
 ```ruby
-Mistri.logger = Mistri::Sinks::Logger.new(logger, color: true, truncate: 500)
-agent.run(input, &Mistri::Sinks::Logger.new(logger))
+Mistri.logger = Mistri::Sinks::Logger.new(logger, color: true, truncate: 500,
+                                          level: :debug)
 ```
 
-Logging never breaks a run: a failing logger warns once and the sink goes
-quiet. Production observability belongs to your telemetry sink; this one is
-for humans (and their AI agents) reading a log.
+Composing per run (`agent.run(input, &Mistri::Sinks::Logger.new(logger))`)
+is deliberately smaller: it delivers the event lines only, with no framing
+and no tag, because those come from the Agent. Logging never breaks a run: a
+failing logger warns once per run and that run's sink goes quiet. With no
+logger assigned the cost is one nil check per run; with one assigned, delta
+events short-circuit without allocating. Production observability belongs to
+your telemetry sink; this one is for humans (and their AI agents) reading a
+log.
 
 ## Long conversations and structured tasks
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,8 @@ That is the point in development, and it is fine in production too when
 your log pipeline is where you want the story (shipping these lines to your
 log platform gives you agent observability for free). When payloads must
 stay out of a log, `content: false` keeps the whole story as metadata:
-names, ids, durations, sizes, tokens, cost, and statuses. `level: :debug`
+names, ids, durations, sizes, tokens, cost, and statuses, and error, crash,
+and retry text reduces to its byte size while classes and reasons stay. `level: :debug`
 floors the ordinary lines, `truncate` bounds rendered values, and a wrong
 assignment raises at assignment time:
 
@@ -279,7 +280,10 @@ Mistri.logger = Mistri::Sinks::Logger.new(logger, content: false, level: :debug)
 Composing per run (`agent.run(input, &Mistri::Sinks::Logger.new(logger))`)
 is deliberately smaller: event lines under a bare `[mistri]` tag, no
 framing, and forwarded child events rendered with their origin, since no
-child sink exists to log them. Logging never breaks a run: construction and
+child sink exists to log them. Logger calls are synchronous on
+the run's own threads, so a slow logger slows the run: keep the destination
+local (stdout, a file) and let your log shipper make the network hop, or
+buffer at the logger layer. Logging never breaks a run: construction and
 every write are contained, and a failing logger warns once per run and that
 run's sink goes quiet. With no logger assigned the cost is one nil check
 per run; with one assigned, delta events short-circuit without allocating

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ the types they use and ignore the rest.
 
 ## Logging
 
-One assignment makes every run tell its story in your development log:
+One assignment makes every run tell its story in your log:
 
 ```ruby
 Mistri.logger = Rails.logger   # or any Logger-compatible object
@@ -251,35 +251,39 @@ Mistri.logger = Rails.logger   # or any Logger-compatible object
 
 A turn line lands when the model finishes speaking, so it precedes the tool
 executions that turn requested. The short `#id` on tool lines pairs
-concurrent same-name calls and is the handle `session.approve` needs when an
-`approval needed` line appears. Failed tools and retries log at warn
-and provider errors at error, while expected stops (a cancel, a budget
-ceiling) log calmly; the closing line reports suspension, abort, or budget
-stops just as plainly. Cached prompt tokens count toward "in" and are called
-out, and non-printing bytes render as visible escapes. Sub-agents log under their own worker label
-(`[mistri researcher#89bb20de]`) exactly once, whichever process runs them;
-interleaved lines stay whole as long as the logger serializes writes, which
-stdlib `Logger` and Rails' do. A `task` logs one frame around all its fix
-passes.
+concurrent same-name calls; an `approval needed` line carries the full call
+id, which is what `session.approve` takes. Failed tools and retries log at
+warn and provider errors at error, while expected stops (a cancel, a budget
+ceiling) log calmly. Cached prompt tokens count toward "in" and are called
+out, dollar cost appears whenever pricing is known (including a known
+$0.0000), and hidden bytes in any value render as visible escapes.
+Sub-agents log under their own worker label (`[mistri researcher#89bb20de]`)
+exactly once, whichever process runs them; a `worker` report line appears
+wherever a sink watched the spawn. Interleaved lines stay whole as long as
+the logger serializes writes, which stdlib `Logger` and Rails' do. A `task`
+logs one frame around all its fix passes.
 
-Assign a preconfigured sink for options. `level: :debug` floors the ordinary
-lines so a production logger sitting at `:info` stays clean, `truncate`
-bounds quoted values, and a wrong assignment raises at assignment time
-rather than leaving the log silently empty:
+By default the lines carry payloads: inputs, thinking, arguments, results.
+That is the point in development, and it is fine in production too when
+your log pipeline is where you want the story (shipping these lines to your
+log platform gives you agent observability for free). When payloads must
+stay out of a log, `content: false` keeps the whole story as metadata:
+names, ids, durations, sizes, tokens, cost, and statuses. `level: :debug`
+floors the ordinary lines, `truncate` bounds rendered values, and a wrong
+assignment raises at assignment time:
 
 ```ruby
-Mistri.logger = Mistri::Sinks::Logger.new(logger, color: true, truncate: 500,
-                                          level: :debug)
+Mistri.logger = Mistri::Sinks::Logger.new(logger, content: false, level: :debug)
 ```
 
 Composing per run (`agent.run(input, &Mistri::Sinks::Logger.new(logger))`)
-is deliberately smaller: it delivers the event lines only, with no framing
-and no tag, because those come from the Agent. Logging never breaks a run: a
-failing logger warns once per run and that run's sink goes quiet. With no
-logger assigned the cost is one nil check per run; with one assigned, delta
-events short-circuit without allocating. Production observability belongs to
-your telemetry sink; this one is for humans (and their AI agents) reading a
-log.
+is deliberately smaller: event lines under a bare `[mistri]` tag, no
+framing, and forwarded child events rendered with their origin, since no
+child sink exists to log them. Logging never breaks a run: construction and
+every write are contained, and a failing logger warns once per run and that
+run's sink goes quiet. With no logger assigned the cost is one nil check
+per run; with one assigned, delta events short-circuit without allocating
+and per-line work is bounded by the truncation limit, not the payload.
 
 ## Long conversations and structured tasks
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,39 @@ The same event stream works in Sinatra, Rack, a WebSocket server, a background
 job, or a test. Event types form an extensible union; consumers should handle
 the types they use and ignore the rest.
 
+## Logging
+
+One assignment makes every run tell its story in your development log:
+
+```ruby
+Mistri.logger = Rails.logger   # or any Logger-compatible object
+```
+
+```text
+[mistri 0a1b2c3d] run "What is 2 plus 3?" (gpt-5.6, 3 tools)
+[mistri 0a1b2c3d] tool add {"a":2,"b":3}
+[mistri 0a1b2c3d] tool add ok 12ms "5"
+[mistri 0a1b2c3d] turn 1 done tool_use (312 in / 48 out)
+[mistri 0a1b2c3d] text "The sum is 5."
+[mistri 0a1b2c3d] turn 2 done stop (410 in / 22 out)
+[mistri 0a1b2c3d] done completed in 1.2s, 2 turns, 722 in / 70 out, $0.0042
+```
+
+Failed tools and retries log at warn, provider errors at error, and the
+closing line reports suspension, abort, or budget stops just as plainly.
+Sub-agents log under their own session tags exactly once, whichever process
+runs them, so concurrent workers interleave without garbling. Assign a
+preconfigured sink for options, or compose one per run like any other sink:
+
+```ruby
+Mistri.logger = Mistri::Sinks::Logger.new(logger, color: true, truncate: 500)
+agent.run(input, &Mistri::Sinks::Logger.new(logger))
+```
+
+Logging never breaks a run: a failing logger warns once and the sink goes
+quiet. Production observability belongs to your telemetry sink; this one is
+for humans (and their AI agents) reading a log.
+
 ## Long conversations and structured tasks
 
 Compaction is on by default for catalogued models. When a session enters the

--- a/README.md
+++ b/README.md
@@ -252,9 +252,11 @@ Mistri.logger = Rails.logger   # or any Logger-compatible object
 A turn line lands when the model finishes speaking, so it precedes the tool
 executions that turn requested. The short `#id` on tool lines pairs
 concurrent same-name calls and is the handle `session.approve` needs when an
-`approval needed` line appears. Failed tools and retries log at warn,
-provider errors at error, and the closing line reports suspension, abort, or
-budget stops just as plainly. Sub-agents log under their own worker label
+`approval needed` line appears. Failed tools and retries log at warn
+and provider errors at error, while expected stops (a cancel, a budget
+ceiling) log calmly; the closing line reports suspension, abort, or budget
+stops just as plainly. Cached prompt tokens count toward "in" and are called
+out, and non-printing bytes render as visible escapes. Sub-agents log under their own worker label
 (`[mistri researcher#89bb20de]`) exactly once, whichever process runs them;
 interleaved lines stay whole as long as the logger serializes writes, which
 stdlib `Logger` and Rails' do. A `task` logs one frame around all its fix

--- a/lib/mistri.rb
+++ b/lib/mistri.rb
@@ -76,7 +76,7 @@ module Mistri
     attr_reader :logger
 
     def logger=(value)
-      sink_like = value.respond_to?(:for_session)
+      sink_like = value.is_a?(Sinks::Logger)
       logger_like = %i[info warn error].all? { |severity| value.respond_to?(severity) }
       unless value.nil? || sink_like || logger_like
         raise ConfigurationError,

--- a/lib/mistri.rb
+++ b/lib/mistri.rb
@@ -76,9 +76,12 @@ module Mistri
     attr_reader :logger
 
     def logger=(value)
-      unless value.nil? || value.respond_to?(:for_session) || value.respond_to?(:info)
+      sink_like = value.respond_to?(:for_session)
+      logger_like = %i[info warn error].all? { |severity| value.respond_to?(severity) }
+      unless value.nil? || sink_like || logger_like
         raise ConfigurationError,
-              "Mistri.logger takes a Logger-compatible object or a Mistri::Sinks::Logger"
+              "Mistri.logger takes a Logger-compatible object (info/warn/error) " \
+              "or a Mistri::Sinks::Logger"
       end
 
       @logger = value

--- a/lib/mistri.rb
+++ b/lib/mistri.rb
@@ -51,6 +51,7 @@ require_relative "mistri/mcp"
 require_relative "mistri/sinks/action_cable"
 require_relative "mistri/sinks/sse"
 require_relative "mistri/sinks/coalesced"
+require_relative "mistri/sinks/logger"
 require_relative "mistri/providers/fake"
 require_relative "mistri/providers/anthropic"
 require_relative "mistri/providers/openai"
@@ -66,8 +67,11 @@ module Mistri
                   gemini: "GEMINI_API_KEY" }.freeze
 
   # The configured lock adapter, nil until a host sets one. See Locks.
+  # The run logger, nil until a host sets one: a Logger-compatible object
+  # (info/warn/error), or a Sinks::Logger for options. Every Agent#run and
+  # #resume then logs its story. See Sinks::Logger.
   class << self
-    attr_accessor :locks
+    attr_accessor :locks, :logger
   end
 
   module_function

--- a/lib/mistri.rb
+++ b/lib/mistri.rb
@@ -68,10 +68,21 @@ module Mistri
 
   # The configured lock adapter, nil until a host sets one. See Locks.
   # The run logger, nil until a host sets one: a Logger-compatible object
-  # (info/warn/error), or a Sinks::Logger for options. Every Agent#run and
-  # #resume then logs its story. See Sinks::Logger.
+  # (info/warn/error), or a Sinks::Logger for options. Every Agent run
+  # then logs its story. A wrong assignment raises here, where the typo
+  # is, instead of leaving every run's log silently empty.
   class << self
-    attr_accessor :locks, :logger
+    attr_accessor :locks
+    attr_reader :logger
+
+    def logger=(value)
+      unless value.nil? || value.respond_to?(:for_session) || value.respond_to?(:info)
+        raise ConfigurationError,
+              "Mistri.logger takes a Logger-compatible object or a Mistri::Sinks::Logger"
+      end
+
+      @logger = value
+    end
   end
 
   module_function

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -77,18 +77,20 @@ module Mistri
     # schema, natively where the provider supports it. task adds validation
     # on top; run alone does not validate.
     def run(input, images: [], signal: nil, output_schema: nil, &emit)
-      if refresh_tool_control.any?
-        raise ConfigurationError,
-              "session is awaiting approvals; call resume"
-      end
-      if input.to_s.empty? && Array(images).empty?
-        raise ArgumentError,
-              "run needs input text or images"
-      end
-
-      fold_inbox # anything queued while this session sat idle arrived first; keep that order
-      @session.append_message(Message.user_with_images(input, images))
+      # The frame covers the whole public method, so an audit rejection or
+      # a store failure gets a crash line too, not just loop failures.
       logged(emit, verb: "run", input: input) do |subscriber|
+        if refresh_tool_control.any?
+          raise ConfigurationError,
+                "session is awaiting approvals; call resume"
+        end
+        if input.to_s.empty? && Array(images).empty?
+          raise ArgumentError,
+                "run needs input text or images"
+        end
+
+        fold_inbox # anything queued while this session sat idle arrived first; keep that order
+        @session.append_message(Message.user_with_images(input, images))
         loop_turns(signal, output_schema, &subscriber)
       end
     end
@@ -99,9 +101,9 @@ module Mistri
     # carries on as if it never stopped, unless a settled call's tool ends
     # the turn, in which case its execution was the run's last word.
     def resume(signal: nil, &emit)
-      open = refresh_tool_control
-      pending = open.select { |approval| approval[:decision].nil? }
       logged(emit, verb: "resume") do |subscriber|
+        open = refresh_tool_control
+        pending = open.select { |approval| approval[:decision].nil? }
         if pending.any?
           next Result.new(message: nil, status: :awaiting_approval,
                           pending: pending.map { |approval| approval[:call] },
@@ -134,11 +136,11 @@ module Mistri
     # belongs to whoever answers, and re-prompting for JSON would steal it
     # back. Ask again once the answer arrives.
     def task(input, schema:, images: [], signal: nil, fixes: 1, &emit)
-      plan = Schema.task_plan(schema)
       # One log frame for the whole task, fix passes included: the inner
       # runs see the frame open and only tee, so the single done line
       # reports the validated outcome, not a rejected intermediate answer.
       logged(emit, verb: "task", input: input) do |subscriber|
+        plan = Schema.task_plan(schema)
         validated_task(input, plan, images, signal, fixes, &subscriber)
       end
     end
@@ -223,11 +225,7 @@ module Mistri
     def log_sink
       return nil if @log_depth.positive?
 
-      configured = Mistri.logger
-      return nil unless configured
-
-      sink = configured.respond_to?(:for_session) ? configured : Sinks::Logger.new(configured)
-      sink.for_session(@session.id, label: @log_label)
+      Sinks::Logger.attach(@session.id, label: @log_label)
     end
 
     def loop_turns(signal, output_schema = nil, &emit)

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -39,10 +39,12 @@ module Mistri
     # when an approved call finally executes, so a decision that aged days
     # still passes current policy); after_tool(call, result, context) may
     # return a replacement result, or nil to keep the original.
+    # log_label tags this agent's log lines (sub-agents
+    # get their worker label); nil falls back to the session id.
     def initialize(provider:, session: nil, system: nil, tools: [], budget: nil,
                    max_concurrency: 4, transform_context: nil, compaction: Compaction.new,
                    retries: RetryPolicy.new, skills: [], before_tool: nil, after_tool: nil,
-                   context: nil)
+                   context: nil, log_label: nil)
       @provider = provider
       @session = session || Session.new(store: Stores::Memory.new)
       skills = skills.is_a?(String) ? Skills.load(skills) : Array(skills)
@@ -62,6 +64,8 @@ module Mistri
       @before_tool = before_tool
       @after_tool = after_tool
       @context = context
+      @log_label = log_label
+      @log_depth = 0
     end
 
     attr_reader :session
@@ -97,13 +101,13 @@ module Mistri
     def resume(signal: nil, &emit)
       open = refresh_tool_control
       pending = open.select { |approval| approval[:decision].nil? }
-      if pending.any?
-        return Result.new(message: nil, status: :awaiting_approval,
+      logged(emit, verb: "resume") do |subscriber|
+        if pending.any?
+          next Result.new(message: nil, status: :awaiting_approval,
                           pending: pending.map { |approval| approval[:call] },
                           usage: Usage.zero)
-      end
+        end
 
-      logged(emit, verb: "resume") do |subscriber|
         executed = settle(open, signal, &subscriber)
         if signal&.aborted?
           last = @session.messages.reverse_each.find(&:assistant?)
@@ -131,22 +135,11 @@ module Mistri
     # back. Ask again once the answer arrives.
     def task(input, schema:, images: [], signal: nil, fixes: 1, &emit)
       plan = Schema.task_plan(schema)
-      result = run(
-        TaskOutput.prompt(input, plan), images:, signal:, output_schema: plan, &emit
-      )
-      spent = result.usage
-      fixes.downto(0) do |remaining|
-        result = result.with(usage: spent)
-        return result unless result.completed?
-        return result if result.handed_off?
-
-        value = TaskOutput.parse(result.text)
-        errors = TaskOutput.errors(value, plan)
-        return result.with(output: value) if errors.empty?
-        raise SchemaError, "task output failed validation: #{errors.join("; ")}" if remaining.zero?
-
-        result = run(TaskOutput.fix_prompt(errors), signal:, output_schema: plan, &emit)
-        spent += result.usage
+      # One log frame for the whole task, fix passes included: the inner
+      # runs see the frame open and only tee, so the single done line
+      # reports the validated outcome, not a rejected intermediate answer.
+      logged(emit, verb: "task", input: input) do |subscriber|
+        validated_task(input, plan, images, signal, fixes, &subscriber)
       end
     end
 
@@ -169,42 +162,72 @@ module Mistri
 
     private
 
+    # The body of task, extracted so its early returns close the log frame
+    # instead of skipping it.
+    def validated_task(input, plan, images, signal, fixes, &emit)
+      result = run(
+        TaskOutput.prompt(input, plan), images:, signal:, output_schema: plan, &emit
+      )
+      spent = result.usage
+      fixes.downto(0) do |remaining|
+        result = result.with(usage: spent)
+        return result unless result.completed?
+        return result if result.handed_off?
+
+        value = TaskOutput.parse(result.text)
+        errors = TaskOutput.errors(value, plan)
+        return result.with(output: value) if errors.empty?
+        raise SchemaError, "task output failed validation: #{errors.join("; ")}" if remaining.zero?
+
+        result = run(TaskOutput.fix_prompt(errors), signal:, output_schema: plan, &emit)
+        spent += result.usage
+      end
+    end
+
     # When a host sets Mistri.logger, every public run tees its events into
     # a fresh logging sink for this session alongside the caller's block,
     # and the framing lines carry what the stream cannot: the input, the
-    # model, and the final Result. Nothing wraps when no logger is set, and
-    # a caller's subscriber failures propagate exactly as before because
-    # the sink never raises.
+    # model, and the final Result. Nothing wraps when no logger is set, a
+    # nested public call (task's inner runs) reuses the open frame, and a
+    # caller's subscriber failures propagate exactly as before because the
+    # sink never raises.
     def logged(emit, verb:, input: nil)
       sink = log_sink
       return yield(emit) unless sink
 
-      sink.run_started(verb: verb, input: input, model: @provider.model,
-                       tool_count: @tools.length)
-      subscriber = if emit
-                     lambda { |event|
-                       sink.call(event)
-                       emit.call(event)
-                     }
-                   else
-                     sink.to_proc
-                   end
+      @log_depth += 1
       begin
-        result = yield(subscriber)
-      rescue StandardError => e
-        sink.run_crashed(EventDelivery.original(e))
-        raise
+        sink.run_started(verb: verb, input: input, model: @provider.model,
+                         tool_count: @tools.length)
+        subscriber = if emit
+                       lambda { |event|
+                         sink.call(event)
+                         emit.call(event)
+                       }
+                     else
+                       sink.to_proc
+                     end
+        begin
+          result = yield(subscriber)
+        rescue StandardError => e
+          sink.run_crashed(EventDelivery.original(e))
+          raise
+        end
+        sink.run_finished(result)
+        result
+      ensure
+        @log_depth -= 1
       end
-      sink.run_finished(result)
-      result
     end
 
     def log_sink
+      return nil if @log_depth.positive?
+
       configured = Mistri.logger
       return nil unless configured
 
-      sink = configured.is_a?(Sinks::Logger) ? configured : Sinks::Logger.new(configured)
-      sink.for_session(@session.id)
+      sink = configured.respond_to?(:for_session) ? configured : Sinks::Logger.new(configured)
+      sink.for_session(@session.id, label: @log_label)
     end
 
     def loop_turns(signal, output_schema = nil, &emit)

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -84,7 +84,9 @@ module Mistri
 
       fold_inbox # anything queued while this session sat idle arrived first; keep that order
       @session.append_message(Message.user_with_images(input, images))
-      loop_turns(signal, output_schema, &emit)
+      logged(emit, verb: "run", input: input) do |subscriber|
+        loop_turns(signal, output_schema, &subscriber)
+      end
     end
 
     # Continue a suspended run. Undecided approvals return immediately, still
@@ -101,17 +103,19 @@ module Mistri
                           usage: Usage.zero)
       end
 
-      executed = settle(open, signal, &emit)
-      if signal&.aborted?
-        last = @session.messages.reverse_each.find(&:assistant?)
-        return finished(last, Usage.zero, signal)
-      end
-      if executed.any? { |call| ends_turn?(call) }
-        last = @session.messages.reverse_each.find(&:assistant?)
-        return finished(last, Usage.zero, signal, handed_off: true)
-      end
+      logged(emit, verb: "resume") do |subscriber|
+        executed = settle(open, signal, &subscriber)
+        if signal&.aborted?
+          last = @session.messages.reverse_each.find(&:assistant?)
+          next finished(last, Usage.zero, signal)
+        end
+        if executed.any? { |call| ends_turn?(call) }
+          last = @session.messages.reverse_each.find(&:assistant?)
+          next finished(last, Usage.zero, signal, handed_off: true)
+        end
 
-      loop_turns(signal, nil, &emit)
+        loop_turns(signal, nil, &subscriber)
+      end
     end
 
     # Run an exchange that must end in a JSON value matching schema. Tools
@@ -164,6 +168,44 @@ module Mistri
     end
 
     private
+
+    # When a host sets Mistri.logger, every public run tees its events into
+    # a fresh logging sink for this session alongside the caller's block,
+    # and the framing lines carry what the stream cannot: the input, the
+    # model, and the final Result. Nothing wraps when no logger is set, and
+    # a caller's subscriber failures propagate exactly as before because
+    # the sink never raises.
+    def logged(emit, verb:, input: nil)
+      sink = log_sink
+      return yield(emit) unless sink
+
+      sink.run_started(verb: verb, input: input, model: @provider.model,
+                       tool_count: @tools.length)
+      subscriber = if emit
+                     lambda { |event|
+                       sink.call(event)
+                       emit.call(event)
+                     }
+                   else
+                     sink.to_proc
+                   end
+      begin
+        result = yield(subscriber)
+      rescue StandardError => e
+        sink.run_crashed(EventDelivery.original(e))
+        raise
+      end
+      sink.run_finished(result)
+      result
+    end
+
+    def log_sink
+      configured = Mistri.logger
+      return nil unless configured
+
+      sink = configured.is_a?(Sinks::Logger) ? configured : Sinks::Logger.new(configured)
+      sink.for_session(@session.id)
+    end
 
     def loop_turns(signal, output_schema = nil, &emit)
       turns = 0

--- a/lib/mistri/sinks/logger.rb
+++ b/lib/mistri/sinks/logger.rb
@@ -9,26 +9,29 @@ module Mistri
     # which arguments, how long each took, what every turn cost, and how
     # the run ended. Deltas never log (whole blocks do), and origin-tagged
     # events are skipped because every agent logs its own: a sub-agent's
-    # lines carry its own session tag exactly once, however deep the
-    # nesting and whichever process runs it.
+    # lines carry its own tag exactly once, however deep the nesting
+    # and whichever process runs it.
     #
     # Assigning Mistri.logger turns this on for every run in one line:
     #
     #   Mistri.logger = Rails.logger
     #   Mistri.logger = Mistri::Sinks::Logger.new(logger, color: true)
     #
-    # or compose it per run like any sink:
+    # or compose it per run like any sink, which delivers the event lines
+    # only: framing (run, done) and the line tag come from the Agent, so
+    # the composed form has neither.
     #
     #   agent.run(input, &Mistri::Sinks::Logger.new(logger))
     #
     # Any object responding to info/warn/error works. Logging must never
-    # break a run: the first failure warns and the sink goes quiet.
-    # Tool events arrive from executor threads; the only mutable state
-    # (the turn counter) moves on loop-thread events, and the logger
-    # itself serializes writes.
+    # break a run: every entry point rescues, the first failure warns, and
+    # the sink goes quiet for the rest of its run. Tool events arrive from
+    # executor threads; the only mutable state (the turn counter) moves on
+    # loop-thread events, and interleaved lines stay whole as long as the
+    # host's logger serializes writes, which stdlib Logger and Rails do.
     class Logger
       SKIPPED = %i[start text_start text_delta thinking_start thinking_delta
-                   toolcall_start toolcall_delta toolcall_end].freeze
+                   toolcall_start toolcall_delta toolcall_end].to_h { |type| [type, true] }.freeze
       LINES = { text_end: :text_line, thinking_end: :thinking_line,
                 tool_started: :tool_line, tool_result: :tool_result_line,
                 done: :turn_line, error: :error_line, retry: :retry_line,
@@ -37,27 +40,33 @@ module Mistri
       COLORS = { bold: "1", dim: "2", red: "31", green: "32", yellow: "33" }.freeze
       private_constant :SKIPPED, :LINES, :COLORS
 
-      # truncate bounds every quoted value (nil for full payloads); session
-      # becomes the line tag so concurrent runs stay distinguishable.
-      def initialize(logger, session: nil, truncate: 200, color: false)
+      # truncate bounds every quoted value (nil for full payloads). session
+      # is the line tag, verbatim, so concurrent runs stay distinguishable.
+      # level is the floor for the ordinary lines: pass :debug to keep the
+      # story out of a production logger sitting at :info; warnings and
+      # errors keep their own levels regardless.
+      def initialize(logger, session: nil, truncate: 200, color: false, level: :info)
         @logger = logger
-        @session = session && session.to_s[0, 8]
+        @session = session&.to_s
         @truncate = truncate
         @color = color
+        @level = level
         @turns = 0
         @started = now
         @warned = false
         @tag = paint(@session ? "[mistri #{@session}]" : "[mistri]", :dim)
       end
 
-      # A fresh sink for one run: same logger and options, this session's
-      # tag, its own turn count and clock.
-      def for_session(id)
-        self.class.new(@logger, session: id, truncate: @truncate, color: @color)
+      # A fresh sink for one run: same logger and options, this run's tag
+      # (a sub-agent's label, or the session id), its own turn count
+      # and clock.
+      def for_session(id, label: nil)
+        self.class.new(@logger, session: label || id.to_s[0, 8], truncate: @truncate,
+                                color: @color, level: @level)
       end
 
       def call(event)
-        return if @warned || event.origin || SKIPPED.include?(event.type)
+        return if @warned || event.origin || SKIPPED[event.type]
 
         handler = LINES[event.type]
         # Future event types degrade to a greppable line, never to silence.
@@ -69,38 +78,51 @@ module Mistri
       def to_proc = method(:call).to_proc
 
       # The framing the stream cannot carry: the Agent calls these around a
-      # run with the input, the model, and the final Result.
+      # run with the input, the model, and the final Result. Each is total
+      # for the same reason call is: a logging failure inside a rescue
+      # block must never replace the host's own exception.
       def run_started(verb:, model:, tool_count:, input: nil)
         @turns = 0
         @started = now
         ask = input ? %( "#{trim(input)}") : ""
         write("#{paint(verb, :bold)}#{ask} (#{model}, #{count(tool_count, "tool")})")
+      rescue StandardError => e
+        quiet(e)
       end
 
       def run_finished(result)
         status, level = status_of(result)
         write("#{paint("done", :bold)} #{status} in #{clock(now - @started)}, " \
               "#{count(@turns, "turn")}#{summary(result.usage)}", level: level)
+      rescue StandardError => e
+        quiet(e)
       end
 
       def run_crashed(error)
         write("#{paint("crashed", :red)} #{error.class}: #{trim(error.message)}", level: :error)
+      rescue StandardError => e
+        quiet(e)
       end
 
       private
 
-      def text_line(event) = write(%(text "#{trim(event.content)}"))
+      def text_line(event)
+        content = trim(event.content)
+        write(%(text "#{content}")) unless content.empty?
+      end
 
-      def thinking_line(event) = write(%(thinking "#{trim(event.content)}"))
+      def thinking_line(event)
+        content = trim(event.content)
+        write(%(thinking "#{content}")) unless content.empty?
+      end
 
       def tool_line(event)
-        write("tool #{paint(event.tool_call.name, :green)} #{arguments(event.tool_call)}")
+        write("tool #{title(event.tool_call)} #{arguments(event.tool_call)}")
       end
 
       def tool_result_line(event)
-        name = event.tool_call ? event.tool_call.name : "?"
         verdict = event.tool_error? ? paint("FAILED", :red) : "ok"
-        parts = ["tool #{paint(name, :green)} #{verdict}", clock(event.duration),
+        parts = ["tool #{title(event.tool_call)} #{verdict}", clock(event.duration),
                  quote(event.content)]
         write(parts.compact.join(" "), level: event.tool_error? ? :warn : :info)
       end
@@ -110,7 +132,9 @@ module Mistri
         write("turn #{@turns} done #{event.reason}#{tokens(event.message&.usage)}")
       end
 
+      # An errored turn still made a provider call, so it counts.
       def error_line(event)
+        @turns += 1
         detail = [event.reason, presence(trim(event.error_message))].compact.join(": ")
         write("#{paint("error", :red)} #{detail}", level: :error)
       end
@@ -122,8 +146,7 @@ module Mistri
       end
 
       def approval_line(event)
-        write("approval needed #{paint(event.tool_call.name, :green)} " \
-              "#{arguments(event.tool_call)}")
+        write("approval needed #{title(event.tool_call)} #{arguments(event.tool_call)}")
       end
 
       def compacting_line(_event) = write("compacting")
@@ -159,24 +182,44 @@ module Mistri
         usage ? " (#{usage.input} in / #{usage.output} out)" : ""
       end
 
+      # A short call id makes concurrent same-name calls pairable and gives
+      # an approval line the handle session.approve needs.
+      def title(tool_call)
+        return paint("?", :green) unless tool_call
+
+        name = paint(tool_call.name, :green)
+        id = tool_call.id.to_s
+        ref = id.length > 4 ? id[-4, 4] : id
+        ref.empty? ? name : "#{name}##{ref}"
+      end
+
       def arguments(tool_call)
         return "[#{trim(tool_call.arguments_error)}]" if tool_call.arguments_error?
 
-        trim(JSON.generate(tool_call.arguments || {}))
+        json = JSON.generate(tool_call.arguments || {})
+        body, cut = clip(json)
+        cut ? "#{body} (#{bytes(json)})" : body
       end
 
       def quote(text)
         return nil if text.nil?
 
-        body = %("#{trim(text)}")
-        text.to_s.length > (@truncate || Float::INFINITY) ? "#{body} (#{bytes(text)})" : body
+        body, cut = clip(text)
+        cut ? %("#{body}" (#{bytes(text)})) : %("#{body}")
       end
 
-      def trim(text)
-        flat = text.to_s.gsub(/\s+/, " ").strip
-        return flat unless @truncate && flat.length > @truncate
+      def trim(text) = clip(text).first
 
-        "#{flat[0, @truncate].rstrip}..."
+      # Invalid bytes degrade to replacement characters instead of raising
+      # out of a log line: scrub repairs a string invalid in its own
+      # encoding (encode alone skips same-encoding validation), then encode
+      # converts binary. The size suffix reports the original payload.
+      def clip(text)
+        flat = text.to_s.scrub.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+                   .gsub(/\s+/, " ").strip
+        return [flat, false] unless @truncate && flat.length > @truncate
+
+        ["#{flat[0, @truncate].rstrip}...", true]
       end
 
       def clock(duration)
@@ -201,6 +244,7 @@ module Mistri
       def write(line, level: :info)
         return if @warned
 
+        level = @level if level == :info
         @logger.public_send(level, "#{@tag} #{line}")
       rescue StandardError => e
         quiet(e)
@@ -210,7 +254,8 @@ module Mistri
         return if @warned
 
         @warned = true
-        warn "mistri: logging sink failed (#{error.class}: #{error.message}); logging disabled"
+        warn "mistri: logging sink failed (#{error.class}: #{error.message}); " \
+             "logging disabled for this run"
       end
 
       def now = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/lib/mistri/sinks/logger.rb
+++ b/lib/mistri/sinks/logger.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Mistri
+  module Sinks
+    # Renders the event stream as one log line per meaningful beat, so a
+    # development log tells each run's whole story: which tools ran with
+    # which arguments, how long each took, what every turn cost, and how
+    # the run ended. Deltas never log (whole blocks do), and origin-tagged
+    # events are skipped because every agent logs its own: a sub-agent's
+    # lines carry its own session tag exactly once, however deep the
+    # nesting and whichever process runs it.
+    #
+    # Assigning Mistri.logger turns this on for every run in one line:
+    #
+    #   Mistri.logger = Rails.logger
+    #   Mistri.logger = Mistri::Sinks::Logger.new(logger, color: true)
+    #
+    # or compose it per run like any sink:
+    #
+    #   agent.run(input, &Mistri::Sinks::Logger.new(logger))
+    #
+    # Any object responding to info/warn/error works. Logging must never
+    # break a run: the first failure warns and the sink goes quiet.
+    # Tool events arrive from executor threads; the only mutable state
+    # (the turn counter) moves on loop-thread events, and the logger
+    # itself serializes writes.
+    class Logger
+      SKIPPED = %i[start text_start text_delta thinking_start thinking_delta
+                   toolcall_start toolcall_delta toolcall_end].freeze
+      LINES = { text_end: :text_line, thinking_end: :thinking_line,
+                tool_started: :tool_line, tool_result: :tool_result_line,
+                done: :turn_line, error: :error_line, retry: :retry_line,
+                approval_needed: :approval_line, compacting: :compacting_line,
+                compaction: :compaction_line, subagent_report: :report_line }.freeze
+      COLORS = { bold: "1", dim: "2", red: "31", green: "32", yellow: "33" }.freeze
+      private_constant :SKIPPED, :LINES, :COLORS
+
+      # truncate bounds every quoted value (nil for full payloads); session
+      # becomes the line tag so concurrent runs stay distinguishable.
+      def initialize(logger, session: nil, truncate: 200, color: false)
+        @logger = logger
+        @session = session && session.to_s[0, 8]
+        @truncate = truncate
+        @color = color
+        @turns = 0
+        @started = now
+        @warned = false
+        @tag = paint(@session ? "[mistri #{@session}]" : "[mistri]", :dim)
+      end
+
+      # A fresh sink for one run: same logger and options, this session's
+      # tag, its own turn count and clock.
+      def for_session(id)
+        self.class.new(@logger, session: id, truncate: @truncate, color: @color)
+      end
+
+      def call(event)
+        return if @warned || event.origin || SKIPPED.include?(event.type)
+
+        handler = LINES[event.type]
+        # Future event types degrade to a greppable line, never to silence.
+        handler ? send(handler, event) : write("#{event.type} #{trim(event.content)}".rstrip)
+      rescue StandardError => e
+        quiet(e)
+      end
+
+      def to_proc = method(:call).to_proc
+
+      # The framing the stream cannot carry: the Agent calls these around a
+      # run with the input, the model, and the final Result.
+      def run_started(verb:, model:, tool_count:, input: nil)
+        @turns = 0
+        @started = now
+        ask = input ? %( "#{trim(input)}") : ""
+        write("#{paint(verb, :bold)}#{ask} (#{model}, #{count(tool_count, "tool")})")
+      end
+
+      def run_finished(result)
+        status, level = status_of(result)
+        write("#{paint("done", :bold)} #{status} in #{clock(now - @started)}, " \
+              "#{count(@turns, "turn")}#{summary(result.usage)}", level: level)
+      end
+
+      def run_crashed(error)
+        write("#{paint("crashed", :red)} #{error.class}: #{trim(error.message)}", level: :error)
+      end
+
+      private
+
+      def text_line(event) = write(%(text "#{trim(event.content)}"))
+
+      def thinking_line(event) = write(%(thinking "#{trim(event.content)}"))
+
+      def tool_line(event)
+        write("tool #{paint(event.tool_call.name, :green)} #{arguments(event.tool_call)}")
+      end
+
+      def tool_result_line(event)
+        name = event.tool_call ? event.tool_call.name : "?"
+        verdict = event.tool_error? ? paint("FAILED", :red) : "ok"
+        parts = ["tool #{paint(name, :green)} #{verdict}", clock(event.duration),
+                 quote(event.content)]
+        write(parts.compact.join(" "), level: event.tool_error? ? :warn : :info)
+      end
+
+      def turn_line(event)
+        @turns += 1
+        write("turn #{@turns} done #{event.reason}#{tokens(event.message&.usage)}")
+      end
+
+      def error_line(event)
+        detail = [event.reason, presence(trim(event.error_message))].compact.join(": ")
+        write("#{paint("error", :red)} #{detail}", level: :error)
+      end
+
+      def retry_line(event)
+        wait = event.delay ? " in #{event.delay.round(1)}s" : ""
+        write("#{paint("retry", :yellow)} #{event.attempt}/#{event.max_attempts}#{wait}: " \
+              "#{trim(event.content)}", level: :warn)
+      end
+
+      def approval_line(event)
+        write("approval needed #{paint(event.tool_call.name, :green)} " \
+              "#{arguments(event.tool_call)}")
+      end
+
+      def compacting_line(_event) = write("compacting")
+
+      def compaction_line(event) = write(%(compacted "#{trim(event.content)}"))
+
+      def report_line(event)
+        write("worker #{event.agent} (#{event.session_id.to_s[0, 8]}) #{event.status} " \
+              "#{quote(event.content)}".rstrip)
+      end
+
+      def status_of(result)
+        case result.status
+        when :completed
+          [result.handed_off? ? "completed (handed off)" : "completed", :info]
+        when :awaiting_approval
+          ["suspended (#{count(result.pending.length, "approval")} pending)", :info]
+        when :aborted then ["aborted", :info]
+        when :budget then ["stopped on budget", :warn]
+        else [paint(result.status.to_s, :red), :error]
+        end
+      end
+
+      def summary(usage)
+        return "" unless usage
+
+        base = ", #{usage.input} in / #{usage.output} out"
+        cost = usage.cost
+        cost&.known? && cost.total.positive? ? base + format(", $%.4f", cost.total) : base
+      end
+
+      def tokens(usage)
+        usage ? " (#{usage.input} in / #{usage.output} out)" : ""
+      end
+
+      def arguments(tool_call)
+        return "[#{trim(tool_call.arguments_error)}]" if tool_call.arguments_error?
+
+        trim(JSON.generate(tool_call.arguments || {}))
+      end
+
+      def quote(text)
+        return nil if text.nil?
+
+        body = %("#{trim(text)}")
+        text.to_s.length > (@truncate || Float::INFINITY) ? "#{body} (#{bytes(text)})" : body
+      end
+
+      def trim(text)
+        flat = text.to_s.gsub(/\s+/, " ").strip
+        return flat unless @truncate && flat.length > @truncate
+
+        "#{flat[0, @truncate].rstrip}..."
+      end
+
+      def clock(duration)
+        return nil unless duration
+
+        duration < 1 ? "#{(duration * 1000).round}ms" : "#{duration.round(1)}s"
+      end
+
+      def bytes(text)
+        size = text.to_s.bytesize
+        return "#{size}B" if size < 1024
+
+        size < 1_048_576 ? format("%.1fKB", size / 1024.0) : format("%.1fMB", size / 1_048_576.0)
+      end
+
+      def count(number, noun) = "#{number} #{number == 1 ? noun : "#{noun}s"}"
+
+      def presence(text) = text.empty? ? nil : text
+
+      def paint(text, color) = @color ? "\e[#{COLORS.fetch(color)}m#{text}\e[0m" : text
+
+      def write(line, level: :info)
+        return if @warned
+
+        @logger.public_send(level, "#{@tag} #{line}")
+      rescue StandardError => e
+        quiet(e)
+      end
+
+      def quiet(error)
+        return if @warned
+
+        @warned = true
+        warn "mistri: logging sink failed (#{error.class}: #{error.message}); logging disabled"
+      end
+
+      def now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/mistri/sinks/logger.rb
+++ b/lib/mistri/sinks/logger.rb
@@ -38,7 +38,9 @@ module Mistri
                 approval_needed: :approval_line, compacting: :compacting_line,
                 compaction: :compaction_line, subagent_report: :report_line }.freeze
       COLORS = { bold: "1", dim: "2", red: "31", green: "32", yellow: "33" }.freeze
-      private_constant :SKIPPED, :LINES, :COLORS
+      CONTROLS = /[\x00-\x1f\x7f]/
+      HEAD = 4096
+      private_constant :SKIPPED, :LINES, :COLORS, :CONTROLS, :HEAD
 
       # truncate bounds every quoted value (nil for full payloads). session
       # is the line tag, verbatim, so concurrent runs stay distinguishable.
@@ -132,11 +134,20 @@ module Mistri
         write("turn #{@turns} done #{event.reason}#{tokens(event.message&.usage)}")
       end
 
-      # An errored turn still made a provider call, so it counts.
+      # :error also carries expected stops, which log calmly; only real
+      # failures alarm. A budget stop is synthetic (no provider call), so
+      # it alone does not count as a turn.
       def error_line(event)
-        @turns += 1
-        detail = [event.reason, presence(trim(event.error_message))].compact.join(": ")
-        write("#{paint("error", :red)} #{detail}", level: :error)
+        case event.reason
+        when StopReason::BUDGET then write("stopped on budget", level: :warn)
+        when StopReason::ABORTED
+          @turns += 1
+          write("aborted")
+        else
+          @turns += 1
+          detail = [event.reason, presence(trim(event.error_message))].compact.join(": ")
+          write("#{paint("error", :red)} #{detail}", level: :error)
+        end
       end
 
       def retry_line(event)
@@ -173,13 +184,21 @@ module Mistri
       def summary(usage)
         return "" unless usage
 
-        base = ", #{usage.input} in / #{usage.output} out"
+        base = ", #{prompt(usage)} / #{usage.output} out"
         cost = usage.cost
         cost&.known? && cost.total.positive? ? base + format(", $%.4f", cost.total) : base
       end
 
       def tokens(usage)
-        usage ? " (#{usage.input} in / #{usage.output} out)" : ""
+        usage ? " (#{prompt(usage)} / #{usage.output} out)" : ""
+      end
+
+      # Cache traffic is real prompt volume; input alone under-reports it.
+      def prompt(usage)
+        cached = usage.cache_read + usage.cache_write
+        return "#{usage.input} in" unless cached.positive?
+
+        "#{usage.input + cached} in (#{cached} cached)"
       end
 
       # A short call id makes concurrent same-name calls pairable and gives
@@ -210,14 +229,19 @@ module Mistri
 
       def trim(text) = clip(text).first
 
-      # Invalid bytes degrade to replacement characters instead of raising
-      # out of a log line: scrub repairs a string invalid in its own
-      # encoding (encode alone skips same-encoding validation), then encode
-      # converts binary. The size suffix reports the original payload.
+      # String work per line stays bounded: only a head of the payload is
+      # normalized, never all of it. scrub repairs invalid bytes (encode
+      # alone skips same-encoding validation), encode converts binary, and
+      # non-printing controls become visible escapes so untrusted output
+      # cannot steer a terminal. The size suffix reports the whole payload.
       def clip(text)
-        flat = text.to_s.scrub.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+        raw = text.to_s
+        head = @truncate ? raw[0, [(@truncate * 2) + 1, HEAD].max] : raw
+        flat = head.scrub.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
                    .gsub(/\s+/, " ").strip
-        return [flat, false] unless @truncate && flat.length > @truncate
+                   .gsub(CONTROLS) { |control| format("\\x%02x", control.ord) }
+        cut = @truncate && (flat.length > @truncate || head.bytesize < raw.bytesize)
+        return [flat, false] unless cut
 
         ["#{flat[0, @truncate].rstrip}...", true]
       end

--- a/lib/mistri/sinks/logger.rb
+++ b/lib/mistri/sinks/logger.rb
@@ -93,7 +93,7 @@ module Mistri
         configured = Mistri.logger
         return nil unless configured
 
-        sink = configured.respond_to?(:for_session) ? configured : new(configured)
+        sink = configured.is_a?(self) ? configured : new(configured)
         sink.for_session(id, label: label)
       rescue StandardError => e
         warn "mistri: logging sink construction failed (#{e.class}: #{e.message}); run not logged"
@@ -110,7 +110,7 @@ module Mistri
         handler = LINES[event.type]
         prefix = event.origin ? "#{field(event.origin)} " : ""
         # Future event types degrade to a greppable line, never to silence.
-        line = handler ? send(handler, event) : "#{event.type} #{trim(event.content)}".rstrip
+        line = handler ? send(handler, event) : "#{event.type} #{body_of(event.content)}".rstrip
         write("#{prefix}#{line.first}", level: line.last) if line.is_a?(Array)
         write("#{prefix}#{line}") if line.is_a?(String)
       rescue StandardError => e
@@ -145,7 +145,7 @@ module Mistri
       end
 
       def run_crashed(error)
-        write("#{paint("crashed", :red)} #{error.class}: #{trim(error.message)}", level: :error)
+        write("#{paint("crashed", :red)} #{error.class}#{note(error.message)}", level: :error)
       rescue StandardError => e
         quiet(e)
       end
@@ -189,15 +189,14 @@ module Mistri
           "aborted"
         else
           @turns += 1
-          detail = [event.reason, presence(trim(event.error_message))].compact.join(": ")
-          ["#{paint("error", :red)} #{detail}", :error]
+          ["#{paint("error", :red)} #{event.reason}#{note(event.error_message)}", :error]
         end
       end
 
       def retry_line(event)
         wait = event.delay ? " in #{event.delay.round(1)}s" : ""
-        ["#{paint("retry", :yellow)} #{event.attempt}/#{event.max_attempts}#{wait}: " \
-         "#{trim(event.content)}", :warn]
+        ["#{paint("retry", :yellow)} #{event.attempt}/#{event.max_attempts}#{wait}" \
+         "#{note(event.content)}", :warn]
       end
 
       # The full call id rides the line: Session#approve takes exactly that
@@ -278,17 +277,19 @@ module Mistri
         case value
         when Hash
           walk(value, out, "{", "}") do |(key, item)|
-            out << JSON.generate(key.to_s) << ":"
+            out << JSON.generate(snip(key.to_s)) << ":"
             preview(item, out)
           end
         when Array
           walk(value, out, "[", "]") { |item| preview(item, out) }
         when String
-          out << JSON.generate(@truncate ? value[0, @truncate] : value)
+          out << JSON.generate(snip(value))
         else
           out << JSON.generate(value)
         end
       end
+
+      def snip(text) = @truncate ? text[0, @truncate] : text
 
       def walk(items, out, open, close)
         out << open
@@ -299,6 +300,15 @@ module Mistri
           yield(item)
         end
         out << close
+      end
+
+      # Diagnostics keep their class and reason in every mode; the free
+      # text obeys content:, because exception messages can echo payloads.
+      def note(text)
+        flat = presence(trim(text))
+        return "" unless flat
+
+        @content ? ": #{flat}" : " (#{bytes(text)})"
       end
 
       # content: false keeps the beat and the volume, never the words.

--- a/lib/mistri/sinks/logger.rb
+++ b/lib/mistri/sinks/logger.rb
@@ -5,23 +5,26 @@ require "json"
 module Mistri
   module Sinks
     # Renders the event stream as one log line per meaningful beat, so a
-    # development log tells each run's whole story: which tools ran with
-    # which arguments, how long each took, what every turn cost, and how
-    # the run ended. Deltas never log (whole blocks do), and origin-tagged
-    # events are skipped because every agent logs its own: a sub-agent's
-    # lines carry its own tag exactly once, however deep the nesting
-    # and whichever process runs it.
+    # log tells each run's whole story: which tools ran with which
+    # arguments, how long each took, what every turn cost, and how the run
+    # ended. Deltas never log (whole blocks do).
     #
     # Assigning Mistri.logger turns this on for every run in one line:
     #
     #   Mistri.logger = Rails.logger
     #   Mistri.logger = Mistri::Sinks::Logger.new(logger, color: true)
     #
-    # or compose it per run like any sink, which delivers the event lines
-    # only: framing (run, done) and the line tag come from the Agent, so
-    # the composed form has neither.
+    # Payloads (inputs, text, thinking, arguments, results, reports) log in
+    # full by default; content: false keeps the same story with metadata
+    # only, for logs whose payloads must stay out. level: floors the
+    # ordinary lines (warnings and errors keep their own levels).
     #
-    #   agent.run(input, &Mistri::Sinks::Logger.new(logger))
+    # Sinks the Agent builds through for_session skip origin-tagged events,
+    # because every agent logs its own events under its own tag: exactly
+    # once, however deep the nesting and whichever process runs it. A sink
+    # composed directly (agent.run(input, &sink)) is the only logger its
+    # run has, so it renders forwarded child events instead, origin first;
+    # framing (run, done) still comes only from the Agent.
     #
     # Any object responding to info/warn/error works. Logging must never
     # break a run: every entry point rescues, the first failure warns, and
@@ -37,22 +40,38 @@ module Mistri
                 done: :turn_line, error: :error_line, retry: :retry_line,
                 approval_needed: :approval_line, compacting: :compacting_line,
                 compaction: :compaction_line, subagent_report: :report_line }.freeze
+      QUIET = %i[text_end thinking_end tool_started done approval_needed
+                 compacting compaction subagent_report].to_h { |type| [type, true] }.freeze
       COLORS = { bold: "1", dim: "2", red: "31", green: "32", yellow: "33" }.freeze
-      CONTROLS = /[\x00-\x1f\x7f]/
+      LEVELS = %i[debug info warn error].freeze
+      # C0 and C1 controls, DEL, Unicode line and paragraph separators, and
+      # bidi embedding controls: everything that could steer a terminal or
+      # forge a line while staying invisible.
+      HIDDEN = /[\u0000-\u001f\u007f-\u009f\u2028\u2029\u202a-\u202e\u2066-\u2069]/
       HEAD = 4096
-      private_constant :SKIPPED, :LINES, :COLORS, :CONTROLS, :HEAD
+      private_constant :SKIPPED, :LINES, :QUIET, :COLORS, :LEVELS, :HIDDEN, :HEAD
 
-      # truncate bounds every quoted value (nil for full payloads). session
-      # is the line tag, verbatim, so concurrent runs stay distinguishable.
-      # level is the floor for the ordinary lines: pass :debug to keep the
-      # story out of a production logger sitting at :info; warnings and
-      # errors keep their own levels regardless.
-      def initialize(logger, session: nil, truncate: 200, color: false, level: :info)
+      # truncate bounds every rendered value (nil for full payloads).
+      # session is the line tag, verbatim, so concurrent runs stay
+      # distinguishable. Options are validated here so a bad configuration
+      # fails at assignment time, not silently at run time.
+      def initialize(logger, session: nil, truncate: 200, color: false, level: :info,
+                     content: true, forwarded: :render)
+        raise ArgumentError, "level must be one of #{LEVELS.join(", ")}" unless
+          LEVELS.include?(level)
+        unless truncate.nil? || (truncate.is_a?(Integer) && truncate.positive?)
+          raise ArgumentError, "truncate must be a positive Integer or nil"
+        end
+        raise ArgumentError, "forwarded must be :render or :skip" unless
+          %i[render skip].include?(forwarded)
+
         @logger = logger
-        @session = session&.to_s
         @truncate = truncate
         @color = color
         @level = level
+        @content = content
+        @forwarded = forwarded
+        @session = session && field(session, limit: 48)
         @turns = 0
         @started = now
         @warned = false
@@ -60,19 +79,40 @@ module Mistri
       end
 
       # A fresh sink for one run: same logger and options, this run's tag
-      # (a sub-agent's label, or the session id), its own turn count
-      # and clock.
+      # (a sub-agent's label, or the session id), its own turn count and
+      # clock. Runs framed this way skip forwarded events, because each
+      # agent in the tree logs its own.
       def for_session(id, label: nil)
         self.class.new(@logger, session: label || id.to_s[0, 8], truncate: @truncate,
-                                color: @color, level: @level)
+                                color: @color, level: @level, content: @content, forwarded: :skip)
+      end
+
+      # The global hookup: builds this run's sink from Mistri.logger, or
+      # nil. Contained, so a broken assignment costs the log, never the run.
+      def self.attach(id, label: nil)
+        configured = Mistri.logger
+        return nil unless configured
+
+        sink = configured.respond_to?(:for_session) ? configured : new(configured)
+        sink.for_session(id, label: label)
+      rescue StandardError => e
+        warn "mistri: logging sink construction failed (#{e.class}: #{e.message}); run not logged"
+        nil
       end
 
       def call(event)
-        return if @warned || event.origin || SKIPPED[event.type]
+        return if @warned
+
+        return if event.origin && (@forwarded == :skip)
+        return if SKIPPED[event.type]
+        return if QUIET[event.type] && !floor_enabled?
 
         handler = LINES[event.type]
+        prefix = event.origin ? "#{field(event.origin)} " : ""
         # Future event types degrade to a greppable line, never to silence.
-        handler ? send(handler, event) : write("#{event.type} #{trim(event.content)}".rstrip)
+        line = handler ? send(handler, event) : "#{event.type} #{trim(event.content)}".rstrip
+        write("#{prefix}#{line.first}", level: line.last) if line.is_a?(Array)
+        write("#{prefix}#{line}") if line.is_a?(String)
       rescue StandardError => e
         quiet(e)
       end
@@ -86,14 +126,18 @@ module Mistri
       def run_started(verb:, model:, tool_count:, input: nil)
         @turns = 0
         @started = now
-        ask = input ? %( "#{trim(input)}") : ""
-        write("#{paint(verb, :bold)}#{ask} (#{model}, #{count(tool_count, "tool")})")
+        return unless floor_enabled?
+
+        ask = input && @content ? %( "#{trim(input)}") : ""
+        write("#{paint(verb, :bold)}#{ask} (#{field(model)}, #{count(tool_count, "tool")})")
       rescue StandardError => e
         quiet(e)
       end
 
       def run_finished(result)
         status, level = status_of(result)
+        return if level == :info && !floor_enabled?
+
         write("#{paint("done", :bold)} #{status} in #{clock(now - @started)}, " \
               "#{count(@turns, "turn")}#{summary(result.usage)}", level: level)
       rescue StandardError => e
@@ -109,29 +153,29 @@ module Mistri
       private
 
       def text_line(event)
-        content = trim(event.content)
-        write(%(text "#{content}")) unless content.empty?
+        body = body_of(event.content)
+        body.empty? ? nil : "text #{body}"
       end
 
       def thinking_line(event)
-        content = trim(event.content)
-        write(%(thinking "#{content}")) unless content.empty?
+        body = body_of(event.content)
+        body.empty? ? nil : "thinking #{body}"
       end
 
       def tool_line(event)
-        write("tool #{title(event.tool_call)} #{arguments(event.tool_call)}")
+        "tool #{title(event.tool_call)} #{arguments(event.tool_call)}".rstrip
       end
 
       def tool_result_line(event)
         verdict = event.tool_error? ? paint("FAILED", :red) : "ok"
         parts = ["tool #{title(event.tool_call)} #{verdict}", clock(event.duration),
-                 quote(event.content)]
-        write(parts.compact.join(" "), level: event.tool_error? ? :warn : :info)
+                 presence(body_of(event.content))]
+        [parts.compact.join(" "), event.tool_error? ? :warn : :info]
       end
 
       def turn_line(event)
         @turns += 1
-        write("turn #{@turns} done #{event.reason}#{tokens(event.message&.usage)}")
+        "turn #{@turns} done #{event.reason}#{tokens(event.message&.usage)}"
       end
 
       # :error also carries expected stops, which log calmly; only real
@@ -139,34 +183,39 @@ module Mistri
       # it alone does not count as a turn.
       def error_line(event)
         case event.reason
-        when StopReason::BUDGET then write("stopped on budget", level: :warn)
+        when StopReason::BUDGET then ["stopped on budget", :warn]
         when StopReason::ABORTED
           @turns += 1
-          write("aborted")
+          "aborted"
         else
           @turns += 1
           detail = [event.reason, presence(trim(event.error_message))].compact.join(": ")
-          write("#{paint("error", :red)} #{detail}", level: :error)
+          ["#{paint("error", :red)} #{detail}", :error]
         end
       end
 
       def retry_line(event)
         wait = event.delay ? " in #{event.delay.round(1)}s" : ""
-        write("#{paint("retry", :yellow)} #{event.attempt}/#{event.max_attempts}#{wait}: " \
-              "#{trim(event.content)}", level: :warn)
+        ["#{paint("retry", :yellow)} #{event.attempt}/#{event.max_attempts}#{wait}: " \
+         "#{trim(event.content)}", :warn]
       end
 
+      # The full call id rides the line: Session#approve takes exactly that
+      # id, and the short pairing suffix is not it.
       def approval_line(event)
-        write("approval needed #{title(event.tool_call)} #{arguments(event.tool_call)}")
+        call = event.tool_call
+        parts = ["approval needed #{title(call)}", presence(arguments(call)),
+                 "id #{field(call.id, limit: 128)}"]
+        parts.compact.join(" ")
       end
 
-      def compacting_line(_event) = write("compacting")
+      def compacting_line(_event) = "compacting"
 
-      def compaction_line(event) = write(%(compacted "#{trim(event.content)}"))
+      def compaction_line(event) = "compacted #{body_of(event.content)}"
 
       def report_line(event)
-        write("worker #{event.agent} (#{event.session_id.to_s[0, 8]}) #{event.status} " \
-              "#{quote(event.content)}".rstrip)
+        "worker #{field(event.agent)} (#{field(event.session_id.to_s[0, 8], limit: 16)}) " \
+        "#{event.status} #{body_of(event.content)}".rstrip
       end
 
       def status_of(result)
@@ -186,7 +235,7 @@ module Mistri
 
         base = ", #{prompt(usage)} / #{usage.output} out"
         cost = usage.cost
-        cost&.known? && cost.total.positive? ? base + format(", $%.4f", cost.total) : base
+        cost&.known? ? base + format(", $%.4f", cost.total) : base
       end
 
       def tokens(usage)
@@ -201,49 +250,94 @@ module Mistri
         "#{usage.input + cached} in (#{cached} cached)"
       end
 
-      # A short call id makes concurrent same-name calls pairable and gives
-      # an approval line the handle session.approve needs.
+      # A short call id makes concurrent same-name calls pairable.
       def title(tool_call)
         return paint("?", :green) unless tool_call
 
-        name = paint(tool_call.name, :green)
-        id = tool_call.id.to_s
+        name = paint(field(tool_call.name), :green)
+        id = field(tool_call.id, limit: 128)
         ref = id.length > 4 ? id[-4, 4] : id
         ref.empty? ? name : "#{name}##{ref}"
       end
 
       def arguments(tool_call)
         return "[#{trim(tool_call.arguments_error)}]" if tool_call.arguments_error?
+        return "" unless @content
 
-        json = JSON.generate(tool_call.arguments || {})
-        body, cut = clip(json)
-        cut ? "#{body} (#{bytes(json)})" : body
+        rendered = +""
+        preview(tool_call.arguments || {}, rendered)
+        trim(rendered)
+      end
+
+      # A bounded JSON preview: rendering stops once the budget is spent,
+      # so a payload near the 8 MiB argument ceiling never materializes as
+      # a whole serialized string on the emission path.
+      def preview(value, out)
+        return out << "..." if @truncate && out.length > @truncate
+
+        case value
+        when Hash
+          walk(value, out, "{", "}") do |(key, item)|
+            out << JSON.generate(key.to_s) << ":"
+            preview(item, out)
+          end
+        when Array
+          walk(value, out, "[", "]") { |item| preview(item, out) }
+        when String
+          out << JSON.generate(@truncate ? value[0, @truncate] : value)
+        else
+          out << JSON.generate(value)
+        end
+      end
+
+      def walk(items, out, open, close)
+        out << open
+        items.each_with_index do |item, index|
+          break if @truncate && out.length > @truncate && index.positive?
+
+          out << "," if index.positive?
+          yield(item)
+        end
+        out << close
+      end
+
+      # content: false keeps the beat and the volume, never the words.
+      def body_of(text)
+        return "" if text.nil? || text.to_s.strip.empty?
+        return "(#{bytes(text)})" unless @content
+
+        quote(text)
       end
 
       def quote(text)
-        return nil if text.nil?
-
         body, cut = clip(text)
         cut ? %("#{body}" (#{bytes(text)})) : %("#{body}")
       end
 
       def trim(text) = clip(text).first
 
+      # Structural scalars (tags, names, ids, labels) are bounded and
+      # stripped of hidden bytes before they join a line, so untrusted
+      # values cannot forge lines or steer a terminal.
+      def field(value, limit: 64)
+        clip(value, limit: limit).first
+      end
+
       # String work per line stays bounded: only a head of the payload is
       # normalized, never all of it. scrub repairs invalid bytes (encode
       # alone skips same-encoding validation), encode converts binary, and
-      # non-printing controls become visible escapes so untrusted output
-      # cannot steer a terminal. The size suffix reports the whole payload.
-      def clip(text)
+      # hidden bytes become visible escapes. The size suffix reports the
+      # whole payload.
+      def clip(text, limit: @truncate)
         raw = text.to_s
-        head = @truncate ? raw[0, [(@truncate * 2) + 1, HEAD].max] : raw
+        head = limit ? raw[0, [(limit * 2) + 1, HEAD].max] : raw
         flat = head.scrub.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
                    .gsub(/\s+/, " ").strip
-                   .gsub(CONTROLS) { |control| format("\\x%02x", control.ord) }
-        cut = @truncate && (flat.length > @truncate || head.bytesize < raw.bytesize)
+                   .gsub(HIDDEN) { |hidden| format("\\u%04x", hidden.ord) }
+        cut = limit && (flat.length > limit || head.bytesize < raw.bytesize)
         return [flat, false] unless cut
 
-        ["#{flat[0, @truncate].rstrip}...", true]
+        ["#{flat[0, limit].rstrip}...", true]
       end
 
       def clock(duration)
@@ -261,9 +355,18 @@ module Mistri
 
       def count(number, noun) = "#{number} #{number == 1 ? noun : "#{noun}s"}"
 
-      def presence(text) = text.empty? ? nil : text
+      def presence(text) = text.nil? || text.empty? ? nil : text
 
       def paint(text, color) = @color ? "\e[#{COLORS.fetch(color)}m#{text}\e[0m" : text
+
+      # Formatting is skipped entirely when the floor level is disabled on
+      # the host logger; warnings and errors always go through.
+      def floor_enabled?
+        query = :"#{@level}?"
+        !@logger.respond_to?(query) || @logger.public_send(query)
+      rescue StandardError
+        true
+      end
 
       def write(line, level: :info)
         return if @warned

--- a/lib/mistri/sub_agent/execution.rb
+++ b/lib/mistri/sub_agent/execution.rb
@@ -58,9 +58,9 @@ module Mistri
 
       def run_child_agent(child:, label:, provider:, system:, tools:, task:, schema:,
                           signal:, emit:, agent_options:)
-        agent = Agent.new(provider: provider, session: child, system: system,
-                          tools: tools, **agent_options)
         origin = "#{label}##{child.id[0, 8]}"
+        agent = Agent.new(provider: provider, session: child, system: system,
+                          tools: tools, log_label: origin, **agent_options)
         tagged = ->(event) { forward(event, origin, emit) }
         return agent.task(task, schema: schema, signal: signal, &tagged) if schema
 

--- a/test/test_agent.rb
+++ b/test/test_agent.rb
@@ -274,6 +274,21 @@ class TestAgent < Minitest::Test
     assert_equal 100, result.usage.input, "both passes count"
   end
 
+  def test_context_usage_reports_tokens_window_and_fraction
+    provider = Mistri::Providers::Fake.new(turns: [])
+    usage = Mistri::Agent.new(provider:).context_usage
+
+    assert_operator usage.fetch(:tokens), :>=, 0
+    assert usage.key?(:window)
+    assert usage.key?(:fraction)
+  end
+
+  def test_compact_returns_nil_when_there_is_nothing_to_compact
+    provider = Mistri::Providers::Fake.new(turns: [])
+
+    assert_nil Mistri::Agent.new(provider:).compact
+  end
+
   private
 
   def session_ready_for_compaction

--- a/test/test_logger_sink.rb
+++ b/test/test_logger_sink.rb
@@ -451,10 +451,11 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
     assert_raises(ArgumentError) { Mistri::Sinks::Logger.new(logger, forwarded: :maybe) }
   end
 
-  def test_a_raising_sink_factory_never_breaks_the_run
-    factory = Object.new
-    def factory.for_session(*) = raise "factory died"
-    Mistri.logger = factory
+  def test_a_raising_sink_never_breaks_the_run
+    broken = Class.new(Mistri::Sinks::Logger) do
+      def for_session(*) = raise "factory died"
+    end.new(capture.first)
+    Mistri.logger = broken
     provider = Mistri::Providers::Fake.new(turns: [{ text: "hi" }])
 
     result = nil
@@ -463,6 +464,39 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
     end
 
     assert_predicate result, :completed?
+  end
+
+  def test_foreign_sink_factories_are_rejected_at_assignment
+    factory = Object.new
+    def factory.for_session(*) = self
+
+    assert_raises(Mistri::ConfigurationError) { Mistri.logger = factory }
+  end
+
+  def test_content_off_covers_diagnostic_free_text
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger, content: false)
+
+    sink.run_crashed(RuntimeError.new("password=hunter2"))
+    sink.call(Mistri::Event.new(type: :error, reason: :error,
+                                error_message: "token sk-secret rejected"))
+    sink.call(Mistri::Event.new(type: :retry, content: "key sk-secret throttled",
+                                attempt: 1, max_attempts: 3, delay: 2.0))
+
+    refute_match(/hunter2|sk-secret/, io.string)
+    assert_match(/crashed RuntimeError \(16B\)/, io.string)
+    assert_match(/error error \(24B\)/, io.string)
+    assert_match(%r{retry 1/3 in 2.0s \(23B\)}, io.string)
+  end
+
+  def test_argument_previews_bound_hash_keys_too
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+    call = tool_call("save", { ("k" * 300_000) => 1 })
+
+    sink.call(Mistri::Event.new(type: :tool_started, tool_call: call))
+
+    assert_operator io.string.lines.fetch(0).length, :<, 400
   end
 
   def test_the_global_requires_the_full_severity_contract

--- a/test/test_logger_sink.rb
+++ b/test/test_logger_sink.rb
@@ -57,9 +57,9 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
     assert_match(/WARN \[mistri\] tool boom#c1 FAILED 2.3s "kaboom"/, io.string)
   end
 
-  def test_skips_deltas_origin_tagged_events_and_empty_text
+  def test_run_sinks_skip_deltas_forwarded_events_and_empty_text
     logger, io = capture
-    sink = Mistri::Sinks::Logger.new(logger)
+    sink = Mistri::Sinks::Logger.new(logger).for_session("0a1b2c3d-ffff")
 
     sink.call(Mistri::Event.new(type: :text_delta, content_index: 0, delta: "Hel"))
     sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "from a child",
@@ -67,6 +67,16 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
     sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "  "))
 
     assert_empty io.string
+  end
+
+  def test_a_standalone_sink_renders_forwarded_events_with_their_origin
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "from a child",
+                                origin: "Corgi#ab12cd34"))
+
+    assert_match(/INFO \[mistri\] Corgi#ab12cd34 text "from a child"/, io.string)
   end
 
   def test_renders_thinking_approvals_compaction_and_worker_reports
@@ -182,7 +192,7 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
     sink.call(Mistri::Event.new(type: :text_end, content_index: 0,
                                 content: "hi \e[31mboo\u0000tail"))
 
-    assert_includes io.string, 'text "hi \x1b[31mboo\x00tail"'
+    assert_includes io.string, 'text "hi \u001b[31mboo\u0000tail"'
   end
 
   def test_no_size_suffix_when_only_whitespace_collapsed
@@ -400,6 +410,174 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
     assert_equal 1, log.scan('text "It is Paris."').length
     assert_match(/\[mistri researcher#[0-9a-f]{8}\] run "Capital of France\?"/, log)
     assert_match(/\[mistri [0-9a-f]{8}\] run "Ask the researcher\."/, log)
+  end
+
+  def test_content_off_keeps_the_story_without_the_words
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger, content: false)
+
+    sink.run_started(verb: "run", input: "the secret question", model: "fake-1", tool_count: 1)
+    sink.call(Mistri::Event.new(type: :tool_started,
+                                tool_call: tool_call("add", { "secret" => "value" })))
+    sink.call(Mistri::Event.new(type: :tool_result, tool_call: tool_call("add"),
+                                content: "secret answer", duration: 0.012, tool_error: false))
+    sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "secret text"))
+
+    refute_includes io.string, "secret"
+    assert_match(/run \(fake-1, 1 tool\)/, io.string)
+    assert_match(/tool add#c1$/, io.string)
+    assert_match(/tool add#c1 ok 12ms \(13B\)/, io.string)
+    assert_match(/text \(11B\)/, io.string)
+  end
+
+  def test_hidden_bytes_in_labels_and_names_cannot_forge_lines
+    logger, io = capture
+    forged = "evil\nINFO [mistri] fake line\u202e"
+    sink = Mistri::Sinks::Logger.new(logger).for_session("id", label: forged)
+
+    sink.call(Mistri::Event.new(type: :tool_started,
+                                tool_call: Mistri::ToolCall.new(id: "c1", name: "na\u0085me")))
+
+    assert_equal 1, io.string.lines.length, "a hidden byte must never mint an extra line"
+    assert_includes io.string, "\\u202e"
+    assert_includes io.string, "na\\u0085me"
+  end
+
+  def test_rejects_bad_options_at_construction_time
+    logger, = capture
+
+    assert_raises(ArgumentError) { Mistri::Sinks::Logger.new(logger, level: :loud) }
+    assert_raises(ArgumentError) { Mistri::Sinks::Logger.new(logger, truncate: -1) }
+    assert_raises(ArgumentError) { Mistri::Sinks::Logger.new(logger, forwarded: :maybe) }
+  end
+
+  def test_a_raising_sink_factory_never_breaks_the_run
+    factory = Object.new
+    def factory.for_session(*) = raise "factory died"
+    Mistri.logger = factory
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "hi" }])
+
+    result = nil
+    assert_output(nil, /logging sink construction failed/) do
+      result = Mistri::Agent.new(provider:).run("hello")
+    end
+
+    assert_predicate result, :completed?
+  end
+
+  def test_the_global_requires_the_full_severity_contract
+    half = Object.new
+    def half.info(*); end
+
+    assert_raises(Mistri::ConfigurationError) { Mistri.logger = half }
+  end
+
+  def test_argument_previews_stay_bounded
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+    huge = { "blob" => "x" * 2_000_000, "list" => Array.new(2_000) { "v" } }
+
+    sink.call(Mistri::Event.new(type: :tool_started, tool_call: tool_call("save", huge)))
+
+    line = io.string.lines.fetch(0)
+
+    assert_operator line.length, :<, 400, "a huge argument tree must render as a bounded preview"
+    assert_includes line, "..."
+  end
+
+  def test_renders_argument_errors_instead_of_arguments
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+    call = Mistri::ToolCall.new(id: "c1", name: "add", arguments_error: "too_large")
+
+    sink.call(Mistri::Event.new(type: :tool_started, tool_call: call))
+
+    assert_match(/tool add#c1 \[.*too_large.*\]/, io.string)
+  end
+
+  def test_skips_formatting_when_the_floor_level_is_disabled
+    io = StringIO.new
+    logger = ::Logger.new(io)
+    logger.level = ::Logger::WARN
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.run_started(verb: "run", input: "hi", model: "fake-1", tool_count: 0)
+    sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "quiet"))
+    sink.call(Mistri::Event.new(type: :tool_result, tool_call: tool_call("boom"),
+                                content: "bad", tool_error: true))
+
+    refute_includes io.string, "quiet"
+    assert_includes io.string, "FAILED"
+  end
+
+  def test_store_failures_get_a_crash_line
+    logger, io = capture
+    Mistri.logger = logger
+    store = Class.new(Mistri::Stores::Memory) do
+      def append(*) = raise "store down"
+    end.new
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "hi" }])
+    agent = Mistri::Agent.new(provider:, session: Mistri::Session.new(store: store))
+
+    assert_raises(RuntimeError) { agent.run("hello") }
+    assert_match(/run "hello"/, io.string)
+    assert_match(/crashed RuntimeError: store down/, io.string)
+  end
+
+  def test_known_free_usage_stays_distinguishable_from_unpriced
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.run_finished(Mistri::Result.new(message: nil, status: :completed,
+                                         usage: Mistri::Usage.zero))
+    sink.run_finished(Mistri::Result.new(message: nil, status: :completed,
+                                         usage: Mistri::Usage.new))
+
+    lines = io.string.lines
+
+    assert_includes lines.fetch(0), "$0.0000"
+    refute_includes lines.fetch(1), "$"
+  end
+
+  def test_every_entry_point_contains_its_own_failures
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+    poison = Object.new
+    def poison.to_s = raise "unrenderable"
+
+    assert_output(nil, /logging sink failed/) do
+      sink.call(Mistri::Event.new(type: :retry, content: "note", attempt: 1,
+                                  max_attempts: 2, delay: poison))
+    end
+    [-> { sink.run_started(verb: "run", input: poison, model: "m", tool_count: 0) },
+     -> { sink.run_finished(nil) },
+     -> { sink.run_crashed(nil) },
+     -> { sink.call(Mistri::Event.new(type: :done, reason: :stop)) }].each do |entry|
+      assert_silent { entry.call }
+    end
+    assert_empty io.string.lines.grep(/unrenderable/)
+  end
+
+  def test_a_raising_level_query_counts_as_enabled
+    io = StringIO.new
+    logger = ::Logger.new(io)
+    def logger.info? = raise "gauge broken"
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "still here"))
+
+    assert_includes io.string, "still here"
+  end
+
+  def test_argument_previews_cut_inside_collections
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger, truncate: 30)
+    call = tool_call("list", { "items" => ["x" * 40, "second", "third"] })
+
+    sink.call(Mistri::Event.new(type: :tool_started, tool_call: call))
+
+    assert_includes io.string, "..."
+    refute_includes io.string, "third"
   end
 
   def test_no_logger_builds_no_sink

--- a/test/test_logger_sink.rb
+++ b/test/test_logger_sink.rb
@@ -150,6 +150,41 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
     assert_match(/tool read#c1 ok "x{1,20}\.\.\." \(4.9KB\)/, io.string)
   end
 
+  def test_expected_stops_log_calmly_and_budget_never_counts_a_turn
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.call(Mistri::Event.new(type: :done, reason: :stop))
+    sink.call(Mistri::Event.new(type: :error, reason: :budget))
+    sink.run_finished(Mistri::Result.new(message: nil, status: :budget))
+    sink.call(Mistri::Event.new(type: :error, reason: :aborted))
+
+    assert_match(/WARN \[mistri\] stopped on budget$/, io.string)
+    assert_match(/WARN \[mistri\] done stopped on budget in \d+m?s, 1 turn/, io.string)
+    assert_match(/INFO \[mistri\] aborted/, io.string)
+    refute_match(/ERROR/, io.string)
+  end
+
+  def test_counts_cached_prompt_tokens
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+    usage = Mistri::Usage.new(input: 10, output: 22, cache_read: 850, cache_write: 40)
+
+    sink.run_finished(Mistri::Result.new(message: nil, status: :completed, usage: usage))
+
+    assert_match(%r{done completed in \d+m?s, 0 turns, 900 in \(890 cached\) / 22 out}, io.string)
+  end
+
+  def test_escapes_control_characters_in_untrusted_content
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.call(Mistri::Event.new(type: :text_end, content_index: 0,
+                                content: "hi \e[31mboo\u0000tail"))
+
+    assert_includes io.string, 'text "hi \x1b[31mboo\x00tail"'
+  end
+
   def test_no_size_suffix_when_only_whitespace_collapsed
     logger, io = capture
     sink = Mistri::Sinks::Logger.new(logger)

--- a/test/test_logger_sink.rb
+++ b/test/test_logger_sink.rb
@@ -7,9 +7,12 @@ require "stringio"
 # The logging sink renders the event stream as one line per beat, and
 # assigning Mistri.logger makes every run log its own story exactly once,
 # sub-agents included.
-class TestLoggerSink < Minitest::Test
+class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- one behavior test per renderer and run path adds up
   class Boom < StandardError
   end
+
+  SCHEMA = { type: "object", properties: { "answer" => { type: "string" } },
+             required: ["answer"] }.freeze
 
   def teardown
     Mistri.logger = nil
@@ -26,7 +29,13 @@ class TestLoggerSink < Minitest::Test
     Mistri::ToolCall.new(id: "c1", name: name, arguments: arguments)
   end
 
-  def test_logs_tool_calls_with_arguments_duration_and_verdict
+  # The first word after the tag, one per line: the cheapest way to pin
+  # line order without matching volatile ids and timings.
+  def kinds(io)
+    io.string.lines.map { |line| line[/\] (\S+)/, 1] }
+  end
+
+  def test_logs_tool_calls_with_ids_arguments_duration_and_verdict
     logger, io = capture
     sink = Mistri::Sinks::Logger.new(logger)
 
@@ -34,8 +43,8 @@ class TestLoggerSink < Minitest::Test
     sink.call(Mistri::Event.new(type: :tool_result, tool_call: tool_call("add"),
                                 content: "5", duration: 0.012, tool_error: false))
 
-    assert_match(/INFO \[mistri\] tool add \{"a":2\}/, io.string)
-    assert_match(/INFO \[mistri\] tool add ok 12ms "5"/, io.string)
+    assert_match(/INFO \[mistri\] tool add#c1 \{"a":2\}/, io.string)
+    assert_match(/INFO \[mistri\] tool add#c1 ok 12ms "5"/, io.string)
   end
 
   def test_marks_failed_tools_at_warn
@@ -45,34 +54,56 @@ class TestLoggerSink < Minitest::Test
     sink.call(Mistri::Event.new(type: :tool_result, tool_call: tool_call("boom"),
                                 content: "kaboom", duration: 2.34, tool_error: true))
 
-    assert_match(/WARN \[mistri\] tool boom FAILED 2.3s "kaboom"/, io.string)
+    assert_match(/WARN \[mistri\] tool boom#c1 FAILED 2.3s "kaboom"/, io.string)
   end
 
-  def test_skips_deltas_and_origin_tagged_events
+  def test_skips_deltas_origin_tagged_events_and_empty_text
     logger, io = capture
     sink = Mistri::Sinks::Logger.new(logger)
 
     sink.call(Mistri::Event.new(type: :text_delta, content_index: 0, delta: "Hel"))
     sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "from a child",
                                 origin: "Corgi#ab12cd34"))
+    sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "  "))
 
     assert_empty io.string
   end
 
-  def test_numbers_turns_and_flags_errors_and_retries
+  def test_renders_thinking_approvals_compaction_and_worker_reports
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.call(Mistri::Event.new(type: :thinking_end, content_index: 0,
+                                content: "Weighing the options"))
+    sink.call(Mistri::Event.new(type: :approval_needed,
+                                tool_call: tool_call("send_gift", { "to" => "sarah" })))
+    sink.call(Mistri::Event.new(type: :compacting))
+    sink.call(Mistri::Event.new(type: :compaction, content: "The story so far"))
+    sink.call(Mistri::Event.new(type: :subagent_report, agent: "Corgi",
+                                session_id: "ef56ab12-0000-4444-aaaa-000000000000",
+                                status: "done", content: "found it"))
+
+    assert_match(/INFO \[mistri\] thinking "Weighing the options"/, io.string)
+    assert_match(/INFO \[mistri\] approval needed send_gift#c1 \{"to":"sarah"\}/, io.string)
+    assert_match(/INFO \[mistri\] compacting/, io.string)
+    assert_match(/INFO \[mistri\] compacted "The story so far"/, io.string)
+    assert_match(/INFO \[mistri\] worker Corgi \(ef56ab12\) done "found it"/, io.string)
+  end
+
+  def test_numbers_turns_counting_errored_turns_and_flags_retries
     logger, io = capture
     sink = Mistri::Sinks::Logger.new(logger)
 
     sink.call(Mistri::Event.new(type: :done, reason: :tool_use))
-    sink.call(Mistri::Event.new(type: :done, reason: :stop))
     sink.call(Mistri::Event.new(type: :retry, content: "rate limited", attempt: 2,
                                 max_attempts: 5, delay: 4.0))
     sink.call(Mistri::Event.new(type: :error, reason: :rate_limit, error_message: "slow down"))
+    sink.run_finished(Mistri::Result.new(message: nil, status: :error))
 
     assert_match(/INFO \[mistri\] turn 1 done tool_use/, io.string)
-    assert_match(/INFO \[mistri\] turn 2 done stop/, io.string)
     assert_match(%r{WARN \[mistri\] retry 2/5 in 4.0s: rate limited}, io.string)
     assert_match(/ERROR \[mistri\] error rate_limit: slow down/, io.string)
+    assert_match(/ERROR \[mistri\] done error in \d+m?s, 2 turns/, io.string)
   end
 
   def test_frames_a_run_with_input_and_result
@@ -91,27 +122,55 @@ class TestLoggerSink < Minitest::Test
                  io.string)
   end
 
-  def test_renders_suspension_and_crashes
+  def test_renders_every_terminal_status
     logger, io = capture
     sink = Mistri::Sinks::Logger.new(logger)
 
-    sink.run_started(verb: "run", input: "send it", model: "fake-1", tool_count: 2)
     sink.run_finished(Mistri::Result.new(message: nil, status: :awaiting_approval,
                                          pending: [tool_call("send_gift")]))
+    sink.run_finished(Mistri::Result.new(message: nil, status: :completed, handed_off: true))
+    sink.run_finished(Mistri::Result.new(message: nil, status: :aborted))
+    sink.run_finished(Mistri::Result.new(message: nil, status: :budget))
     sink.run_crashed(RuntimeError.new("boom"))
 
     assert_match(/INFO \[mistri\] done suspended \(1 approval pending\)/, io.string)
+    assert_match(/INFO \[mistri\] done completed \(handed off\)/, io.string)
+    assert_match(/INFO \[mistri\] done aborted/, io.string)
+    assert_match(/WARN \[mistri\] done stopped on budget/, io.string)
     assert_match(/ERROR \[mistri\] crashed RuntimeError: boom/, io.string)
   end
 
-  def test_truncates_long_values_and_reports_sizes
+  def test_truncates_long_values_and_reports_original_sizes
     logger, io = capture
     sink = Mistri::Sinks::Logger.new(logger, truncate: 20)
 
     sink.call(Mistri::Event.new(type: :tool_result, tool_call: tool_call("read"),
                                 content: "x" * 5000, tool_error: false))
 
-    assert_match(/tool read ok "x{1,20}\.\.\." \(4.9KB\)/, io.string)
+    assert_match(/tool read#c1 ok "x{1,20}\.\.\." \(4.9KB\)/, io.string)
+  end
+
+  def test_no_size_suffix_when_only_whitespace_collapsed
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.call(Mistri::Event.new(type: :tool_result, tool_call: tool_call("read"),
+                                content: "#{"x" * 100}#{" " * 500}", tool_error: false))
+
+    assert_match(/tool read#c1 ok "x{100}"/, io.string)
+    refute_match(/B\)/, io.string)
+  end
+
+  def test_level_floors_the_ordinary_lines_only
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger, level: :debug)
+
+    sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "hi"))
+    sink.call(Mistri::Event.new(type: :tool_result, tool_call: tool_call("boom"),
+                                content: "bad", tool_error: true))
+
+    assert_match(/DEBUG \[mistri\] text "hi"/, io.string)
+    assert_match(/WARN \[mistri\] tool boom#c1 FAILED/, io.string)
   end
 
   def test_color_paints_tool_names_only_when_asked
@@ -120,7 +179,7 @@ class TestLoggerSink < Minitest::Test
 
     sink.call(Mistri::Event.new(type: :tool_started, tool_call: tool_call("add")))
 
-    assert_includes io.string, "\e[32madd\e[0m"
+    assert_includes io.string, "\e[32madd\e[0m#c1"
   end
 
   def test_a_broken_logger_never_raises_and_warns_once
@@ -131,18 +190,44 @@ class TestLoggerSink < Minitest::Test
 
     assert_output(nil, /logging sink failed.*logging disabled/) { sink.call(event) }
     assert_silent { sink.call(event) }
+    assert_silent { sink.run_started(verb: "run", model: "m", tool_count: 0) }
   end
 
-  def test_for_session_tags_lines_with_the_session
-    logger, io = capture
-    sink = Mistri::Sinks::Logger.new(logger).for_session("0a1b2c3d-ffff-4444-aaaa-000000000000")
+  def test_framing_is_total_on_a_broken_logger
+    broken = Object.new
+    def broken.info(*) = raise "io dead"
+    sink = Mistri::Sinks::Logger.new(broken)
 
-    sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "hi"))
+    assert_output(nil, /logging sink failed/) do
+      sink.run_started(verb: "run", model: "m", tool_count: 0)
+    end
+  end
+
+  def test_for_session_tags_lines_with_the_session_or_a_label
+    logger, io = capture
+    base = Mistri::Sinks::Logger.new(logger)
+
+    base.for_session("0a1b2c3d-ffff-4444-aaaa-000000000000")
+        .call(Mistri::Event.new(type: :text_end, content_index: 0, content: "hi"))
+    base.for_session("0a1b2c3d-ffff-4444-aaaa-000000000000", label: "researcher#0a1b2c3d")
+        .call(Mistri::Event.new(type: :text_end, content_index: 0, content: "ho"))
 
     assert_match(/\[mistri 0a1b2c3d\] text "hi"/, io.string)
+    assert_match(/\[mistri researcher#0a1b2c3d\] text "ho"/, io.string)
   end
 
-  def test_a_run_logs_its_whole_story
+  def test_rejects_junk_assignments_at_assignment_time
+    assert_raises(Mistri::ConfigurationError) { Mistri.logger = Object.new }
+    assert_raises(Mistri::ConfigurationError) do
+      Mistri.logger = Mistri::Sinks::Coalesced.new(->(_event) {})
+    end
+
+    Mistri.logger = capture.first
+    Mistri.logger = Mistri::Sinks::Logger.new(capture.first)
+    Mistri.logger = nil
+  end
+
+  def test_a_run_logs_its_whole_story_in_order
     logger, io = capture
     Mistri.logger = logger
     provider = Mistri::Providers::Fake.new(turns: [
@@ -159,16 +244,61 @@ class TestLoggerSink < Minitest::Test
     result = Mistri::Agent.new(provider:, tools: [add]).run("What is 2 plus 3?")
 
     assert_predicate result, :completed?
+    # The model's turn genuinely completes before its tools execute, so the
+    # turn line precedes the tool lines. This order is the README example's
+    # source of truth.
+    assert_equal %w[run turn tool tool text turn done], kinds(io)
     log = io.string
 
     assert_match(/run "What is 2 plus 3\?" \(fake-1, 1 tool\)/, log)
-    assert_match(/tool add \{"a":2,"b":3\}/, log)
-    assert_match(/tool add ok/, log)
-    assert_match(/turn 1 done tool_use/, log)
+    assert_match(/tool add#\S+ \{"a":2,"b":3\}/, log)
+    assert_match(/tool add#\S+ ok/, log)
     assert_match(/text "The sum is 5\."/, log)
-    assert_match(/turn 2 done stop/, log)
     assert_match(/done completed in/, log)
     assert_match(/\[mistri [0-9a-f]{8}\]/, log)
+  end
+
+  def test_task_logs_one_frame_around_its_fix_passes
+    logger, io = capture
+    Mistri.logger = logger
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { text: '{"answer": 41}' },
+                                             { text: '{"answer": "42"}' }
+                                           ])
+
+    result = Mistri::Agent.new(provider:).task("The answer?", schema: SCHEMA)
+
+    assert_equal({ "answer" => "42" }, result.output)
+    assert_equal %w[task text turn text turn done], kinds(io)
+    assert_match(/task "The answer\?" \(fake-1, 0 tools\)/, io.string)
+    assert_match(/done completed in \d+m?s, 2 turns/, io.string)
+  end
+
+  def test_resume_frames_its_outcomes_including_still_pending
+    logger, io = capture
+    Mistri.logger = logger
+    gated = Mistri::Tool.define("send_gift", "Sends.", needs_approval: true) { "sent" }
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "send_gift",
+                                                              arguments: {} }] },
+                                             { text: "Sent it." }
+                                           ])
+    agent = Mistri::Agent.new(provider:, tools: [gated])
+
+    suspended = agent.run("send sarah a gift")
+    agent.resume
+    agent.session.approve(suspended.pending.fetch(0).id)
+    finished = agent.resume
+
+    assert_predicate finished, :completed?
+    log = io.string
+
+    assert_match(/approval needed send_gift#\S+ \{\}/, log)
+    assert_equal 2, log.scan("done suspended (1 approval pending)").length,
+                 "the run frame and the still-pending resume frame both report suspension"
+    assert_equal 2, log.scan("resume (fake-1, 1 tool)").length
+    assert_match(/tool send_gift#\S+ ok/, log)
+    assert_match(/done completed in/, log)
   end
 
   def test_the_callers_block_still_sees_every_event
@@ -196,7 +326,23 @@ class TestLoggerSink < Minitest::Test
     assert_match(/crashed TestLoggerSink::Boom: host sink died/, io.string)
   end
 
-  def test_sub_agents_log_once_each_under_their_own_session
+  def test_an_invalid_byte_crash_keeps_the_hosts_exception
+    logger, io = capture
+    Mistri.logger = logger
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "Hello!" }])
+    bad = "boom \xFF".dup.force_encoding(Encoding::UTF_8)
+
+    error = assert_raises(Boom) do
+      Mistri::Agent.new(provider:).run("hi") do |event|
+        raise Boom, bad if event.type == :done
+      end
+    end
+
+    assert_instance_of Boom, error
+    assert_match(/crashed TestLoggerSink::Boom/, io.string)
+  end
+
+  def test_sub_agents_log_once_each_under_their_own_label
     logger, io = capture
     Mistri.logger = logger
     child_provider = Mistri::Providers::Fake.new(turns: [{ text: "Paris." }])
@@ -217,17 +363,24 @@ class TestLoggerSink < Minitest::Test
     assert_equal 1, log.scan('text "Paris."').length,
                  "the child's answer logs once, from the child's own agent"
     assert_equal 1, log.scan('text "It is Paris."').length
-    assert_match(/run "Capital of France\?"/, log)
-    assert_equal 2, log.scan(/\[mistri ([0-9a-f]{8})\]/).uniq.length,
-                 "parent and child log under their own session tags"
+    assert_match(/\[mistri researcher#[0-9a-f]{8}\] run "Capital of France\?"/, log)
+    assert_match(/\[mistri [0-9a-f]{8}\] run "Ask the researcher\."/, log)
   end
 
-  def test_no_logger_means_no_logging
+  def test_no_logger_builds_no_sink
     provider = Mistri::Providers::Fake.new(turns: [{ text: "Hello!" }])
+    built = false
+    original = Mistri::Sinks::Logger.method(:new)
+    Mistri::Sinks::Logger.define_singleton_method(:new) do |*args, **options|
+      built = true
+      original.call(*args, **options)
+    end
 
-    result = nil
-    assert_silent { result = Mistri::Agent.new(provider:).run("hi") }
+    result = Mistri::Agent.new(provider:).run("hi")
 
     assert_predicate result, :completed?
+    refute built, "with no logger assigned, no sink should ever be constructed"
+  ensure
+    Mistri::Sinks::Logger.singleton_class.remove_method(:new)
   end
 end

--- a/test/test_logger_sink.rb
+++ b/test/test_logger_sink.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "logger"
+require "stringio"
+
+# The logging sink renders the event stream as one line per beat, and
+# assigning Mistri.logger makes every run log its own story exactly once,
+# sub-agents included.
+class TestLoggerSink < Minitest::Test
+  class Boom < StandardError
+  end
+
+  def teardown
+    Mistri.logger = nil
+  end
+
+  def capture
+    io = StringIO.new
+    logger = ::Logger.new(io)
+    logger.formatter = ->(severity, _time, _progname, message) { "#{severity} #{message}\n" }
+    [logger, io]
+  end
+
+  def tool_call(name, arguments = {})
+    Mistri::ToolCall.new(id: "c1", name: name, arguments: arguments)
+  end
+
+  def test_logs_tool_calls_with_arguments_duration_and_verdict
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.call(Mistri::Event.new(type: :tool_started, tool_call: tool_call("add", { "a" => 2 })))
+    sink.call(Mistri::Event.new(type: :tool_result, tool_call: tool_call("add"),
+                                content: "5", duration: 0.012, tool_error: false))
+
+    assert_match(/INFO \[mistri\] tool add \{"a":2\}/, io.string)
+    assert_match(/INFO \[mistri\] tool add ok 12ms "5"/, io.string)
+  end
+
+  def test_marks_failed_tools_at_warn
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.call(Mistri::Event.new(type: :tool_result, tool_call: tool_call("boom"),
+                                content: "kaboom", duration: 2.34, tool_error: true))
+
+    assert_match(/WARN \[mistri\] tool boom FAILED 2.3s "kaboom"/, io.string)
+  end
+
+  def test_skips_deltas_and_origin_tagged_events
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.call(Mistri::Event.new(type: :text_delta, content_index: 0, delta: "Hel"))
+    sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "from a child",
+                                origin: "Corgi#ab12cd34"))
+
+    assert_empty io.string
+  end
+
+  def test_numbers_turns_and_flags_errors_and_retries
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.call(Mistri::Event.new(type: :done, reason: :tool_use))
+    sink.call(Mistri::Event.new(type: :done, reason: :stop))
+    sink.call(Mistri::Event.new(type: :retry, content: "rate limited", attempt: 2,
+                                max_attempts: 5, delay: 4.0))
+    sink.call(Mistri::Event.new(type: :error, reason: :rate_limit, error_message: "slow down"))
+
+    assert_match(/INFO \[mistri\] turn 1 done tool_use/, io.string)
+    assert_match(/INFO \[mistri\] turn 2 done stop/, io.string)
+    assert_match(%r{WARN \[mistri\] retry 2/5 in 4.0s: rate limited}, io.string)
+    assert_match(/ERROR \[mistri\] error rate_limit: slow down/, io.string)
+  end
+
+  def test_frames_a_run_with_input_and_result
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+    cost = Mistri::Usage::Cost.new(input: 0.003, output: 0.0012, cache_read: 0.0,
+                                   cache_write: 0.0, total: 0.0042)
+    usage = Mistri::Usage.new(input: 500, output: 60, cost: cost)
+
+    sink.run_started(verb: "run", input: "What is 2 plus 3?", model: "fake-1", tool_count: 1)
+    sink.call(Mistri::Event.new(type: :done, reason: :stop))
+    sink.run_finished(Mistri::Result.new(message: nil, status: :completed, usage: usage))
+
+    assert_match(/INFO \[mistri\] run "What is 2 plus 3\?" \(fake-1, 1 tool\)/, io.string)
+    assert_match(%r{INFO \[mistri\] done completed in \d+m?s, 1 turn, 500 in / 60 out, \$0.0042},
+                 io.string)
+  end
+
+  def test_renders_suspension_and_crashes
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger)
+
+    sink.run_started(verb: "run", input: "send it", model: "fake-1", tool_count: 2)
+    sink.run_finished(Mistri::Result.new(message: nil, status: :awaiting_approval,
+                                         pending: [tool_call("send_gift")]))
+    sink.run_crashed(RuntimeError.new("boom"))
+
+    assert_match(/INFO \[mistri\] done suspended \(1 approval pending\)/, io.string)
+    assert_match(/ERROR \[mistri\] crashed RuntimeError: boom/, io.string)
+  end
+
+  def test_truncates_long_values_and_reports_sizes
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger, truncate: 20)
+
+    sink.call(Mistri::Event.new(type: :tool_result, tool_call: tool_call("read"),
+                                content: "x" * 5000, tool_error: false))
+
+    assert_match(/tool read ok "x{1,20}\.\.\." \(4.9KB\)/, io.string)
+  end
+
+  def test_color_paints_tool_names_only_when_asked
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger, color: true)
+
+    sink.call(Mistri::Event.new(type: :tool_started, tool_call: tool_call("add")))
+
+    assert_includes io.string, "\e[32madd\e[0m"
+  end
+
+  def test_a_broken_logger_never_raises_and_warns_once
+    broken = Object.new
+    def broken.info(*) = raise "io dead"
+    sink = Mistri::Sinks::Logger.new(broken)
+    event = Mistri::Event.new(type: :text_end, content_index: 0, content: "hi")
+
+    assert_output(nil, /logging sink failed.*logging disabled/) { sink.call(event) }
+    assert_silent { sink.call(event) }
+  end
+
+  def test_for_session_tags_lines_with_the_session
+    logger, io = capture
+    sink = Mistri::Sinks::Logger.new(logger).for_session("0a1b2c3d-ffff-4444-aaaa-000000000000")
+
+    sink.call(Mistri::Event.new(type: :text_end, content_index: 0, content: "hi"))
+
+    assert_match(/\[mistri 0a1b2c3d\] text "hi"/, io.string)
+  end
+
+  def test_a_run_logs_its_whole_story
+    logger, io = capture
+    Mistri.logger = logger
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "add",
+                                                              arguments: { "a" => 2,
+                                                                           "b" => 3 } }] },
+                                             { text: "The sum is 5." }
+                                           ])
+    add = Mistri::Tool.define("add", "Add.", schema: lambda {
+      integer :a, "First number", required: true
+      integer :b, "Second number", required: true
+    }) { |args| (args["a"] + args["b"]).to_s }
+
+    result = Mistri::Agent.new(provider:, tools: [add]).run("What is 2 plus 3?")
+
+    assert_predicate result, :completed?
+    log = io.string
+
+    assert_match(/run "What is 2 plus 3\?" \(fake-1, 1 tool\)/, log)
+    assert_match(/tool add \{"a":2,"b":3\}/, log)
+    assert_match(/tool add ok/, log)
+    assert_match(/turn 1 done tool_use/, log)
+    assert_match(/text "The sum is 5\."/, log)
+    assert_match(/turn 2 done stop/, log)
+    assert_match(/done completed in/, log)
+    assert_match(/\[mistri [0-9a-f]{8}\]/, log)
+  end
+
+  def test_the_callers_block_still_sees_every_event
+    logger, = capture
+    Mistri.logger = logger
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "Hello!" }])
+    seen = []
+
+    Mistri::Agent.new(provider:).run("hi") { |event| seen << event.type }
+
+    assert_includes seen, :text_delta
+    assert_includes seen, :done
+  end
+
+  def test_subscriber_failures_still_propagate_and_log_the_crash
+    logger, io = capture
+    Mistri.logger = logger
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "Hello!" }])
+
+    assert_raises(Boom) do
+      Mistri::Agent.new(provider:).run("hi") do |event|
+        raise Boom, "host sink died" if event.type == :done
+      end
+    end
+    assert_match(/crashed TestLoggerSink::Boom: host sink died/, io.string)
+  end
+
+  def test_sub_agents_log_once_each_under_their_own_session
+    logger, io = capture
+    Mistri.logger = logger
+    child_provider = Mistri::Providers::Fake.new(turns: [{ text: "Paris." }])
+    researcher = Mistri::SubAgent.new(name: "researcher", description: "Answers questions.",
+                                      provider: child_provider)
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { tool_calls: [{ name: "researcher",
+                                                              arguments: {
+                                                                "task" => "Capital of France?"
+                                                              } }] },
+                                             { text: "It is Paris." }
+                                           ])
+
+    Mistri::Agent.new(provider:, tools: [researcher.tool]).run("Ask the researcher.")
+
+    log = io.string
+
+    assert_equal 1, log.scan('text "Paris."').length,
+                 "the child's answer logs once, from the child's own agent"
+    assert_equal 1, log.scan('text "It is Paris."').length
+    assert_match(/run "Capital of France\?"/, log)
+    assert_equal 2, log.scan(/\[mistri ([0-9a-f]{8})\]/).uniq.length,
+                 "parent and child log under their own session tags"
+  end
+
+  def test_no_logger_means_no_logging
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "Hello!" }])
+
+    result = nil
+    assert_silent { result = Mistri::Agent.new(provider:).run("hi") }
+
+    assert_predicate result, :completed?
+  end
+end


### PR DESCRIPTION
Assigning `Mistri.logger` makes every run log its story as one scannable line per beat: the input, each tool call and result with a short pairing id, arguments, duration, and payload size, each turn's token usage, retries, compaction, approvals, worker reports, and a closing line with the outcome, elapsed time, turn count, and dollar cost when pricing is known. Origin-tagged events are skipped so every agent, sub-agents included in any process, logs its own events exactly once, tagged by session or by its worker label. A logging failure warns once per run and that run's sink goes quiet; with no logger assigned, the per-event path is untouched.

```text
[mistri 44ebe274] run "What is the weather in Lahore right now?" (claude-opus-4-8, 1 tool)
[mistri 44ebe274] thinking "Looking at a straightforward weather question."
[mistri 44ebe274] turn 1 done tool_use (403 in / 59 out)
[mistri 44ebe274] tool weather#uXE6 {"city":"Lahore"}
[mistri 44ebe274] tool weather#uXE6 ok 0ms "Sunny, 31C in Lahore."
[mistri 44ebe274] text "It's currently sunny and 31C in Lahore."
[mistri 44ebe274] turn 2 done stop (481 in / 20 out)
[mistri 44ebe274] done completed in 3.8s, 2 turns, 884 in / 79 out, $0.0064
```

Motivation: hosts have production telemetry sinks but nothing readable for local development. RubyLLM and friends log transport internals; this logs what the agent actually did.

The second commit answers an adversarial review: framing methods are total so a logging failure can never replace a host exception (including invalid byte sequences), the global accepts sinks by duck type and rejects junk at assignment time, `task` logs one frame around its fix passes, resume frames every outcome including still-pending, sub-agents log under their worker label, tool lines carry pairing ids, a `level:` option floors the ordinary lines, errored turns count, size suffixes only appear on actually-truncated values, and the line order in the docs is pinned by a test.

Tested with the hermetic suite (1062 runs), the live suite against all three providers, and a live end-to-end smoke on claude-opus-4-8, gpt-5.6-sol, and gemini-3.1-pro-preview including a cross-provider sub-agent run.