### PR TITLE
Preserve line boundaries in fuzzy edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `claude-opus-5` joins the model catalog with its published pricing and
   context window, verified against the live API.
+- Fuzzy edits preserve the final LF or CRLF separator when the search text
+  does not include it, rather than joining the replacement to the next line.
+  Trailing blank lines remain part of the search anchor and its diagnostics.
 
 ## [0.7.0] - 2026-07-30
 

--- a/docs/context-and-workspaces.md
+++ b/docs/context-and-workspaces.md
@@ -201,6 +201,12 @@ intentional blind whole-document replacement, and deletion has no conditional
 form. When concurrent writers must preserve unrelated changes, use an anchored
 edit or provide a host tool with a stronger domain contract.
 
+For a single replacement, `edit_file` tries an exact match first, then tolerates
+indentation and trailing space differences across whole lines. In that fallback,
+the final line separator is replaced only when `old_string` includes it;
+otherwise it stays untouched. Trailing blank lines are part of the anchor.
+Replacement indentation is not adjusted automatically.
+
 Bind one to the built-in read, write, edit, find, and list tools:
 
 ```ruby

--- a/lib/mistri/edit.rb
+++ b/lib/mistri/edit.rb
@@ -121,13 +121,13 @@ module Mistri
     end
 
     # Match the old text's lines against a window of content lines, comparing
-    # each line stripped of leading and trailing whitespace. The matched region
-    # is the exact original bytes those content lines span.
+    # each line stripped of leading and trailing whitespace. A final line
+    # separator belongs to the match only when the old text includes it.
     def fuzzy_match(content, edit)
       lines = line_spans(content)
       wanted = edit[:old].lines.map(&:strip)
-      wanted.pop if wanted.last == "" # a trailing newline in old text is not a line to match
-      return nil if wanted.empty?
+      # Whitespace alone must not turn an empty line into a zero-length match.
+      return nil if wanted.empty? || wanted == [""]
 
       windows = matching_windows(lines, wanted)
       return nil if windows.empty?
@@ -135,8 +135,15 @@ module Mistri
       raise EditError, ambiguous_message(edit, windows.map { |w| w + 1 }) if windows.length > 1
 
       first = windows.first
-      Match.new(lines[first][:start], lines[first + wanted.length - 1][:finish],
-                edit[:new], edit[:index])
+      finish = fuzzy_finish(content, lines[first + wanted.length - 1][:finish], edit[:old])
+      Match.new(lines[first][:start], finish, edit[:new], edit[:index])
+    end
+
+    def fuzzy_finish(content, finish, old)
+      return finish if old.end_with?("\n")
+      return finish - 2 if content[finish - 2, 2] == "\r\n"
+
+      content[finish - 1] == "\n" ? finish - 1 : finish
     end
 
     # When nothing matched, show the model the closest region and exactly how
@@ -161,7 +168,6 @@ module Mistri
       lines = line_spans(content)
       wanted_raw = old_text.lines.map(&:chomp)
       wanted = wanted_raw.map(&:strip)
-      wanted.pop && wanted_raw.pop if wanted.last == ""
       return nil if wanted.empty? || lines.length < wanted.length
 
       best = best_window(lines, wanted)

--- a/test/test_atomic_file_edits.rb
+++ b/test/test_atomic_file_edits.rb
@@ -145,6 +145,22 @@ class TestAtomicFileEdits < Minitest::Test
     assert_equal 2, workspace.comparisons
   end
 
+  def test_a_fuzzy_edit_preserves_the_boundary_after_rebasing
+    workspace = ScriptedWorkspace.new(page) do |store, comparison|
+      next unless comparison == 1
+
+      store.replace(store.content.sub("</main>", "  <aside>Human</aside>\n</main>"))
+    end
+
+    result = tool(workspace).call(fuzzy_body_edit)
+
+    assert_equal "Replaced 1 occurrence(s) in page.html", result
+    assert_equal "<main>\n  <h1>Agent</h1>\n  <p>Updated</p>\n  <aside>Human</aside>\n</main>\n",
+                 workspace.content
+    assert_equal 2, workspace.snapshots
+    assert_equal 2, workspace.comparisons
+  end
+
   def test_a_same_target_conflict_becomes_a_typed_edit_error
     workspace = ScriptedWorkspace.new(page) do |store, comparison|
       store.replace(store.content.sub("Old", "Human")) if comparison == 1
@@ -314,6 +330,18 @@ class TestAtomicFileEdits < Minitest::Test
     assert_equal 1, workspace.writes
   end
 
+  def test_a_fuzzy_edit_preserves_the_boundary_in_a_legacy_workspace
+    workspace = LegacyWorkspace.new(page)
+
+    result = tool(workspace).call(fuzzy_body_edit)
+
+    assert_equal "Replaced 1 occurrence(s) in page.html", result
+    assert_equal 1, workspace.reads
+    assert_equal 1, workspace.writes
+    assert_equal "<main>\n  <h1>Agent</h1>\n  <p>Updated</p>\n</main>\n",
+                 workspace.read("page.html")
+  end
+
   def test_incomplete_atomic_claims_fail_at_tool_construction
     atomic_methods = %i[snapshot compare_and_write]
     atomic_methods.each do |present|
@@ -353,5 +381,10 @@ class TestAtomicFileEdits < Minitest::Test
   def paragraph_edit(value)
     { "path" => "page.html", "old_string" => "<p>Old copy</p>",
       "new_string" => "<p>#{value}</p>" }
+  end
+
+  def fuzzy_body_edit
+    { "path" => "page.html", "old_string" => "<h1>Old</h1>\n<p>Old copy</p>",
+      "new_string" => "  <h1>Agent</h1>\n  <p>Updated</p>" }
   end
 end

--- a/test/test_edit.rb
+++ b/test/test_edit.rb
@@ -23,8 +23,7 @@ class TestEdit < Minitest::Test
     edit = { old: "do_work\nfinish", new: "do_work\n    log\n    finish" }
     result = Mistri::Edit.apply(content, [edit])
 
-    assert_includes result, "log"
-    assert_equal "def run\n", result.lines.first
+    assert_equal "def run\ndo_work\n    log\n    finish\nend\n", result
   end
 
   def test_a_match_that_is_not_unique_raises
@@ -122,7 +121,6 @@ class TestEdit < Minitest::Test
     content = "﻿<html>\n  <body></body>\n</html>\n"
     result = Mistri::Edit.replace(content, "<html>\n<body></body>", "<html>\n<body>hi</body>")
 
-    assert result.content.start_with?("﻿")
-    assert_includes result.content, "hi"
+    assert_equal "﻿<html>\n<body>hi</body>\n</html>\n", result.content
   end
 end

--- a/test/test_edit_boundaries.rb
+++ b/test/test_edit_boundaries.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Fuzzy matching forgives whitespace drift, not the ownership of line separators.
+class TestEditBoundaries < Minitest::Test
+  def test_fuzzy_replacements_only_consume_explicit_final_newlines
+    cases = [
+      ["alpha\nbeta", "A\nB", "before\nA\nB\nafter\n"],
+      ["alpha\nbeta\n", "A\nB", "before\nA\nBafter\n"],
+      ["alpha\nbeta", "A\nB\n", "before\nA\nB\n\nafter\n"],
+      ["alpha\nbeta\n", "A\nB\n", "before\nA\nB\nafter\n"],
+      ["alpha\nbeta", "", "before\n\nafter\n"],
+      ["alpha\nbeta\n", "", "before\nafter\n"]
+    ]
+    ["\n", "\r\n"].each do |newline|
+      content = "before\n  alpha  \n  beta\t\nafter\n".gsub("\n", newline)
+
+      cases.each do |old, replacement, expected|
+        assert_fuzzy_edit(expected.gsub("\n", newline), content,
+                          old.gsub("\n", newline), replacement.gsub("\n", newline))
+      end
+    end
+  end
+
+  def test_an_unterminated_final_line_does_not_gain_an_implicit_newline
+    [false, true].each do |terminated|
+      old = terminated ? "alpha\nbeta\n" : "alpha\nbeta"
+
+      assert_fuzzy_edit("before\nA\nB", "before\n  alpha\n  beta", old, "A\nB")
+      assert_fuzzy_edit("before\nA\nB\n", "before\n  alpha\n  beta", old, "A\nB\n")
+    end
+  end
+
+  def test_a_terminated_final_line_keeps_its_unmatched_newline
+    assert_fuzzy_edit("before\nA\nB\n", "before\n  alpha\n  beta\n", "alpha\nbeta", "A\nB")
+  end
+
+  def test_mixed_line_endings_outside_the_match_are_unchanged
+    assert_fuzzy_edit("before\r\nA\nB\r\nafter\nlast\n",
+                      "before\r\n  alpha\n  beta\r\nafter\nlast\n", "alpha\nbeta", "A\nB")
+  end
+
+  def test_bom_and_multibyte_characters_do_not_shift_boundaries
+    assert_fuzzy_edit("\uFEFFhéader\r\nCafé\r\n完了\r\n末尾\r\n",
+                      "\uFEFFhéader\r\n  café  \r\n  fin  \r\n末尾\r\n",
+                      "café\nfin", "Café\r\n完了")
+    assert_fuzzy_edit("\uFEFFCafé\n完了\nsuffix\n", "\uFEFF  café\n  fin\nsuffix\n",
+                      "café\nfin", "Café\n完了")
+  end
+
+  def test_trailing_blank_lines_are_part_of_the_anchor
+    assert_fuzzy_edit("before\nA\nafter\n", "before\n  alpha  \n\n\nafter\n",
+                      "alpha\n\n\n", "A\n")
+    assert_fuzzy_edit("before\nA\nafter\n", "before\n  alpha  \n \t\nafter\n",
+                      "alpha\n \n", "A\n")
+  end
+
+  def test_a_trailing_blank_line_can_disambiguate_fuzzy_matches
+    assert_fuzzy_edit("  alpha  \nfirst\nA\nlast\n", "  alpha  \nfirst\n  alpha  \n\nlast\n",
+                      "alpha\n\n", "A\n")
+  end
+
+  def test_a_missing_trailing_blank_line_cannot_match
+    content = "before\n  alpha  \nafter\n"
+    error = assert_raises(Mistri::EditError) do
+      Mistri::Edit.replace(content, "alpha\n\n", "A\n")
+    end
+
+    assert_match(/old text was not found/, error.message)
+    assert_equal "before\n  alpha  \nafter\n", content
+  end
+
+  def test_a_single_whitespace_only_line_cannot_be_a_fuzzy_anchor
+    [false, true].each do |terminated|
+      old = terminated ? "\t\n" : "\t"
+
+      assert_raises(Mistri::EditError) { Mistri::Edit.replace("\n", old, "X") }
+      assert_raises(Mistri::EditError) do
+        Mistri::Edit.apply("\n", [{ old: old, new: "X" }])
+      end
+    end
+  end
+
+  def test_whitespace_only_anchors_cannot_insert_at_the_same_boundary
+    assert_raises(Mistri::EditError) do
+      Mistri::Edit.apply("\n", [{ old: "\t", new: "X" }, { old: " ", new: "Y" }])
+    end
+  end
+
+  def test_near_miss_diagnostics_count_real_trailing_blank_lines
+    error = assert_raises(Mistri::EditError) do
+      Mistri::Edit.replace("  alpha\n  betx\n\nsuffix\n", "alpha\nbeta\n\n", "A\n")
+    end
+
+    assert_match(/Closest region is lines 1-3/, error.message)
+    assert_match(/differs at line 2/, error.message)
+  end
+
+  def test_adjacent_fuzzy_edits_leave_each_unmatched_separator_intact
+    edits = [{ old: "alpha\nbeta", new: "A\nB" }, { old: "gamma\ndelta", new: "G\nD" }]
+    result = Mistri::Edit.apply("before\n  alpha\n  beta\n  gamma\n  delta\nafter\n", edits)
+
+    assert_equal "before\nA\nB\nG\nD\nafter\n", result
+  end
+
+  def test_an_explicit_blank_line_is_included_in_overlap_detection
+    content = "  alpha  \n\n  beta\nsuffix\n"
+    error = assert_raises(Mistri::EditError) do
+      Mistri::Edit.apply(content, [{ old: "alpha\n\n", new: "A\n" },
+                                   { old: "\nbeta", new: "B" }])
+    end
+
+    assert_match(/overlap/, error.message)
+    assert_equal "  alpha  \n\n  beta\nsuffix\n", content
+  end
+
+  def test_duplicate_fuzzy_windows_remain_ambiguous
+    error = assert_raises(Mistri::EditError) do
+      Mistri::Edit.replace("  alpha\n  beta\n  alpha\n  beta\n", "alpha\nbeta", "A\nB")
+    end
+
+    assert_match(/matched 2 places \(lines 1, 3\)/, error.message)
+  end
+
+  def test_exact_matching_still_takes_precedence_over_fuzzy_candidates
+    content = "  alpha\n  beta\nalpha\nbeta\nafter\n"
+
+    assert_equal "  alpha\n  beta\nA\nB\nafter\n",
+                 Mistri::Edit.replace(content, "alpha\nbeta", "A\nB").content
+  end
+
+  def test_replace_all_remains_exact_only
+    assert_raises(Mistri::EditError) do
+      Mistri::Edit.replace("  alpha\n  beta\n", "alpha\nbeta", "A\nB", replace_all: true)
+    end
+    result = Mistri::Edit.replace("alpha\nbeta\nalpha\nbeta\n", "alpha\nbeta", "A\nB",
+                                  replace_all: true)
+
+    assert_equal "A\nB\nA\nB\n", result.content
+    assert_equal 2, result.count
+  end
+
+  def test_replace_adapts_newlines_but_apply_keeps_replacement_bytes
+    content = "before\r\n  alpha\r\n  beta\r\nafter\r\n"
+    result = Mistri::Edit.replace(content, "alpha\nbeta", "A\nB")
+
+    assert_equal "before\r\nA\r\nB\r\nafter\r\n", result.content
+    assert_equal "before\r\nA\nB\r\nafter\r\n",
+                 Mistri::Edit.apply(content, [{ old: "alpha\nbeta", new: "A\nB" }])
+  end
+
+  private
+
+  def assert_fuzzy_edit(expected, content, old, replacement)
+    refute_includes content, old
+    assert_equal expected, Mistri::Edit.apply(content, [{ old: old, new: replacement }])
+    result = Mistri::Edit.replace(content, old, replacement)
+
+    assert_equal expected, result.content
+    assert_equal 1, result.count
+  end
+end

--- a/test/test_file_tools.rb
+++ b/test/test_file_tools.rb
@@ -30,6 +30,16 @@ class TestFileTools < Minitest::Test
     assert_includes @workspace.read("hero.html"), "<h1>Hello</h1>"
   end
 
+  def test_a_fuzzy_edit_preserves_the_following_line_in_storage
+    reply = @tools["edit_file"].call({ "path" => "hero.html",
+                                       "old_string" => "<h1>Welcome</h1>\n<p>Hi</p>",
+                                       "new_string" => "  <h1>Hello</h1>\n  <p>Updated</p>" })
+
+    assert_equal "Replaced 1 occurrence(s) in hero.html", reply
+    assert_equal "<div>\n  <h1>Hello</h1>\n  <p>Updated</p>\n</div>\n",
+                 @workspace.read("hero.html")
+  end
+
   def test_edit_file_tolerates_alias_keys_and_stringly_booleans
     @workspace.write("x.txt", "a\na\n")
     reply = @tools["edit_file"].call({ "file" => "x.txt", "oldText" => "a",


### PR DESCRIPTION
## What and why

Fuzzy edits could swallow a newline and join the replacement to the next line while reporting success.

Preserve separators outside the search text and keep trailing blank lines in the anchor. Exact matching and `replace_all` are unchanged. The fix adds final-boundary checks, with no new I/O or change in algorithmic complexity.

## Testing

Tests pass on Ruby 3.2 and 3.3; lint is clean. Regressions cover newline styles, EOF, Unicode, blank lines, and saved workspace content through conflict retries.