### PR TITLE
Reject incomplete compaction summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Compaction rejects incomplete summaries instead of replacing replay with
+  partial context. Manual compaction raises `CompactionError`; automatic
+  compaction retains the previous context and counts the failed attempt's
+  usage. Custom providers must return `stop_reason: :stop`, nonblank text,
+  and no tool calls for a successful summary.
 - `gpt-6-astra` and `claude-fable-5-1` join the model catalog with published
   context limits and pricing. Provider defaults are unchanged. Compacted
   replay drops Fable 5.1 thinking bound to the old prefix, preserving tool

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -415,8 +415,10 @@ end
 Disable compaction explicitly only when a custom provider cannot describe a
 model context window.
 
-It returns an assistant `Mistri::Message`. A completed tool call must be a
-`Mistri::ToolCall` with:
+It returns an assistant `Mistri::Message` with an explicit `stop_reason` from
+`Mistri::StopReason`. In particular, compaction accepts only `:stop` with
+nonblank text and no tool calls; missing completion metadata is not success.
+A completed tool call must be a `Mistri::ToolCall` with:
 
 - a non-empty UTF-8 String ID unique for new calls in the Session;
 - a non-empty UTF-8 String name;

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -239,6 +239,15 @@ Manual `compact` returns nil when there is no useful cut. During a compaction,
 `:compacting` announces that work began. The later `:compaction` event carries
 the visible summary in `event.content`.
 
+Only a normally completed summary with nonblank text and no tool calls can
+become a checkpoint. A truncated or otherwise incomplete response leaves the
+previous summary and retained context unchanged, and emits no `:compaction`
+event. Manual `compact` raises `Mistri::CompactionError` with the attempt's
+usage in `error.usage`. Automatic compaction counts that usage toward the run
+and its budget, then continues with the existing context if the budget permits.
+If that context no longer fits, the next request can still fail with a provider
+context-limit error. A later tool turn may attempt compaction again.
+
 The summary and kept-tail boundary append to the session. Provider replay then
 uses the visible summary plus the retained tail, while the full original log
 remains available through `entries` and `transcript`. Compaction cannot hide an

--- a/lib/mistri/compactor.rb
+++ b/lib/mistri/compactor.rb
@@ -153,16 +153,21 @@ module Mistri
         prompt << (previous ? UPDATE_PROMPT : CHECKPOINT_PROMPT)
         prompt << "\nAdditional focus: #{instructions}\n" if instructions
         reply = provider.stream(messages: [Message.user(prompt)], system: SUMMARIZER_SYSTEM)
-        unless usable?(reply)
-          raise CompactionError.new("summarization failed: #{reply.error_message}",
-                                    usage: reply.usage)
+        if (failure = summary_failure(reply))
+          raise CompactionError.new("summarization failed: #{failure}", usage: reply.usage)
         end
 
         reply
       end
 
-      def usable?(reply)
-        reply.stop_reason != StopReason::ERROR && !reply.text.to_s.strip.empty?
+      def summary_failure(reply)
+        return reply.error_message || "provider error" if reply.stop_reason == StopReason::ERROR
+        if reply.stop_reason != StopReason::STOP
+          return "unexpected stop reason: #{reply.stop_reason.inspect}"
+        end
+        return "unexpected tool calls" if reply.tool_calls?
+
+        "empty summary" if reply.text.to_s.strip.empty?
       end
 
       def finish(session, reply, tokens_before, &emit)

--- a/test/test_compaction_failure.rb
+++ b/test/test_compaction_failure.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require_relative "test_helper"
+
+# An incomplete summary must never replace the context needed to continue a session.
+class TestCompactionFailure < Minitest::Test
+  SETTINGS = Mistri::Compaction.new(window: 600, reserve: 550, keep_recent: 10)
+  SUMMARY_USAGE = Mistri::Usage.new(input: 1_000, output: 48)
+                               .with_cost(input: 1.0, output: 5.0)
+
+  def test_nonempty_summaries_require_a_normal_stop
+    (Mistri::StopReason::ALL - [:stop] + [nil]).each do |reason|
+      reply = Mistri::Message.assistant(content: "private unfinished summary",
+                                        stop_reason: reason, usage: SUMMARY_USAGE)
+      expected = reason == :error ? "provider error" : "unexpected stop reason: #{reason.inspect}"
+
+      assert_rejected(reply, expected)
+    end
+  end
+
+  def test_a_normal_stop_requires_visible_nonblank_text
+    [nil, "", " \n\t", Mistri::Content::Thinking.new(thinking: "not a summary")].each do |content|
+      reply = Mistri::Message.assistant(content:, stop_reason: :stop, usage: SUMMARY_USAGE)
+
+      assert_rejected(reply, "empty summary")
+    end
+  end
+
+  def test_a_normal_stop_cannot_hide_a_tool_call_alongside_text
+    call = Mistri::ToolCall.new(id: "unexpected", name: "save", arguments: {})
+    reply = Mistri::Message.assistant(content: "private unfinished summary", tool_calls: [call],
+                                      stop_reason: :stop, usage: SUMMARY_USAGE)
+
+    assert_rejected(reply, "unexpected tool calls")
+  end
+
+  def test_provider_errors_keep_their_diagnostic_and_usage
+    reply = Mistri::Message.assistant(content: "private unfinished summary", stop_reason: :error,
+                                      error_message: "summarizer unavailable", usage: SUMMARY_USAGE)
+
+    assert_rejected(reply, "summarizer unavailable")
+  end
+
+  def test_completed_text_with_thinking_does_not_need_prescribed_headings
+    provider = Mistri::Providers::Fake.new(turns: [{ thinking: "considering the history",
+                                                     text: "The export is ready.",
+                                                     usage: SUMMARY_USAGE }])
+    session = history
+
+    result = Mistri::Compactor.call(session:, provider:, settings: SETTINGS)
+
+    assert_equal "The export is ready.", result[:summary]
+    assert_same SUMMARY_USAGE, result[:usage]
+    assert_equal "The export is ready.", session.last_compaction.fetch("summary")
+  end
+
+  def test_manual_rejection_preserves_the_previous_checkpoint_across_reload
+    Dir.mktmpdir do |directory|
+      session = history(store: Mistri::Stores::JSONL.new(directory), checkpoint: true)
+      path = File.join(directory, "compaction-test.jsonl")
+      before_file = File.binread(path)
+      before_replay = session.messages
+      provider = Mistri::Providers::Fake.new(turns: [incomplete_turn])
+      events = []
+
+      error = assert_raises(Mistri::CompactionError) do
+        Mistri::Agent.new(provider:, session:, compaction: SETTINGS).compact do |event|
+          events << event.type
+        end
+      end
+      reloaded = Mistri::Session.new(store: Mistri::Stores::JSONL.new(directory), id: session.id)
+
+      assert_same SUMMARY_USAGE, error.usage
+      assert_equal before_file, File.binread(path)
+      assert_equal before_replay, reloaded.messages
+      assert_equal session.last_compaction, reloaded.last_compaction
+      assert_equal [:compacting], events
+      assert_equal 1, provider.requests.length
+    end
+  end
+
+  def test_automatic_rejection_retains_context_and_counts_usage_once
+    [false, true].each do |checkpoint|
+      session = history(checkpoint:)
+      before = session.entries
+      replay = session.messages
+      turn_usage = Mistri::Usage.new(input: 500).with_cost(input: 1.0)
+      provider = Mistri::Providers::Fake.new(turns: [incomplete_turn,
+                                                     { text: "done", usage: turn_usage }])
+      events = []
+
+      result = Mistri::Agent.new(provider:, session:,
+                                 compaction: SETTINGS).run("Continue.") do |event|
+        events << event.type
+      end
+
+      assert_predicate result, :completed?
+      assert_equal SUMMARY_USAGE + turn_usage, result.usage
+      assert_equal 2, provider.requests.length
+      assert_equal replay + [Mistri::Message.user("Continue.")], provider.requests.last[:messages]
+      assert_equal before, session.entries.take(before.length)
+      assert_equal(checkpoint ? 1 : 0, session.entries.count do |entry|
+        entry["type"] == "compaction"
+      end)
+      assert_equal 1, events.count(:compacting)
+      refute_includes events, :compaction
+    end
+  end
+
+  def test_incomplete_summary_cost_can_stop_before_another_provider_call
+    session = history(checkpoint: true)
+    checkpoint = session.last_compaction
+    provider = Mistri::Providers::Fake.new(turns: [incomplete_turn, { text: "must not run" }])
+    budget = Mistri::Budget.new(cost_usd: SUMMARY_USAGE.cost.total / 2)
+
+    result = Mistri::Agent.new(provider:, session:, compaction: SETTINGS, budget:).run("Continue.")
+
+    assert_predicate result, :stopped_by_budget?
+    assert_equal "budget_cost", result.error_message
+    assert_equal SUMMARY_USAGE, result.usage
+    assert_equal 1, provider.requests.length
+    assert_equal checkpoint, session.last_compaction
+  end
+
+  def test_rejection_keeps_approval_gated_execution_resumable
+    session = history(checkpoint: true)
+    saved = []
+    tool = Mistri::Tool.define("save", "Save the export.", needs_approval: true,
+                                                           ends_turn: true) do
+      saved << :saved
+      "saved"
+    end
+    provider = Mistri::Providers::Fake.new(turns: [incomplete_turn,
+                                                   { tool_calls: [{ name: "save" }] }])
+    agent = Mistri::Agent.new(provider:, session:, tools: [tool], compaction: SETTINGS)
+
+    result = agent.run("Save the export.")
+
+    assert_predicate result, :awaiting_approval?
+    assert_equal 1, result.pending.length
+    assert_empty saved
+    assert_equal SUMMARY_USAGE, result.usage
+
+    reloaded = Mistri::Session.new(store: session.store, id: session.id)
+    reloaded.approve(result.pending.first.id)
+    resumed = Mistri::Agent.new(provider:, session: reloaded, tools: [tool],
+                                compaction: false).resume
+
+    assert_equal [:saved], saved
+    assert_predicate resumed, :completed?
+    assert_equal 2, provider.requests.length
+  end
+
+  private
+
+  def history(store: Mistri::Stores::Memory.new, checkpoint: false)
+    session = Mistri::Session.new(store:, id: "compaction-test")
+    session.append_message(Mistri::Message.user("Original export rules. " * 80))
+    session.append_message(Mistri::Message.assistant(content: "Source inspected. " * 80,
+                                                     stop_reason: :stop))
+    session.append_message(Mistri::Message.user("Retain this follow-up. " * 80))
+    if checkpoint
+      provider = Mistri::Providers::Fake.new(turns: [{ text: "Previous export rules." }])
+      Mistri::Compactor.call(session:, provider:, settings: SETTINGS)
+      session.append_message(Mistri::Message.assistant(content: "Ready to continue. " * 80,
+                                                       stop_reason: :stop))
+      session.append_message(Mistri::Message.user("Keep the export rules."))
+    end
+    session
+  end
+
+  def incomplete_turn
+    { text: "private unfinished summary", stop_reason: :length, usage: SUMMARY_USAGE }
+  end
+
+  def assert_rejected(reply, diagnostic)
+    session = history
+    before = session.entries
+    replay = session.messages
+    events = []
+    provider = Mistri::Providers::Fake.new
+    provider.define_singleton_method(:stream) { |**| reply }
+
+    error = assert_raises(Mistri::CompactionError) do
+      Mistri::Compactor.call(session:, provider:, settings: SETTINGS) { |event| events << event.type }
+    end
+
+    assert_equal "summarization failed: #{diagnostic}", error.message
+    refute_includes error.message, "private unfinished summary"
+    assert_same reply.usage, error.usage
+    assert_equal before, session.entries
+    assert_equal replay, session.messages
+    assert_nil session.last_compaction
+    assert_equal [:compacting], events
+  end
+end

--- a/test/test_compaction_live.rb
+++ b/test/test_compaction_live.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "tmpdir"
+require_relative "test_helper"
+
+# A real output-limit stop must leave the durable conversation usable after reload.
+class TestCompactionLive < Minitest::Test
+  # Observe the actual wire result without replacing the summarizer or its response.
+  class ObservedAnthropic < Mistri::Providers::Anthropic
+    attr_reader :reply
+
+    def stream(**)
+      @reply = Mistri::Test.retry_transient { super }
+    end
+  end
+
+  def setup
+    skip "set MISTRI_LIVE=1 for live tests" unless ENV["MISTRI_LIVE"] == "1"
+    skip "no ANTHROPIC_API_KEY" if ENV["ANTHROPIC_API_KEY"].to_s.empty?
+
+    options = { api_key: ENV.fetch("ANTHROPIC_API_KEY"), model: "claude-haiku-4-5-20251001",
+                thinking: { type: "disabled" }, service_tier: "standard_only", read_timeout: 120 }
+    @summarizer = ObservedAnthropic.new(**options, max_tokens: 48)
+    @provider = Mistri::Providers::Anthropic.new(**options)
+  end
+
+  def teardown
+    @summarizer&.close
+    @provider&.close
+  end
+
+  def test_a_truncated_summary_preserves_requirements_for_a_live_continuation
+    Dir.mktmpdir do |dir|
+      filename = "export-#{SecureRandom.hex(12)}.json"
+      session = export_session(dir, filename)
+      path = File.join(dir, "#{session.id}.jsonl")
+      durable = File.binread(path)
+      replay = session.replay
+      events = []
+      agent = Mistri::Agent.new(provider: @summarizer, session:,
+                                compaction: Mistri::Compaction.new(keep_recent: 20))
+
+      error = assert_raises(Mistri::CompactionError) do
+        agent.compact { |event| events << event.type }
+      end
+
+      assert_equal :length, @summarizer.reply.stop_reason
+      refute_empty @summarizer.reply.text.strip
+      assert_equal @summarizer.reply.usage, error.usage
+      assert_operator error.usage.output, :>, 0
+      assert_predicate error.usage.cost, :known?
+      assert_operator error.usage.cost.total, :>, 0
+      assert_equal [:compacting], events
+
+      reloaded = Mistri::Session.new(store: Mistri::Stores::JSONL.new(dir), id: session.id)
+
+      assert_equal durable, File.binread(path)
+      assert_equal replay, reloaded.replay
+      assert_nil reloaded.last_compaction
+      assert_original_filename(reloaded, filename)
+    end
+  end
+
+  private
+
+  def export_session(dir, filename)
+    session = Mistri::Session.new(store: Mistri::Stores::JSONL.new(dir))
+    session.append_message(Mistri::Message.user(
+                             "Prepare an export of active European customers, sorted by id. " \
+                             "Use only id, company, and region fields. The exact export " \
+                             "filename must be #{filename}. Do not write the file yet."
+                           ))
+    session.append_message(Mistri::Message.assistant(
+                             content: "Preparation notes: validate the source records, retain " \
+                                      "the requested fields, and await permission to export. " * 50,
+                             stop_reason: :stop
+                           ))
+    session.append_message(Mistri::Message.user("Leave the export pending until I return."))
+    session.append_message(Mistri::Message.assistant(content: "Ready.", stop_reason: :stop))
+    session
+  end
+
+  def assert_original_filename(session, filename)
+    agent = Mistri::Agent.new(provider: @provider, session:, compaction: false,
+                              system: "Return requested identifiers exactly, without formatting.")
+    result = agent.run("What exact export filename did I originally request? " \
+                       "Reply with that filename only.")
+
+    assert_equal :stop, result.stop_reason
+    assert_equal filename, result.text.strip
+  end
+end


### PR DESCRIPTION
Compaction could commit a truncated summary and hide the user's original instructions from replay. A real export harness reproduced the problem.

Require a completed, nonblank summary without tool calls before committing a checkpoint. Rejected attempts preserve context and billed usage. Custom providers must explicitly return `stop_reason: :stop`; the docs and changelog call this out.

The checks add a content-block scan, with no extra I/O or provider calls.

Verified with the full suite on Ruby 3.2 and 3.3, RuboCop, a live truncation regression, and packaged export scenarios across Astra, Fable, Haiku, and Gemini. Healthy and truncated-summary scenarios both pass.
