### PR TITLE
Keep the live ring honest under provider capacity spikes

### DIFF
--- a/test/test_gemini_live.rb
+++ b/test/test_gemini_live.rb
@@ -80,8 +80,11 @@ class TestGeminiLive < Minitest::Test
   end
 
   def test_foreign_tool_history_projects_into_a_valid_gemini_continuation
-    provider = Mistri::Providers::Gemini.new(api_key: ENV.fetch("GEMINI_API_KEY"),
-                                             model: "gemini-3.5-flash")
+    # The provider default, like every other test here: this test proves
+    # history projection, and pinning the newest model makes it fail on
+    # that model's capacity spikes instead. The matrix suite owns per-model
+    # liveness.
+    provider = Mistri::Providers::Gemini.new(api_key: ENV.fetch("GEMINI_API_KEY"))
     fact = "Mistri-cross-provider-#{SecureRandom.hex(5)}"
     call = Mistri::ToolCall.new(id: "openai-call-1", name: "lookup",
                                 arguments: { "record" => "one" },
@@ -94,9 +97,11 @@ class TestGeminiLive < Minitest::Test
       Mistri::Message.user("Repeat the exact historical lookup result and nothing else.")
     ]
 
-    message = provider.stream(messages: history) { |_event| nil }
+    message = Mistri::Test.retry_transient do
+      provider.stream(messages: history) { |_event| nil }
+    end
 
-    assert_equal :stop, message.stop_reason
+    assert_equal :stop, message.stop_reason, message.error_message.to_s
     assert_includes message.text, fact
   ensure
     provider&.close

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,5 +42,25 @@ require "minitest/autorun"
 module Mistri
   module Test
     ALLOW_LOOPBACK = ->(_uri, address) { address.loopback? }
+
+    # Live provider calls ride out capacity spikes: retry a turn whose
+    # terminal is a transient server-side failure, so the live ring proves a
+    # model is real without failing on its provider's bad minute. Anything
+    # else (a 404 for a retired id, a schema rejection) returns immediately
+    # and fails the test as it should.
+    TRANSIENT = /ServerError|status 5\d\d|UNAVAILABLE|overloaded|try again/i
+
+    def self.retry_transient(attempts: 3, pause: 10)
+      result = nil
+      attempts.times do |round|
+        result = yield
+        transient = result.respond_to?(:stop_reason) && result.stop_reason == :error &&
+                    result.error_message.to_s.match?(TRANSIENT)
+        return result unless transient
+
+        sleep(pause * (round + 1)) unless round == attempts - 1
+      end
+      result
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,19 +44,16 @@ module Mistri
     ALLOW_LOOPBACK = ->(_uri, address) { address.loopback? }
 
     # Live provider calls ride out capacity spikes: retry a turn whose
-    # terminal is a transient server-side failure, so the live ring proves a
-    # model is real without failing on its provider's bad minute. Anything
-    # else (a 404 for a retired id, a schema rejection) returns immediately
-    # and fails the test as it should.
-    TRANSIENT = /ServerError|status 5\d\d|UNAVAILABLE|overloaded|try again/i
-
-    def self.retry_transient(attempts: 3, pause: 10)
+    # terminal the gem's own RetryPolicy classifies as transient, so the
+    # live ring retries exactly what the loop itself would (429s, 5xx,
+    # overload, truncated streams) and fails fast on everything else (a
+    # retired id's 404, a schema rejection), as it should.
+    def self.retry_transient(attempts: 3, pause: 10, policy: Mistri::RetryPolicy.new)
       result = nil
       attempts.times do |round|
         result = yield
-        transient = result.respond_to?(:stop_reason) && result.stop_reason == :error &&
-                    result.error_message.to_s.match?(TRANSIENT)
-        return result unless transient
+        error = result.respond_to?(:stop_reason) ? policy.error_for(result) : nil
+        return result unless error && policy.retryable?(error)
 
         sleep(pause * (round + 1)) unless round == attempts - 1
       end

--- a/test/test_model_matrix_live.rb
+++ b/test/test_model_matrix_live.rb
@@ -31,11 +31,15 @@ class TestModelMatrixLive < Minitest::Test
     provider = config[:klass].new(api_key: ENV.fetch(config[:key]), model: model.id,
                                   **config[:options])
     events = []
-    message = provider.stream(
-      messages: [Mistri::Message.user("Reply with exactly: ok")]
-    ) { |event| events << event }
+    message = Mistri::Test.retry_transient do
+      events = []
+      provider.stream(
+        messages: [Mistri::Message.user("Reply with exactly: ok")]
+      ) { |event| events << event }
+    end
 
-    assert_equal :stop, message.stop_reason, "#{model.id} did not finish cleanly"
+    assert_equal :stop, message.stop_reason,
+                 "#{model.id} did not finish cleanly: #{message.error_message}"
     assert_match(/ok/i, message.text, "#{model.id} produced no usable text")
     assert(events.any? { |e| e.type == :text_delta }, "#{model.id} did not stream")
     assert_operator message.usage.output, :>, 0, "#{model.id} reported no output tokens"

--- a/test/test_transient_retries.rb
+++ b/test/test_transient_retries.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# The live ring's transient-retry helper: classification comes from the
+# gem's own RetryPolicy, so live tests ride out exactly what the loop
+# itself would retry and fail fast on everything else.
+class TestTransientRetries < Minitest::Test
+  def stream(provider)
+    provider.stream(messages: [Mistri::Message.user("Reply with exactly: ok")]) { |_event| nil }
+  end
+
+  def test_a_clean_result_returns_without_retrying
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "ok" }, { text: "never" }])
+
+    message = Mistri::Test.retry_transient(pause: 0) { stream(provider) }
+
+    assert_equal :stop, message.stop_reason
+    assert_equal 1, provider.requests.length
+  end
+
+  def test_transient_errors_retry_until_one_succeeds
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { error: "overloaded", status: 529 },
+                                             { error: "rate limited", status: 429 },
+                                             { text: "recovered" }
+                                           ])
+
+    message = Mistri::Test.retry_transient(pause: 0) { stream(provider) }
+
+    assert_equal :stop, message.stop_reason
+    assert_equal 3, provider.requests.length
+  end
+
+  def test_exhausted_attempts_return_the_last_errored_result
+    provider = Mistri::Providers::Fake.new(turns: Array.new(3) { { error: "down", status: 503 } })
+
+    message = Mistri::Test.retry_transient(attempts: 3, pause: 0) { stream(provider) }
+
+    assert_equal :error, message.stop_reason
+    assert_equal 3, provider.requests.length
+  end
+
+  def test_non_transient_errors_fail_fast
+    provider = Mistri::Providers::Fake.new(turns: [
+                                             { error: "model not found", status: 404 },
+                                             { text: "never" }
+                                           ])
+
+    message = Mistri::Test.retry_transient(pause: 0) { stream(provider) }
+
+    assert_equal :error, message.stop_reason
+    assert_equal 1, provider.requests.length
+  end
+end


### PR DESCRIPTION
Two Gemini live tests were failing on `gemini-3.5-flash` returning 503 UNAVAILABLE ("high demand") for hours. The model id is real (a retired id 404s), so nothing in the catalog is stale; the live ring just had no resilience and no diagnostics.

Three changes:

- `Mistri::Test.retry_transient` retries a turn whose terminal is a transient server-side failure (5xx, UNAVAILABLE, overloaded) with backoff, so the live ring proves a model is real without failing on its provider's bad minute. A 404 or schema rejection still fails immediately.
- Failed liveness assertions now print the provider's actual error, so a red live run says why without a rerun.
- The foreign-history projection test uses the provider default model like every other test in its file, instead of pinning the newest (and currently capacity-starved) flash. That test proves history projection; the matrix suite owns per-model liveness.

With this, the full Gemini live file passes. The matrix entry for `gemini-3.5-flash` still fails while Google's capacity spike lasts, which is the truth a live matrix exists to report.

Tested: full Gemini live file green, hermetic suite green, rubocop clean.