### PR TITLE
Prepare the 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-30
+
 - `Mistri.logger` and `Mistri::Sinks::Logger`: assign any Logger-compatible
   object and every run logs its story as one scannable line per beat, tagged
   by session (sub-agents get their worker label): the input, each tool call
@@ -913,7 +915,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Reserved the gem name.
 
-[Unreleased]: https://github.com/mcheemaa/mistri/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/mcheemaa/mistri/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/mcheemaa/mistri/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/mcheemaa/mistri/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/mcheemaa/mistri/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mcheemaa/mistri/compare/v0.4.1...v0.5.0

--- a/lib/mistri/version.rb
+++ b/lib/mistri/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mistri
-  VERSION = "0.6.1"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
Stamps the CHANGELOG's Unreleased section as 0.7.0 dated today and bumps the version, so the `v0.7.0` tag can be cut from main once this merges.

0.7.0 is a minor release with one feature: `Mistri.logger` and `Mistri::Sinks::Logger`, the built-in run logging that renders every run's story as one line per beat, with content controls, worker labels, bounded rendering, and dollar cost. Fully backward compatible; with no logger assigned nothing changes.

Release flow after merge: push the `v0.7.0` tag, the verify job runs, and the publish job holds for the release-environment approval before OIDC publishes to RubyGems and the release page is cut from the changelog.

Tested: full hermetic suite (1,088 runs) and RuboCop clean on the bumped tree.