### PR TITLE
Update model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- `gpt-6-astra` and `claude-fable-5-1` join the model catalog with published
+  context limits and pricing. Provider defaults are unchanged. Compacted
+  replay drops Fable 5.1 thinking bound to the old prefix, preserving tool
+  calls, results, the durable transcript, and new post-compaction thinking.
 - `claude-opus-5` joins the model catalog with its published pricing and
   context window, verified against the live API.
 - Fuzzy edits preserve the final LF or CRLF separator when the search text

--- a/docs/context-and-workspaces.md
+++ b/docs/context-and-workspaces.md
@@ -139,6 +139,11 @@ This seam supports host redaction, retrieval, and deliberate windowing, but it
 is low-level. Preserve message order and every tool-call/result pair. A
 provider will reject a history whose correlation facts were removed.
 
+Fable 5.1 also binds thinking to the preceding prefix. A transform that changes
+between turns, including the periodic reminder below, can invalidate retained
+thinking. See [provider constraints](reliability.md#gpt-6-astra-and-fable-51)
+before using these transforms with it.
+
 For periodic instruction reinforcement, use the built-in Reminder:
 
 ```ruby

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -370,6 +370,31 @@ Provider-specific per-turn overrides belong on a directly constructed
 provider's `stream` contract. The Agent intentionally exposes a stable common
 loop rather than mirroring every provider option as a top-level keyword.
 
+### GPT-6 Astra and Fable 5.1
+
+Select `gpt-6-astra` or `claude-fable-5-1` explicitly; adding them to the catalog
+does not change any default model. Both support streaming tools, native
+structured output, context-window accounting, and standard-tier cost estimates.
+
+[Astra](https://developers.openai.com/api/docs/models/gpt-6-astra) accepts
+reasoning effort `low`, `medium`, `high`, `xhigh`, or `max`, not `none` or
+`minimal`. Its standard rates increase above 272,000 input tokens, including
+cached tokens; Mistri applies that tier to each request.
+
+[Fable 5.1](https://platform.claude.com/docs/en/models/fable-5-1/migration-guide)
+uses always-on adaptive thinking. Keep Mistri's default thinking configuration;
+disabled or token-budget thinking and forced `tool_choice: any/tool` are not
+supported. It also requires an eligible Anthropic account with 30-day retention.
+
+Fable's signed thinking binds to all preceding messages, the system prompt,
+and tool definitions. Keep those stable when continuing a session. Transient
+context transforms, including `Reminder.every`, can invalidate later thinking
+when their injected messages disappear. Mistri handles its own
+[compaction boundary](sessions.md#compaction), not arbitrary host prefix
+rewrites. Start a new session for a different prefix, or deliberately remove
+the affected thinking blocks from the host's replay view. Do not rewrite the
+stored transcript or tool-call/result pairs.
+
 ## Custom providers
 
 A provider used by `Mistri::Agent` exposes a model ID and responds to `stream`:

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -244,6 +244,14 @@ uses the visible summary plus the retained tail, while the full original log
 remains available through `entries` and `transcript`. Compaction cannot hide an
 open approval or split a completed tool call from its result.
 
+Fable 5.1 binds thinking to the conversation prefix. After compaction, replay
+omits its pre-compaction thinking from the kept tail; new thinking and the
+durable transcript stay intact. Other models' thinking is unchanged. Manual
+compaction must use the same per-session serialization as `run` and `resume`,
+between provider turns, not inside an event callback or alongside an in-flight
+request. An answer generated against the old prefix cannot safely join the
+new one.
+
 Very large tool results may be shortened only in the request sent to the
 summarizer. The durable result and ordinary replay remain unchanged until a
 successful compaction intentionally replaces earlier context with the summary.

--- a/lib/mistri/compactor.rb
+++ b/lib/mistri/compactor.rb
@@ -6,8 +6,8 @@ module Mistri
   # Compacts a session in place: everything before a cut point is summarized
   # by the provider, and a compaction entry redirects replay to the summary
   # plus the kept tail. Append-only: the full history stays in the store for
-  # transcript UIs; only what the model sees shrinks. Callable from any
-  # process (a UI button, a job), with or without a running agent.
+  # transcript UIs; only what the model sees shrinks. Manual callers share
+  # the session runner's serialization and compact between provider turns.
   #
   # Cuts land on user messages or assistant tool-call turns, never results,
   # so every call/result set stays on one side. A parked approval's turn is

--- a/lib/mistri/models.rb
+++ b/lib/mistri/models.rb
@@ -98,6 +98,8 @@ module Mistri
     private_class_method :price
 
     CATALOG = [
+      ["claude-fable-5-1", :anthropic, 128_000, 1_000_000, :adaptive,
+       [price(input: 10.0, output: 50.0, cache_read: 0.25, cache_write: 12.5)]],
       ["claude-fable-5", :anthropic, 128_000, 1_000_000, :adaptive,
        [price(input: 10.0, output: 50.0, cache_read: 1.0, cache_write: 12.5)]],
       ["claude-opus-5", :anthropic, 128_000, 1_000_000, :adaptive,
@@ -116,6 +118,11 @@ module Mistri
        [price(input: 3.0, output: 15.0, cache_read: 0.3, cache_write: 3.75)]],
       ["claude-haiku-4-5", :anthropic, 64_000, 200_000, :budget,
        [price(input: 1.0, output: 5.0, cache_read: 0.1, cache_write: 1.25)]],
+      ["gpt-6-astra", :openai, 128_000, 1_050_000, :effort,
+       [price({ input: 10.0, output: 50.0, cache_read: 1.0, cache_write: 12.5 },
+              above: 272_000,
+              higher: { input: 20.0, output: 75.0, cache_read: 2.0,
+                        cache_write: 25.0 })]],
       ["gpt-5.6-sol", :openai, 128_000, 1_050_000, :effort,
        [price({ input: 5.0, output: 30.0, cache_read: 0.5, cache_write: 6.25 },
               above: 272_000,
@@ -175,6 +182,9 @@ module Mistri
     end
 
     def self.thinking(id) = find(id)&.thinking
+
+    # These signatures bind to the preceding conversation, not just their turn.
+    def self.prefix_bound_thinking?(id) = find(id)&.id == "claude-fable-5-1"
 
     def self.rates(id, usage: nil, at: Time.now) = find(id)&.rates(usage:, at:)
 

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -565,15 +565,32 @@ module Mistri
     end
 
     def replay_from(log)
-      compaction = log.reverse_each.find { |entry| entry["type"] == "compaction" }
+      compacted_at = log.rindex { |entry| entry["type"] == "compaction" }
+      compaction = log[compacted_at] if compacted_at
       from = compaction ? compaction["kept_from"] : 0
       pairs = log.each_with_index.filter_map do |entry, index|
         next unless index >= from && entry["type"] == "message"
 
-        [Message.from_h(entry["message"]), index]
+        message = replay_message(entry, before_compaction: compacted_at && index < compacted_at)
+        [message, index] if message
       end
       pairs = heal(pairs, replay_call_states(log, from:))
       compaction ? [[summary_message(compaction["summary"]), nil], *pairs] : pairs
+    end
+
+    # A new summary invalidates prefix-bound thinking in the kept tail. Only
+    # replay drops it: the transcript and thoughts from the new prefix survive.
+    def replay_message(entry, before_compaction:)
+      message = Message.from_h(entry["message"])
+      return message unless before_compaction && message.assistant? &&
+                            message.provider == :anthropic &&
+                            Models.prefix_bound_thinking?(message.model)
+
+      content = message.content.grep_v(Content::Thinking)
+      return message if content.length == message.content.length
+      return if content.all? { |block| block.is_a?(Content::Text) && block.text.empty? }
+
+      message.with(content:)
     end
 
     # Replay only needs occurrence pairing, not the authorization audit. Keep

--- a/test/test_fable_compaction_live.rb
+++ b/test/test_fable_compaction_live.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require_relative "test_helper"
+
+# Fable's prefix-bound thinking must survive compaction as durable history,
+# without sending an invalid signature back in the shortened replay.
+class TestFableCompactionLive < Minitest::Test
+  SYSTEM = "Follow the user's instructions exactly. " \
+           "Use lookup_checkpoint before stating its value."
+
+  # Older accounts do not enforce binding by default; explicitly opt in so
+  # this regression exercises the same rejection as newly created accounts.
+  class BindingCheckedTransport
+    def initialize(transport)
+      @transport = transport
+    end
+
+    def stream_post(path, body:, headers:, **, &emit)
+      headers = headers.merge("anthropic-beta" => "thinking-binding-controls-2026-08-01")
+      thinking = body.fetch(:thinking).merge(block_binding: { prefix_mismatch_behavior: "error" })
+      @transport.stream_post(path, body: body.merge(thinking:), headers:, **, &emit)
+    end
+
+    def close = @transport.close
+  end
+
+  def setup
+    skip "set MISTRI_LIVE=1 for live tests" unless ENV["MISTRI_LIVE"] == "1"
+    skip "no ANTHROPIC_API_KEY" if ENV["ANTHROPIC_API_KEY"].to_s.empty?
+
+    @provider = Mistri::Providers::Anthropic.new(
+      api_key: ENV.fetch("ANTHROPIC_API_KEY"), model: "claude-fable-5-1", read_timeout: 120
+    )
+    transport = BindingCheckedTransport.new(@provider.instance_variable_get(:@transport))
+    @provider.instance_variable_set(:@transport, transport)
+    @tools = [{ name: "lookup_checkpoint", description: "Returns the checkpoint value.",
+                input_schema: { type: "object", properties: { prime: { type: "integer" } },
+                                required: ["prime"] } }]
+  end
+
+  def teardown
+    @provider&.close
+  end
+
+  def test_signed_tool_thinking_replays_after_compaction_and_a_later_turn
+    session = checkpoint_session
+    reply = signed_tool_reply(session.messages)
+    call = reply.tool_calls.first
+    secret = "checkpoint-#{SecureRandom.hex(12)}"
+    session.append_message(reply)
+    session.append_message(Mistri::Message.tool(
+                             content: "CHECKPOINT_VALUE=#{secret}\n" \
+                                      "Return CHECKPOINT_VALUE exactly.",
+                             tool_call_id: call.id, tool_name: call.name
+                           ))
+
+    assert_completed_value(session.messages, secret)
+    durable = session.entries
+
+    compaction = Mistri::Compactor.call(session:, provider: @provider,
+                                        settings: Mistri::Compaction.new(keep_recent: 100))
+
+    refute_nil compaction, "the fixture must cross a real compaction boundary"
+    assert_operator session.last_compaction.fetch("kept_from"), :>, 0
+    retained = session.messages.find { |message| message.tool_calls.include?(call) }
+
+    refute_nil retained, "the signed tool-call turn must remain in the compacted tail"
+    assert_empty retained.content.grep(Mistri::Content::Thinking)
+    assert_equal durable, session.entries.take(durable.length), "the durable history changed"
+
+    continued = assert_completed_value(session.messages, secret)
+    session.append_message(continued)
+
+    assert_equal continued, session.messages.last, "new post-compaction thinking must remain intact"
+
+    session.append_message(Mistri::Message.user(
+                             "Repeat the checkpoint value exactly, without calling a tool."
+                           ))
+
+    assert_completed_value(session.messages, secret)
+  end
+
+  private
+
+  def checkpoint_session
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    session.append_message(Mistri::Message.user(
+                             "Earlier task: verify a synthetic migration. " * 50
+                           ))
+    session.append_message(Mistri::Message.assistant(
+                             content: "Earlier preparation is complete. " * 50, stop_reason: :stop
+                           ))
+    session.append_message(Mistri::Message.user(
+                             "Determine the smallest prime larger than 1000000. " \
+                             "Check its divisibility carefully. Then call lookup_checkpoint " \
+                             "with that prime once, without answering in text first."
+                           ))
+    session
+  end
+
+  def signed_tool_reply(messages)
+    reply = stream(messages)
+
+    assert_equal :tool_use, reply.stop_reason, reply.error_message
+    assert_equal 1, reply.tool_calls.length
+    assert_equal "lookup_checkpoint", reply.tool_calls.first.name
+    assert(reply.content.grep(Mistri::Content::Thinking).any? do |block|
+      !block.signature.to_s.empty?
+    end, "the tool turn must carry real signed thinking to exercise prefix binding")
+    reply
+  end
+
+  def assert_completed_value(messages, secret)
+    reply = stream(messages)
+
+    assert_equal :stop, reply.stop_reason, reply.error_message
+    assert_includes reply.text, secret
+    reply
+  end
+
+  def stream(messages)
+    Mistri::Test.retry_transient do
+      @provider.stream(messages:, system: SYSTEM, tools: @tools)
+    end
+  end
+end

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -6,7 +6,9 @@ require_relative "support/stub_server"
 
 class TestModels < Minitest::Test
   def test_known_models_carry_their_output_ceiling
+    assert_equal 128_000, Mistri::Models.max_output("claude-fable-5-1")
     assert_equal 128_000, Mistri::Models.max_output("claude-opus-4-8")
+    assert_equal 128_000, Mistri::Models.max_output("gpt-6-astra")
     assert_equal 128_000, Mistri::Models.max_output("gpt-5.6")
     assert_equal 64_000, Mistri::Models.max_output("claude-haiku-4-5")
     assert_equal %i[id provider max_output context_window thinking],
@@ -14,13 +16,13 @@ class TestModels < Minitest::Test
   end
 
   def test_catalogued_models_carry_their_published_context_windows
-    million = %w[claude-fable-5 claude-opus-4-8 claude-opus-4-7 claude-opus-4-6
+    million = %w[claude-fable-5-1 claude-fable-5 claude-opus-4-8 claude-opus-4-7 claude-opus-4-6
                  claude-sonnet-5 claude-sonnet-4-6]
 
     million.each { |model| assert_equal 1_000_000, Mistri::Models.find(model).context_window }
 
     assert_equal 200_000, Mistri::Models.find("claude-haiku-4-5").context_window
-    %w[gpt-5.6 gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna gpt-5.5 gpt-5.4].each do |model|
+    %w[gpt-6-astra gpt-5.6 gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna gpt-5.5 gpt-5.4].each do |model|
       assert_equal 1_050_000, Mistri::Models.find(model).context_window
     end
     assert_equal 400_000, Mistri::Models.find("gpt-5-nano").context_window
@@ -32,9 +34,11 @@ class TestModels < Minitest::Test
   end
 
   def test_only_shared_context_windows_reserve_output_capacity
+    assert_equal 128_000, Mistri::Models.shared_output("gpt-6-astra")
     assert_equal 128_000, Mistri::Models.shared_output("gpt-5.6")
     assert_equal 128_000, Mistri::Models.shared_output("gpt-5.5")
     assert_equal 128_000, Mistri::Models.shared_output("claude-opus-4-8")
+    assert_equal 128_000, Mistri::Models.shared_output("claude-fable-5-1")
     assert_nil Mistri::Models.shared_output("gemini-3.1-pro-preview")
     assert_nil Mistri::Models.shared_output("future-model")
   end
@@ -69,6 +73,62 @@ class TestModels < Minitest::Test
     assert_nil Mistri::Models.rates("claude-next-9000"), "unknown models carry no rates"
     assert(Mistri::Models::CATALOG.each_value.all?(&:priced?),
            "every catalogued model carries verified rates")
+  end
+
+  def test_astra_and_fable_5_1_dated_ids_preserve_their_capabilities
+    { "gpt-6-astra" => %i[openai effort],
+      "claude-fable-5-1" => %i[anthropic adaptive] }.each do |id, (provider, thinking)|
+      model = Mistri::Models.find(id)
+
+      assert_equal provider, model.provider
+      assert_equal thinking, Mistri::Models.thinking(id)
+      assert_equal model, Mistri::Models.find("#{id}-20260901")
+      assert_equal model, Mistri::Models.find("#{id}-2026-09-01")
+    end
+  end
+
+  def test_astra_and_fable_5_1_enable_native_schemas_and_standard_tier_cost_budgets
+    schema = Mistri::Schema.task_plan(Mistri::Schema.build do
+      string :answer, required: true
+    end).schema
+    providers = [
+      Mistri::Providers::OpenAI.new(api_key: "test", model: "gpt-6-astra",
+                                    service_tier: "default"),
+      Mistri::Providers::Anthropic.new(api_key: "test", model: "claude-fable-5-1",
+                                       service_tier: "standard_only")
+    ]
+
+    providers.each do |provider|
+      assert_equal schema, provider.native_output_schema(schema)
+      assert_predicate provider, :prices_usage?
+    end
+  ensure
+    providers&.each(&:close)
+  end
+
+  def test_astra_pricing_includes_cache_writes_on_both_context_tiers
+    boundary = Mistri::Usage.new(input: 100_000, cache_read: 100_000, cache_write: 72_000)
+    over = boundary.with(cache_write: 72_001)
+    standard = { input: 10.0, output: 50.0, cache_read: 1.0, cache_write: 12.5 }
+    higher = { input: 20.0, output: 75.0, cache_read: 2.0, cache_write: 25.0 }
+
+    assert_equal standard, Mistri::Models.rates("gpt-6-astra")
+    assert_equal standard, Mistri::Models.rates("gpt-6-astra", usage: boundary)
+    assert_equal higher, Mistri::Models.rates("gpt-6-astra", usage: over)
+  end
+
+  def test_fable_5_1_pricing_covers_both_cache_retention_windows
+    rates = Mistri::Models.rates("claude-fable-5-1")
+    usage = Mistri::Usage.new(input: 300_000, output: 100_000, cache_read: 200_000,
+                              cache_write: 300_000, cache_write_1h: 100_000)
+    priced = usage.with_cost(rates)
+
+    assert_equal({ input: 10.0, output: 50.0, cache_read: 0.25, cache_write: 12.5 }, rates)
+    assert_equal rates, Mistri::Models.rates("claude-fable-5-1", usage:)
+    assert_in_delta 0.05, priced.cost.cache_read
+    assert_in_delta 4.5, priced.cost.cache_write
+    assert_in_delta 12.55, priced.cost.total
+    assert_predicate priced.cost, :known?
   end
 
   def test_openai_long_context_pricing_uses_each_requests_prompt_size

--- a/test/test_session_compaction_thinking.rb
+++ b/test/test_session_compaction_thinking.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Compaction changes the prefix without rewriting the durable thinking record.
+class TestSessionCompactionThinking < Minitest::Test
+  def setup
+    @session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    @session.append_message(Mistri::Message.user("earlier context"))
+  end
+
+  def test_uncompacted_thinking_round_trips_unchanged
+    message = assistant("original")
+    @session.append_message(message)
+
+    assert_equal message, @session.messages.last
+  end
+
+  def test_compaction_removes_only_pre_boundary_prefix_bound_thinking
+    old = assistant("old", model: "claude-fable-5-1-20260901")
+    @session.append_message(old)
+    compact
+    fresh = assistant("fresh")
+    @session.append_message(fresh)
+    original_entries = @session.entries
+
+    replay = @session.replay
+
+    assert_equal [nil, 1, 3], replay.map(&:last)
+    assert_equal old.with(content: old.content.grep(Mistri::Content::Text)), replay[1].first
+    assert_equal fresh, replay.last.first
+    assert_equal replay, @session.replay, "repeated reads must keep the same signed prefix"
+    assert_equal original_entries, @session.entries
+    assert_equal old, Mistri::Message.from_h(@session.entries[1].fetch("message"))
+  end
+
+  def test_repeated_compaction_invalidates_thinking_from_the_previous_prefix
+    @session.append_message(assistant("first"))
+    compact
+    @session.append_message(assistant("second"))
+    compact
+    third = assistant("third")
+    @session.append_message(third)
+
+    replay = @session.messages
+
+    assert_empty replay[1].content.grep(Mistri::Content::Thinking)
+    assert_empty replay[2].content.grep(Mistri::Content::Thinking)
+    assert_equal third, replay.last
+    assert_equal(3, @session.entries.count { |entry| entry.dig("message", "role") == "assistant" })
+  end
+
+  def test_redacted_and_empty_thinking_are_removed_without_empty_wire_turns
+    redacted = Mistri::Content::Thinking.new(thinking: "", signature: "redacted", redacted: true)
+    empty = Mistri::Content::Thinking.new(thinking: "", signature: "empty")
+    blank = Mistri::Content::Text.new(text: "")
+    @session.append_message(assistant("hidden").with(content: [redacted]))
+    @session.append_message(assistant("empty").with(content: [empty, blank]))
+    visible = assistant("visible").with(content: [redacted, empty,
+                                                  Mistri::Content::Text.new(text: "kept")])
+    @session.append_message(visible)
+    compact
+
+    replay = @session.replay
+
+    assert_equal [nil, 3], replay.map(&:last)
+    assert_equal "kept", replay.last.first.text
+    wire = Mistri::Providers::Anthropic::Serializer.messages(@session.messages)
+
+    assert_equal [{ type: "text", text: "kept" }], wire.last[:content]
+    assert_equal 5, @session.entries.length
+  end
+
+  def test_other_models_and_provider_metadata_remain_unchanged
+    messages = [assistant("older", model: "claude-fable-5"),
+                assistant("opus", model: "claude-opus-5"),
+                assistant("foreign", model: "gpt-6-astra", provider: :openai),
+                assistant("missing", model: nil),
+                assistant("future", model: "claude-fable-6"),
+                assistant("mismatched", provider: :gemini),
+                assistant("plain").with(content: [Mistri::Content::Text.new(text: "no thinking")])]
+    messages.each { |message| @session.append_message(message) }
+    compact
+
+    assert_equal messages, @session.messages.drop(1)
+  end
+
+  def test_tool_pairing_and_crash_healing_survive_thinking_removal
+    calls = %w[answered interrupted].map do |id|
+      Mistri::ToolCall.new(id:, name: "lookup", arguments: {})
+    end
+    original = assistant("checking")
+    original = original.with(content: [*original.content, *calls], stop_reason: :tool_use)
+    @session.append_message(original)
+    @session.append_message(Mistri::Message.tool(content: "found", tool_call_id: "answered"))
+    compact
+
+    replay = @session.messages
+    results = replay.select(&:tool?)
+
+    assert_equal calls, replay.find(&:assistant?).tool_calls
+    assert_equal %w[answered interrupted], results.map(&:tool_call_id)
+    assert_equal "found", results.first.text
+    assert_predicate results.last, :tool_error?
+    wire = Mistri::Providers::Anthropic::Serializer.messages(replay)
+
+    blocks = wire.flat_map { |message| message[:content] }
+
+    refute(blocks.any? { |block| block[:type] == "thinking" })
+    assert_equal original, Mistri::Message.from_h(@session.entries[1].fetch("message"))
+  end
+
+  def test_parked_approvals_remain_open_without_manufactured_results
+    call = Mistri::ToolCall.new(id: "approval", name: "send", arguments: {})
+    message = assistant("checking")
+    message = message.with(content: [*message.content, call], stop_reason: :tool_use)
+    @session.append_message(message)
+    @session.append("approval_request", "call" => call.to_h)
+    compact
+
+    assert_equal([call], @session.open_approvals.map { |approval| approval[:call] })
+    assert_empty @session.messages.select(&:tool?)
+    assert_equal [call], @session.messages.find(&:assistant?).tool_calls
+
+    executions = 0
+    tool = Mistri::Tool.define("send", "Send after approval.", needs_approval: true) do
+      executions += 1
+      "sent"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "done" }])
+    @session.approve(call.id)
+    result = Mistri::Agent.new(provider:, session: @session, tools: [tool]).resume
+
+    assert_predicate result, :completed?
+    assert_equal 1, executions
+    assert_empty @session.open_approvals
+    sent = provider.requests.first.fetch(:messages)
+
+    assert_empty sent.find(&:assistant?).content.grep(Mistri::Content::Thinking)
+    assert_equal "sent", sent.find(&:tool?).text
+    assert_equal message, Mistri::Message.from_h(@session.entries[1].fetch("message"))
+  end
+
+  private
+
+  def assistant(text, model: "claude-fable-5-1", provider: :anthropic)
+    Mistri::Message.assistant(
+      content: [Mistri::Content::Thinking.new(thinking: "reasoning", signature: "sig-#{text}"),
+                Mistri::Content::Text.new(text:)],
+      model:, provider:, stop_reason: :stop
+    )
+  end
+
+  def compact
+    @session.append("compaction", "summary" => "earlier context summary", "kept_from" => 1)
+  end
+end


### PR DESCRIPTION
## What and why

Add GPT-6 Astra and Fable 5.1 to the catalog with verified limits and pricing, without changing defaults.

Fable binds thinking to the preceding conversation. Compacted replay now removes its invalidated thinking while preserving stored history, tool pairs, and new thinking. Document the prefix and manual-compaction constraints.

Replay adds a shallow scan of retained pre-compaction Fable content, with no extra I/O or streaming buffering. Incomplete-summary rejection stays separate.

## Testing

`bundle exec rake test` and `bundle exec rubocop` pass. Live checks cover both new models, approvals, structured output, enforced Fable signature validation, and repeated compaction across five models.
