### PR TITLE
Bound the summary request and stop retrying failed compactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 - The summary request has its own output limit, `Compaction.new(max_tokens:)`
-  (16,384 by default, capped at the model's published output limit), and runs
-  with the provider's default thinking. A host's chat `max_tokens` or thinking
-  budget no longer shapes or truncates the summary.
-- A rejected summary appends a `compaction_failed` entry and emits
-  `:compaction_failed` with the reason in `error_message`. Automatic
-  compaction stops after three failed attempts in a row until a compaction
-  succeeds, instead of billing a full-context request every turn.
+  (16,384 by default, capped at the model's published output limit, sent as
+  Anthropic `max_tokens`, OpenAI `max_output_tokens`, and Gemini
+  `maxOutputTokens`), and runs with the API's default thinking and reasoning.
+  A host's chat limit, thinking budget, or reasoning effort no longer shapes
+  or truncates the summary. A `max_tokens:` stream override now bounds one
+  request's output on every built-in provider.
+- A rejected summary appends a `compaction_failed` entry with the reason and
+  its trigger, emits `:compaction_failed` with the reason in `error_message`,
+  and logs a warning through `Mistri::Sinks::Logger`. Automatic compaction
+  stops after three failed automatic attempts in a row until a compaction
+  succeeds, instead of billing a full-context request every turn; manual
+  attempts are recorded but do not count.
 - Compaction rejects incomplete summaries instead of replacing replay with
   partial context. Manual compaction raises `CompactionError`; automatic
   compaction retains the previous context and counts the failed attempt's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- The summary request has its own output limit, `Compaction.new(max_tokens:)`
+  (16,384 by default, capped at the model's published output limit), and runs
+  with the provider's default thinking. A host's chat `max_tokens` or thinking
+  budget no longer shapes or truncates the summary.
+- A rejected summary appends a `compaction_failed` entry and emits
+  `:compaction_failed` with the reason in `error_message`. Automatic
+  compaction stops after three failed attempts in a row until a compaction
+  succeeds, instead of billing a full-context request every turn.
 - Compaction rejects incomplete summaries instead of replacing replay with
   partial context. Manual compaction raises `CompactionError`; automatic
   compaction retains the previous context and counts the failed attempt's

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -369,7 +369,10 @@ Mistri.agent(
 
 Provider-specific per-turn overrides belong on a directly constructed
 provider's `stream` contract. The Agent intentionally exposes a stable common
-loop rather than mirroring every provider option as a top-level keyword.
+loop rather than mirroring every provider option as a top-level keyword. One
+override is common to every built-in provider: `max_tokens:` bounds that
+request's output (OpenAI `max_output_tokens`, Gemini `maxOutputTokens`); the
+compactor uses it for its summary request.
 
 ### GPT-6 Astra and Fable 5.1
 

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -147,8 +147,9 @@ Loop-level events are:
 - `:tool_started` when a resolved call commits to handler invocation;
 - `:tool_result` after settlement, with a required `tool_error` boolean;
 - `:approval_needed` when a prepared call parks;
-- `:compacting` before summary work and `:compaction` with the committed
-  summary in `content`;
+- `:compacting` before summary work, then `:compaction` with the committed
+  summary in `content` or `:compaction_failed` with the reason in
+  `error_message`;
 - `:retry` before provider backoff;
 - `:subagent_report` when a running background child reaches a terminal state;
   an inactive `Child#stop` persists the report without this callback because it

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -217,6 +217,7 @@ crosses the published window minus safe output headroom. Disable it with
 settings = Mistri::Compaction.new(
   reserve: 64_000,
   keep_recent: 24_000,
+  max_tokens: 8_192,
   instructions: "Preserve decisions, identifiers, and unresolved risks.",
 )
 
@@ -227,6 +228,13 @@ An explicit `window:` enables compaction for an uncatalogued deployment. An
 explicit `reserve:` is host policy; the automatic default otherwise protects a
 catalogued model's shared output capacity plus framing slack. Gemini publishes
 an independent input limit, so its automatic reserve remains input-oriented.
+
+The summary is the compactor's own request. `max_tokens:` bounds its output
+(16,384 by default, never more than the model's published output limit) and
+the request runs with the provider's default thinking, so a short limit or a
+large thinking budget a host set for its own replies never shapes the summary.
+Anthropic counts thinking toward `max_tokens`; OpenAI and Gemini publish no
+request cap here and run at their ceilings.
 
 ```ruby
 agent.context_usage
@@ -241,12 +249,16 @@ the visible summary in `event.content`.
 
 Only a normally completed summary with nonblank text and no tool calls can
 become a checkpoint. A truncated or otherwise incomplete response leaves the
-previous summary and retained context unchanged, and emits no `:compaction`
-event. Manual `compact` raises `Mistri::CompactionError` with the attempt's
-usage in `error.usage`. Automatic compaction counts that usage toward the run
-and its budget, then continues with the existing context if the budget permits.
-If that context no longer fits, the next request can still fail with a provider
-context-limit error. A later tool turn may attempt compaction again.
+previous summary and retained context unchanged, emits `:compaction_failed`
+with the reason in `event.error_message`, and appends a `compaction_failed`
+entry, so the failure shows in `entries` and `transcript` and survives an
+agent rebuilt in another process. Manual `compact` raises
+`Mistri::CompactionError` with the attempt's usage in `error.usage`. Automatic
+compaction counts that usage toward the run and its budget, then continues
+with the existing context if the budget permits. It tries again on a later
+turn while the context stays over the threshold, and stops after three failed
+attempts in a row until a compaction succeeds. If the context no longer fits,
+the next request can still fail with a provider context-limit error.
 
 The summary and kept-tail boundary append to the session. Provider replay then
 uses the visible summary plus the retained tail, while the full original log

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -230,11 +230,13 @@ catalogued model's shared output capacity plus framing slack. Gemini publishes
 an independent input limit, so its automatic reserve remains input-oriented.
 
 The summary is the compactor's own request. `max_tokens:` bounds its output
-(16,384 by default, never more than the model's published output limit) and
-the request runs with the provider's default thinking, so a short limit or a
-large thinking budget a host set for its own replies never shapes the summary.
-Anthropic counts thinking toward `max_tokens`; OpenAI and Gemini publish no
-request cap here and run at their ceilings.
+on every built-in provider (16,384 by default, never more than the model's
+published output limit; sent as Anthropic `max_tokens`, OpenAI
+`max_output_tokens`, and Gemini `maxOutputTokens`, each of which counts
+thinking or reasoning toward the limit). The request runs with the API's
+default thinking and reasoning, so a short limit, a thinking budget, or a
+reasoning effort a host set for its own replies never shapes the summary.
+Ordinary turns keep the host's settings.
 
 ```ruby
 agent.context_usage
@@ -251,14 +253,16 @@ Only a normally completed summary with nonblank text and no tool calls can
 become a checkpoint. A truncated or otherwise incomplete response leaves the
 previous summary and retained context unchanged, emits `:compaction_failed`
 with the reason in `event.error_message`, and appends a `compaction_failed`
-entry, so the failure shows in `entries` and `transcript` and survives an
-agent rebuilt in another process. Manual `compact` raises
-`Mistri::CompactionError` with the attempt's usage in `error.usage`. Automatic
-compaction counts that usage toward the run and its budget, then continues
-with the existing context if the budget permits. It tries again on a later
-turn while the context stays over the threshold, and stops after three failed
-attempts in a row until a compaction succeeds. If the context no longer fits,
-the next request can still fail with a provider context-limit error.
+entry carrying the reason and its trigger (`manual` or `automatic`), so the
+failure shows in `entries` and `transcript` and survives an agent rebuilt in
+another process. Manual `compact` raises `Mistri::CompactionError` with the
+attempt's usage in `error.usage`. Automatic compaction counts that usage
+toward the run and its budget, then continues with the existing context if
+the budget permits. It tries again on a later turn while the context stays
+over the threshold, and stops after three failed automatic attempts in a row
+until a compaction succeeds; manual attempts are recorded but do not count.
+If the context no longer fits, the next request can still fail with a
+provider context-limit error.
 
 The summary and kept-tail boundary append to the session. Provider replay then
 uses the visible summary plus the retained tail, while the full original log

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -269,10 +269,13 @@ module Mistri
     end
 
     # Compact when the context has grown into the reserve. A failed
-    # summarization skips quietly here: if the context genuinely no longer
-    # fits, the next turn surfaces the real provider error.
+    # summarization is recorded on the session and skipped here; after
+    # AUTOMATIC_ATTEMPTS failures in a row the loop stops paying for a
+    # full-context request every turn, and if the context genuinely no
+    # longer fits, the next turn surfaces the real provider error.
     def auto_compact(&)
       return nil unless @compaction
+      return nil if @session.compaction_failures >= Compaction::AUTOMATIC_ATTEMPTS
 
       tokens = @session.context_tokens
       return nil unless @compaction.needed?(tokens, context_window,

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -270,23 +270,30 @@ module Mistri
 
     # Compact when the context has grown into the reserve. A failed
     # summarization is recorded on the session and skipped here; after
-    # AUTOMATIC_ATTEMPTS failures in a row the loop stops paying for a
-    # full-context request every turn, and if the context genuinely no
-    # longer fits, the next turn surfaces the real provider error.
+    # AUTOMATIC_ATTEMPTS automatic failures in a row the loop stops paying
+    # for a full-context request every turn, and if the context genuinely
+    # no longer fits, the next turn surfaces the real provider error. The
+    # failure count is read only once the threshold says compaction is due,
+    # so an ordinary turn costs one history read, not two.
     def auto_compact(&)
       return nil unless @compaction
-      return nil if @session.compaction_failures >= Compaction::AUTOMATIC_ATTEMPTS
 
       tokens = @session.context_tokens
       return nil unless @compaction.needed?(tokens, context_window,
                                             max_output: Models.shared_output(@provider.model))
+      return nil if automatic_compaction_exhausted?
 
       compact_automatically(&)
     end
 
+    def automatic_compaction_exhausted?
+      @session.compaction_failures(trigger: :automatic) >= Compaction::AUTOMATIC_ATTEMPTS
+    end
+
     def compact_automatically(&emit)
       delivery = EventDelivery.wrap(emit)
-      Compactor.call(session: @session, provider: @provider, settings: @compaction, &delivery)
+      Compactor.call(session: @session, provider: @provider, settings: @compaction,
+                     trigger: :automatic, &delivery)
     rescue EventDelivery::Failure => e
       raise EventDelivery.unwrap(e, delivery)
     rescue CompactionError => e

--- a/lib/mistri/compaction.rb
+++ b/lib/mistri/compaction.rb
@@ -14,24 +14,32 @@ module Mistri
   class Compaction
     DEFAULT_RESERVE = 16_384
     DEFAULT_KEEP_RECENT = 20_000
+    DEFAULT_MAX_TOKENS = 16_384
+    # Automatic compaction stops retrying after this many failures in a row: a
+    # failure the configuration makes predictable must not bill a full-context
+    # request every turn.
+    AUTOMATIC_ATTEMPTS = 3
     OUTPUT_SAFETY = 4_096
     IMAGE_CHARS = 4_800
 
     SUMMARY_PREFACE = "The earlier conversation was compacted. This summary replaces it:"
 
-    attr_reader :reserve, :keep_recent, :window, :instructions
+    attr_reader :reserve, :keep_recent, :window, :instructions, :max_tokens
 
     # window overrides the model catalog's context window (required for
     # models the catalog does not know). A nil reserve selects automatic
     # headroom; a number is explicit host policy. instructions add a
-    # host-specific focus to the summary prompt.
+    # host-specific focus to the summary prompt. max_tokens bounds the
+    # summary request's output: the summary is the compactor's own request
+    # and never inherits the limit a host set for its chat replies.
     def initialize(reserve: nil, keep_recent: DEFAULT_KEEP_RECENT,
-                   window: nil, instructions: nil)
+                   window: nil, instructions: nil, max_tokens: DEFAULT_MAX_TOKENS)
       @automatic_reserve = reserve.nil?
       @reserve = reserve || DEFAULT_RESERVE
       @keep_recent = keep_recent
       @window = window
       @instructions = instructions
+      @max_tokens = max_tokens
     end
 
     def automatic_reserve? = @automatic_reserve

--- a/lib/mistri/compaction.rb
+++ b/lib/mistri/compaction.rb
@@ -15,9 +15,9 @@ module Mistri
     DEFAULT_RESERVE = 16_384
     DEFAULT_KEEP_RECENT = 20_000
     DEFAULT_MAX_TOKENS = 16_384
-    # Automatic compaction stops retrying after this many failures in a row: a
-    # failure the configuration makes predictable must not bill a full-context
-    # request every turn.
+    # Automatic compaction stops retrying after this many automatic failures
+    # in a row: a failure the configuration makes predictable must not bill a
+    # full-context request every turn.
     AUTOMATIC_ATTEMPTS = 3
     OUTPUT_SAFETY = 4_096
     IMAGE_CHARS = 4_800
@@ -34,6 +34,10 @@ module Mistri
     # and never inherits the limit a host set for its chat replies.
     def initialize(reserve: nil, keep_recent: DEFAULT_KEEP_RECENT,
                    window: nil, instructions: nil, max_tokens: DEFAULT_MAX_TOKENS)
+      unless max_tokens.is_a?(Integer) && max_tokens.positive?
+        raise ArgumentError, "max_tokens must be a positive Integer"
+      end
+
       @automatic_reserve = reserve.nil?
       @reserve = reserve || DEFAULT_RESERVE
       @keep_recent = keep_recent

--- a/lib/mistri/compactor.rb
+++ b/lib/mistri/compactor.rb
@@ -73,7 +73,7 @@ module Mistri
       # Summarize and cut. Returns {summary:, tokens_before:, tokens_after:,
       # usage:}, or nil when there is nothing worth compacting. Emits
       # :compacting and :compaction when a block is given.
-      def call(session:, provider:, settings: Compaction.new, &emit)
+      def call(session:, provider:, settings: Compaction.new, trigger: :manual, &emit)
         replay = session.replay
         cut = cut_index(replay, session, settings)
         return nil unless cut
@@ -87,7 +87,7 @@ module Mistri
         tokens_before = session.context_tokens
         reply = summarize(provider, head, previous, settings)
         failure = summary_failure(reply)
-        reject(session, failure, tokens_before, reply.usage, &emit) if failure
+        reject(session, failure, trigger, tokens_before, reply.usage, &emit) if failure
 
         session.append("compaction", "summary" => reply.text,
                                      "kept_from" => cut, "tokens_before" => tokens_before)
@@ -161,12 +161,12 @@ module Mistri
 
       # The summary is the compactor's own request. Its output limit comes
       # from the settings, never from the limit a host set for chat replies,
-      # and thinking is the provider's default so a host thinking budget
-      # cannot outsize that limit. Providers without a request cap run at
-      # their published ceiling.
+      # and it runs with the API's default thinking and reasoning, so a host
+      # thinking budget or reasoning effort cannot shape or outsize it.
+      # Commercial settings (keys, origin, service tier) stay the host's.
       def request_overrides(provider, settings)
         ceiling = Models.max_output(provider.model)
-        { max_tokens: [settings.max_tokens, ceiling].compact.min, thinking: nil }
+        { max_tokens: [settings.max_tokens, ceiling].compact.min, thinking: nil, reasoning: nil }
       end
 
       def summary_failure(reply)
@@ -180,10 +180,11 @@ module Mistri
       end
 
       # A failed summary is part of the session's story: the entry keeps the
-      # failure visible across processes so automatic compaction can stop
-      # retrying it, and the event tells a subscriber that :compacting ended.
-      def reject(session, failure, tokens_before, usage, &emit)
-        session.append("compaction_failed", "reason" => failure,
+      # failure and its trigger visible across processes so automatic
+      # compaction can stop retrying its own failures, and the event tells a
+      # subscriber that :compacting ended.
+      def reject(session, failure, trigger, tokens_before, usage, &emit)
+        session.append("compaction_failed", "reason" => failure, "trigger" => trigger.to_s,
                                             "tokens_before" => tokens_before)
         emit&.call(Event.new(type: :compaction_failed, error_message: failure))
         raise CompactionError.new("summarization failed: #{failure}", usage: usage)

--- a/lib/mistri/compactor.rb
+++ b/lib/mistri/compactor.rb
@@ -85,7 +85,10 @@ module Mistri
 
         emit&.call(Event.new(type: :compacting))
         tokens_before = session.context_tokens
-        reply = summarize(provider, head, previous, settings.instructions)
+        reply = summarize(provider, head, previous, settings)
+        failure = summary_failure(reply)
+        reject(session, failure, tokens_before, reply.usage, &emit) if failure
+
         session.append("compaction", "summary" => reply.text,
                                      "kept_from" => cut, "tokens_before" => tokens_before)
         finish(session, reply, tokens_before, &emit)
@@ -147,17 +150,23 @@ module Mistri
         end
       end
 
-      def summarize(provider, messages, previous, instructions)
+      def summarize(provider, messages, previous, settings)
         prompt = "<conversation>\n#{serialize(messages)}\n</conversation>\n\n"
         prompt << "<previous-summary>\n#{previous}\n</previous-summary>\n\n" if previous
         prompt << (previous ? UPDATE_PROMPT : CHECKPOINT_PROMPT)
-        prompt << "\nAdditional focus: #{instructions}\n" if instructions
-        reply = provider.stream(messages: [Message.user(prompt)], system: SUMMARIZER_SYSTEM)
-        if (failure = summary_failure(reply))
-          raise CompactionError.new("summarization failed: #{failure}", usage: reply.usage)
-        end
+        prompt << "\nAdditional focus: #{settings.instructions}\n" if settings.instructions
+        provider.stream(messages: [Message.user(prompt)], system: SUMMARIZER_SYSTEM,
+                        **request_overrides(provider, settings))
+      end
 
-        reply
+      # The summary is the compactor's own request. Its output limit comes
+      # from the settings, never from the limit a host set for chat replies,
+      # and thinking is the provider's default so a host thinking budget
+      # cannot outsize that limit. Providers without a request cap run at
+      # their published ceiling.
+      def request_overrides(provider, settings)
+        ceiling = Models.max_output(provider.model)
+        { max_tokens: [settings.max_tokens, ceiling].compact.min, thinking: nil }
       end
 
       def summary_failure(reply)
@@ -168,6 +177,16 @@ module Mistri
         return "unexpected tool calls" if reply.tool_calls?
 
         "empty summary" if reply.text.to_s.strip.empty?
+      end
+
+      # A failed summary is part of the session's story: the entry keeps the
+      # failure visible across processes so automatic compaction can stop
+      # retrying it, and the event tells a subscriber that :compacting ended.
+      def reject(session, failure, tokens_before, usage, &emit)
+        session.append("compaction_failed", "reason" => failure,
+                                            "tokens_before" => tokens_before)
+        emit&.call(Event.new(type: :compaction_failed, error_message: failure))
+        raise CompactionError.new("summarization failed: #{failure}", usage: usage)
       end
 
       def finish(session, reply, tokens_before, &emit)

--- a/lib/mistri/event.rb
+++ b/lib/mistri/event.rb
@@ -22,11 +22,12 @@ module Mistri
     # The stream types come from a provider mid-turn; the loop adds
     # :tool_started when a resolved tool commits to execution, :tool_result
     # after it finishes, :approval_needed when a gated call parks for a human,
-    # :compacting/:compaction around a context
-    # compaction, and :retry (with attempt, max_attempts, delay) before it
-    # waits out a transient failure, so one subscription sees the whole
-    # exchange. :done and :error are loop-owned and terminal: only the
-    # accepted attempt's terminal event reaches the subscriber.
+    # :compacting before a context compaction and then :compaction or
+    # :compaction_failed (the reason in error_message), and :retry (with
+    # attempt, max_attempts, delay) before it waits out a transient failure,
+    # so one subscription sees the whole exchange. :done and :error are
+    # loop-owned and terminal: only the accepted attempt's terminal event
+    # reaches the subscriber.
     # :subagent_report announces a background child's terminal outcome
     # (agent, session_id, status; content carries the report), so a UI that
     # watched the spawn can settle the child's lane the moment it ends.
@@ -37,7 +38,7 @@ module Mistri
       toolcall_start toolcall_delta toolcall_end
       done error
       tool_started tool_result approval_needed
-      compacting compaction
+      compacting compaction compaction_failed
       retry
       subagent_report
     ].freeze

--- a/lib/mistri/providers/gemini.rb
+++ b/lib/mistri/providers/gemini.rb
@@ -10,8 +10,8 @@ module Mistri
     # Thinking is deliberately unconstrained: no budget, no level, only
     # includeThoughts so summaries stream for the UI. The model's own defaults
     # decide how much to think, and a host override passes through verbatim.
-    # maxOutputTokens is omitted for the same reason: the API defaults to the
-    # model's ceiling.
+    # maxOutputTokens is sent only when a stream call passes max_tokens;
+    # otherwise the API defaults to the model's ceiling.
     class Gemini
       DEFAULT_ORIGIN = "https://generativelanguage.googleapis.com"
       DEFAULT_THINKING = { includeThoughts: true }.freeze
@@ -77,6 +77,7 @@ module Mistri
         config = {}
         thinking = overrides.fetch(:thinking, @thinking)
         config[:thinkingConfig] = thinking if thinking
+        config[:maxOutputTokens] = overrides[:max_tokens] if overrides[:max_tokens]
         # Constrained decoding combines with tools only on 3-series models
         # (preview); with tools present the task loop's validate-and-fix
         # pass carries the guarantee instead.

--- a/lib/mistri/providers/openai.rb
+++ b/lib/mistri/providers/openai.rb
@@ -7,8 +7,9 @@ module Mistri
     # The OpenAI Responses API, streamed and stateless: store is always false,
     # the full history replays every turn, and encrypted reasoning items round
     # trip through the signature slots so nothing depends on server-side
-    # state. Reasoning summaries stream as thinking. max_output_tokens is
-    # deliberately omitted: the API defaults to the model's own ceiling.
+    # state. Reasoning summaries stream as thinking. max_output_tokens is sent
+    # only when a stream call passes max_tokens; otherwise the API defaults to
+    # the model's own ceiling.
     #
     # Provider failures fold into the stream as an error turn rather than
     # raising, matching the Anthropic provider's contract.
@@ -78,6 +79,7 @@ module Mistri
         body[:service_tier] = service_tier if service_tier
         reasoning = overrides.fetch(:reasoning, @reasoning)
         body[:reasoning] = reasoning if reasoning
+        body[:max_output_tokens] = overrides[:max_tokens] if overrides[:max_tokens]
         if (schema = overrides[:output_schema])
           body[:text] = { format: { type: "json_schema", name: "output", strict: true,
                                     schema: Schema.strict(schema, all_required: true) } }

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -92,6 +92,14 @@ module Mistri
       entries.reverse_each.find { |entry| entry["type"] == "compaction" }
     end
 
+    # Failed summaries since the last checkpoint. Automatic compaction reads
+    # this to stop retrying a failure that has proven persistent.
+    def compaction_failures
+      log = entries
+      since = (log.rindex { |entry| entry["type"] == "compaction" } || -1) + 1
+      log.drop(since).count { |entry| entry["type"] == "compaction_failed" }
+    end
+
     # The inbox: entry types queued for the loop's next turn boundary, each
     # mapped to the marker key its fold leaves on the consuming message
     # entry.

--- a/lib/mistri/session.rb
+++ b/lib/mistri/session.rb
@@ -92,12 +92,15 @@ module Mistri
       entries.reverse_each.find { |entry| entry["type"] == "compaction" }
     end
 
-    # Failed summaries since the last checkpoint. Automatic compaction reads
-    # this to stop retrying a failure that has proven persistent.
-    def compaction_failures
+    # Failed summaries since the last checkpoint, all of them or only those
+    # of one trigger (:manual or :automatic). Automatic compaction counts its
+    # own failures to stop retrying one that has proven persistent.
+    def compaction_failures(trigger: nil)
       log = entries
       since = (log.rindex { |entry| entry["type"] == "compaction" } || -1) + 1
-      log.drop(since).count { |entry| entry["type"] == "compaction_failed" }
+      log.drop(since).count do |entry|
+        entry["type"] == "compaction_failed" && (trigger.nil? || entry["trigger"] == trigger.to_s)
+      end
     end
 
     # The inbox: entry types queued for the loop's next turn boundary, each

--- a/lib/mistri/sinks/logger.rb
+++ b/lib/mistri/sinks/logger.rb
@@ -39,7 +39,8 @@ module Mistri
                 tool_started: :tool_line, tool_result: :tool_result_line,
                 done: :turn_line, error: :error_line, retry: :retry_line,
                 approval_needed: :approval_line, compacting: :compacting_line,
-                compaction: :compaction_line, subagent_report: :report_line }.freeze
+                compaction: :compaction_line, compaction_failed: :compaction_failed_line,
+                subagent_report: :report_line }.freeze
       QUIET = %i[text_end thinking_end tool_started done approval_needed
                  compacting compaction subagent_report].to_h { |type| [type, true] }.freeze
       COLORS = { bold: "1", dim: "2", red: "31", green: "32", yellow: "33" }.freeze
@@ -182,15 +183,12 @@ module Mistri
       # failures alarm. A budget stop is synthetic (no provider call), so
       # it alone does not count as a turn.
       def error_line(event)
-        case event.reason
-        when StopReason::BUDGET then ["stopped on budget", :warn]
-        when StopReason::ABORTED
-          @turns += 1
-          "aborted"
-        else
-          @turns += 1
-          ["#{paint("error", :red)} #{event.reason}#{note(event.error_message)}", :error]
-        end
+        return ["stopped on budget", :warn] if event.reason == StopReason::BUDGET
+
+        @turns += 1
+        return "aborted" if event.reason == StopReason::ABORTED
+
+        ["#{paint("error", :red)} #{event.reason}#{note(event.error_message)}", :error]
       end
 
       def retry_line(event)
@@ -211,6 +209,10 @@ module Mistri
       def compacting_line(_event) = "compacting"
 
       def compaction_line(event) = "compacted #{body_of(event.content)}"
+
+      def compaction_failed_line(event)
+        ["#{paint("compaction failed", :yellow)}#{note(event.error_message)}", :warn]
+      end
 
       def report_line(event)
         "worker #{field(event.agent)} (#{field(event.session_id.to_s[0, 8], limit: 16)}) " \

--- a/test/test_agent_compaction.rb
+++ b/test/test_agent_compaction.rb
@@ -177,7 +177,8 @@ class TestAgentCompaction < Minitest::Test
       Mistri::Compactor.call(session:, provider:,
                              settings: Mistri::Compaction.new(keep_recent: 10))
     end
-    assert_equal before, session.entries
+    assert_equal before, session.entries.take(before.length)
+    assert_equal "compaction_failed", session.entries.last["type"]
     assert_nil session.last_compaction
   end
 

--- a/test/test_agent_compaction.rb
+++ b/test/test_agent_compaction.rb
@@ -164,6 +164,37 @@ class TestAgentCompaction < Minitest::Test
     assert_equal output, Mistri::Message.from_h(stored["message"]).text
   end
 
+  # Counts store reads so a test can price what a turn costs in history loads.
+  class CountingStore < Mistri::Stores::Memory
+    attr_reader :loads
+
+    def initialize
+      super
+      @loads = 0
+    end
+
+    def load(id)
+      @loads += 1
+      super
+    end
+  end
+
+  def test_an_ordinary_turn_reads_history_once_for_the_compaction_check
+    loads = [false, Mistri::Compaction.new].map do |compaction|
+      store = CountingStore.new
+      session = Mistri::Session.new(store:)
+      session.append_message(Mistri::Message.user("small context"))
+      session.append_message(Mistri::Message.assistant(content: "noted", stop_reason: :stop))
+      provider = Mistri::Providers::Fake.new(turns: [{ text: "done" }])
+
+      Mistri::Agent.new(provider:, session:, compaction:).run("Continue.")
+
+      store.loads
+    end
+
+    assert_equal loads.first + 1, loads.last
+  end
+
   def test_a_failed_summary_does_not_move_the_replay_boundary
     session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
     session.append_message(Mistri::Message.user("old context " * 80))

--- a/test/test_compaction_failure.rb
+++ b/test/test_compaction_failure.rb
@@ -110,32 +110,6 @@ class TestCompactionFailure < Minitest::Test
     end
   end
 
-  def test_the_summary_request_uses_its_own_output_limit_and_default_thinking
-    provider = Mistri::Providers::Fake.new(turns: [{ text: "Summary." }])
-
-    Mistri::Compactor.call(session: history, provider:, settings: SETTINGS)
-
-    options = provider.requests.first[:options]
-
-    assert_equal Mistri::Compaction::DEFAULT_MAX_TOKENS, options[:max_tokens]
-    assert options.key?(:thinking)
-    assert_nil options[:thinking]
-    assert_equal Mistri::Compactor::SUMMARIZER_SYSTEM, options[:system]
-  end
-
-  def test_the_summary_output_limit_is_host_policy_capped_at_the_model_ceiling
-    provider = Mistri::Providers::Fake.new(turns: [{ text: "Summary." }, { text: "Summary." }])
-    provider.define_singleton_method(:model) { "claude-haiku-4-5" }
-    ceiling = Mistri::Models.max_output("claude-haiku-4-5")
-
-    Mistri::Compactor.call(session: history, provider:, settings: settings(max_tokens: 2_000))
-    Mistri::Compactor.call(session: history, provider:, settings: settings(max_tokens: ceiling * 2))
-
-    limits = provider.requests.map { |request| request[:options][:max_tokens] }
-
-    assert_equal [2_000, ceiling], limits
-  end
-
   def test_automatic_compaction_stops_after_repeated_failures_until_one_succeeds
     Dir.mktmpdir do |directory|
       store = Mistri::Stores::JSONL.new(directory)
@@ -152,7 +126,8 @@ class TestCompactionFailure < Minitest::Test
       end
 
       assert_equal attempts, compacting
-      assert_equal attempts, session.compaction_failures
+      assert_equal attempts, session.compaction_failures(trigger: :automatic)
+      assert_equal 0, session.compaction_failures(trigger: :manual)
       assert_equal (attempts * 2) + 1, provider.requests.length
       assert_equal Mistri::Message.user("Continue."), provider.requests.last[:messages].last
 
@@ -167,6 +142,30 @@ class TestCompactionFailure < Minitest::Test
       assert_equal 0, session.compaction_failures
       assert_equal "Checkpoint again.", session.last_compaction.fetch("summary")
     end
+  end
+
+  def test_manual_failures_are_recorded_but_do_not_spend_the_automatic_quota
+    session = history
+    attempts = Mistri::Compaction::AUTOMATIC_ATTEMPTS
+    manual = Mistri::Providers::Fake.new(turns: Array.new(attempts) { incomplete_turn })
+
+    attempts.times do
+      assert_raises(Mistri::CompactionError) do
+        Mistri::Agent.new(provider: manual, session:, compaction: settings(max_tokens: 1)).compact
+      end
+    end
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "Checkpoint." }, { text: "done" }])
+
+    Mistri::Agent.new(provider:, session:, compaction: SETTINGS).run("Continue.")
+
+    triggers = session.entries.filter_map do |entry|
+      entry["trigger"] if entry["type"] == "compaction_failed"
+    end
+
+    assert_equal %w[manual manual manual], triggers
+    assert_equal 0, session.compaction_failures(trigger: :automatic)
+    assert_equal "Checkpoint.", session.last_compaction.fetch("summary")
+    assert_equal 2, provider.requests.length
   end
 
   def test_incomplete_summary_cost_can_stop_before_another_provider_call
@@ -255,8 +254,8 @@ class TestCompactionFailure < Minitest::Test
     refute_includes error.message, "private unfinished summary"
     assert_same reply.usage, error.usage
     assert_equal before, session.entries.take(before.length)
-    assert_equal({ "type" => "compaction_failed", "reason" => diagnostic },
-                 session.entries.last.slice("type", "reason"))
+    assert_equal({ "type" => "compaction_failed", "reason" => diagnostic, "trigger" => "manual" },
+                 session.entries.last.slice("type", "reason", "trigger"))
     assert_equal 1, session.compaction_failures
     assert_equal replay, session.messages
     assert_nil session.last_compaction

--- a/test/test_compaction_failure.rb
+++ b/test/test_compaction_failure.rb
@@ -72,10 +72,11 @@ class TestCompactionFailure < Minitest::Test
       reloaded = Mistri::Session.new(store: Mistri::Stores::JSONL.new(directory), id: session.id)
 
       assert_same SUMMARY_USAGE, error.usage
-      assert_equal before_file, File.binread(path)
+      assert File.binread(path).start_with?(before_file)
+      assert_equal 1, reloaded.compaction_failures
       assert_equal before_replay, reloaded.messages
       assert_equal session.last_compaction, reloaded.last_compaction
-      assert_equal [:compacting], events
+      assert_equal %i[compacting compaction_failed], events
       assert_equal 1, provider.requests.length
     end
   end
@@ -104,7 +105,67 @@ class TestCompactionFailure < Minitest::Test
         entry["type"] == "compaction"
       end)
       assert_equal 1, events.count(:compacting)
+      assert_equal 1, events.count(:compaction_failed)
       refute_includes events, :compaction
+    end
+  end
+
+  def test_the_summary_request_uses_its_own_output_limit_and_default_thinking
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "Summary." }])
+
+    Mistri::Compactor.call(session: history, provider:, settings: SETTINGS)
+
+    options = provider.requests.first[:options]
+
+    assert_equal Mistri::Compaction::DEFAULT_MAX_TOKENS, options[:max_tokens]
+    assert options.key?(:thinking)
+    assert_nil options[:thinking]
+    assert_equal Mistri::Compactor::SUMMARIZER_SYSTEM, options[:system]
+  end
+
+  def test_the_summary_output_limit_is_host_policy_capped_at_the_model_ceiling
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "Summary." }, { text: "Summary." }])
+    provider.define_singleton_method(:model) { "claude-haiku-4-5" }
+    ceiling = Mistri::Models.max_output("claude-haiku-4-5")
+
+    Mistri::Compactor.call(session: history, provider:, settings: settings(max_tokens: 2_000))
+    Mistri::Compactor.call(session: history, provider:, settings: settings(max_tokens: ceiling * 2))
+
+    limits = provider.requests.map { |request| request[:options][:max_tokens] }
+
+    assert_equal [2_000, ceiling], limits
+  end
+
+  def test_automatic_compaction_stops_after_repeated_failures_until_one_succeeds
+    Dir.mktmpdir do |directory|
+      store = Mistri::Stores::JSONL.new(directory)
+      session = history(store:)
+      attempts = Mistri::Compaction::AUTOMATIC_ATTEMPTS
+      turns = Array.new(attempts) { [incomplete_turn, { text: "done" }] }.flatten
+      provider = Mistri::Providers::Fake.new(turns: turns + [{ text: "done" }])
+      compacting = 0
+
+      (attempts + 1).times do
+        reloaded = Mistri::Session.new(store:, id: session.id)
+        agent = Mistri::Agent.new(provider:, session: reloaded, compaction: SETTINGS)
+        agent.run("Continue.") { |event| compacting += 1 if event.type == :compacting }
+      end
+
+      assert_equal attempts, compacting
+      assert_equal attempts, session.compaction_failures
+      assert_equal (attempts * 2) + 1, provider.requests.length
+      assert_equal Mistri::Message.user("Continue."), provider.requests.last[:messages].last
+
+      checkpoint = Mistri::Providers::Fake.new(turns: [{ text: "Checkpoint." }])
+      Mistri::Compactor.call(session:, provider: checkpoint, settings: SETTINGS)
+      session.append_message(Mistri::Message.user("New export rules. " * 80))
+      resumed = Mistri::Providers::Fake.new(turns: [{ text: "Checkpoint again." },
+                                                    { text: "done" }])
+
+      Mistri::Agent.new(provider: resumed, session:, compaction: SETTINGS).run("Continue.")
+
+      assert_equal 0, session.compaction_failures
+      assert_equal "Checkpoint again.", session.last_compaction.fetch("summary")
     end
   end
 
@@ -174,6 +235,10 @@ class TestCompactionFailure < Minitest::Test
     { text: "private unfinished summary", stop_reason: :length, usage: SUMMARY_USAGE }
   end
 
+  def settings(**overrides)
+    Mistri::Compaction.new(window: 600, reserve: 550, keep_recent: 10, **overrides)
+  end
+
   def assert_rejected(reply, diagnostic)
     session = history
     before = session.entries
@@ -183,15 +248,19 @@ class TestCompactionFailure < Minitest::Test
     provider.define_singleton_method(:stream) { |**| reply }
 
     error = assert_raises(Mistri::CompactionError) do
-      Mistri::Compactor.call(session:, provider:, settings: SETTINGS) { |event| events << event.type }
+      Mistri::Compactor.call(session:, provider:, settings: SETTINGS) { |event| events << event }
     end
 
     assert_equal "summarization failed: #{diagnostic}", error.message
     refute_includes error.message, "private unfinished summary"
     assert_same reply.usage, error.usage
-    assert_equal before, session.entries
+    assert_equal before, session.entries.take(before.length)
+    assert_equal({ "type" => "compaction_failed", "reason" => diagnostic },
+                 session.entries.last.slice("type", "reason"))
+    assert_equal 1, session.compaction_failures
     assert_equal replay, session.messages
     assert_nil session.last_compaction
-    assert_equal [:compacting], events
+    assert_equal %i[compacting compaction_failed], events.map(&:type)
+    assert_equal diagnostic, events.last.error_message
   end
 end

--- a/test/test_compaction_live.rb
+++ b/test/test_compaction_live.rb
@@ -21,7 +21,7 @@ class TestCompactionLive < Minitest::Test
 
     options = { api_key: ENV.fetch("ANTHROPIC_API_KEY"), model: "claude-haiku-4-5-20251001",
                 thinking: { type: "disabled" }, service_tier: "standard_only", read_timeout: 120 }
-    @summarizer = ObservedAnthropic.new(**options, max_tokens: 48)
+    @summarizer = ObservedAnthropic.new(**options)
     @provider = Mistri::Providers::Anthropic.new(**options)
   end
 
@@ -39,7 +39,7 @@ class TestCompactionLive < Minitest::Test
       replay = session.replay
       events = []
       agent = Mistri::Agent.new(provider: @summarizer, session:,
-                                compaction: Mistri::Compaction.new(keep_recent: 20))
+                                compaction: Mistri::Compaction.new(keep_recent: 20, max_tokens: 48))
 
       error = assert_raises(Mistri::CompactionError) do
         agent.compact { |event| events << event.type }
@@ -51,11 +51,12 @@ class TestCompactionLive < Minitest::Test
       assert_operator error.usage.output, :>, 0
       assert_predicate error.usage.cost, :known?
       assert_operator error.usage.cost.total, :>, 0
-      assert_equal [:compacting], events
+      assert_equal %i[compacting compaction_failed], events
 
       reloaded = Mistri::Session.new(store: Mistri::Stores::JSONL.new(dir), id: session.id)
 
-      assert_equal durable, File.binread(path)
+      assert_failure_appended(path, durable)
+      assert_equal 1, reloaded.compaction_failures
       assert_equal replay, reloaded.replay
       assert_nil reloaded.last_compaction
       assert_original_filename(reloaded, filename)
@@ -63,6 +64,13 @@ class TestCompactionLive < Minitest::Test
   end
 
   private
+
+  def assert_failure_appended(path, durable)
+    after = File.binread(path)
+
+    assert after.start_with?(durable)
+    assert_equal "compaction_failed", JSON.parse(after.delete_prefix(durable)).fetch("type")
+  end
 
   def export_session(dir, filename)
     session = Mistri::Session.new(store: Mistri::Stores::JSONL.new(dir))

--- a/test/test_compaction_request.rb
+++ b/test/test_compaction_request.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# The summary is the compactor's own request: its output limit and thinking come
+# from compaction settings and the API, never from the host's chat configuration.
+class TestCompactionRequest < Minitest::Test
+  HISTORY = [Mistri::Message.user("hello")].freeze
+
+  def test_the_summary_request_uses_its_own_output_limit_and_default_thinking
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "Summary." }])
+
+    Mistri::Compactor.call(session: history, provider:, settings: settings)
+
+    options = provider.requests.first[:options]
+
+    assert_equal Mistri::Compaction::DEFAULT_MAX_TOKENS, options[:max_tokens]
+    assert_equal [nil, nil], options.values_at(:thinking, :reasoning)
+    assert options.key?(:thinking)
+    assert options.key?(:reasoning)
+    assert_equal Mistri::Compactor::SUMMARIZER_SYSTEM, options[:system]
+  end
+
+  def test_the_summary_output_limit_is_host_policy_capped_at_the_model_ceiling
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "Summary." }, { text: "Summary." }])
+    provider.define_singleton_method(:model) { "claude-haiku-4-5" }
+    ceiling = Mistri::Models.max_output("claude-haiku-4-5")
+
+    Mistri::Compactor.call(session: history, provider:, settings: settings(max_tokens: 2_000))
+    Mistri::Compactor.call(session: history, provider:, settings: settings(max_tokens: ceiling * 2))
+
+    limits = provider.requests.map { |request| request[:options][:max_tokens] }
+
+    assert_equal [2_000, ceiling], limits
+  end
+
+  def test_every_built_in_provider_sends_the_summary_limit_in_its_own_field
+    overrides = { max_tokens: 400, thinking: nil, reasoning: nil }
+    openai = Mistri::Providers::OpenAI.new(api_key: "k", reasoning: { effort: "high" })
+    gemini = Mistri::Providers::Gemini.new(api_key: "k")
+    anthropic = Mistri::Providers::Anthropic.new(api_key: "k", model: "claude-opus-4-8",
+                                                 max_tokens: 1_024)
+
+    openai_body = openai.send(:build_body, "gpt-5.6", HISTORY, nil, [], overrides)
+    gemini_body = gemini.send(:build_body, HISTORY, nil, [], overrides)
+    anthropic_body = anthropic.send(:build_body, "claude-opus-4-8", HISTORY, nil, [], overrides)
+
+    assert_equal 400, openai_body[:max_output_tokens]
+    refute openai_body.key?(:reasoning), "the host's reasoning effort must not reach the summary"
+    assert_equal 400, gemini_body.dig(:generationConfig, :maxOutputTokens)
+    refute gemini_body.dig(:generationConfig, :thinkingConfig)
+    assert_equal 400, anthropic_body[:max_tokens]
+    refute anthropic_body.key?(:thinking)
+  ensure
+    [openai, gemini, anthropic].compact.each(&:close)
+  end
+
+  def test_ordinary_requests_keep_the_hosts_settings_and_no_cap
+    openai = Mistri::Providers::OpenAI.new(api_key: "k", reasoning: { effort: "high" })
+    gemini = Mistri::Providers::Gemini.new(api_key: "k")
+    anthropic = Mistri::Providers::Anthropic.new(api_key: "k", model: "claude-opus-4-8",
+                                                 max_tokens: 1_024)
+
+    openai_body = openai.send(:build_body, "gpt-5.6", HISTORY, nil, [], {})
+    gemini_body = gemini.send(:build_body, HISTORY, nil, [], {})
+    anthropic_body = anthropic.send(:build_body, "claude-opus-4-8", HISTORY, nil, [], {})
+
+    refute openai_body.key?(:max_output_tokens)
+    assert_equal({ effort: "high" }, openai_body[:reasoning])
+    refute gemini_body.dig(:generationConfig, :maxOutputTokens)
+    assert_equal({ includeThoughts: true }, gemini_body.dig(:generationConfig, :thinkingConfig))
+    assert_equal 1_024, anthropic_body[:max_tokens]
+    assert_equal({ type: "adaptive", display: "summarized" }, anthropic_body[:thinking])
+  ensure
+    [openai, gemini, anthropic].compact.each(&:close)
+  end
+
+  def test_the_summary_limit_must_be_a_positive_integer
+    [nil, 0, -1, 1.5, "400", false].each do |value|
+      error = assert_raises(ArgumentError) { Mistri::Compaction.new(max_tokens: value) }
+
+      assert_equal "max_tokens must be a positive Integer", error.message
+    end
+    assert_equal 400, Mistri::Compaction.new(max_tokens: 400).max_tokens
+  end
+
+  private
+
+  def settings(**overrides)
+    Mistri::Compaction.new(window: 600, reserve: 550, keep_recent: 10, **overrides)
+  end
+
+  def history
+    session = Mistri::Session.new(store: Mistri::Stores::Memory.new)
+    session.append_message(Mistri::Message.user("Original export rules. " * 80))
+    session.append_message(Mistri::Message.assistant(content: "Source inspected. " * 80,
+                                                     stop_reason: :stop))
+    session.append_message(Mistri::Message.user("Retain this follow-up. " * 80))
+    session
+  end
+end

--- a/test/test_fable_compaction_live.rb
+++ b/test/test_fable_compaction_live.rb
@@ -11,15 +11,24 @@ class TestFableCompactionLive < Minitest::Test
 
   # Older accounts do not enforce binding by default; explicitly opt in so
   # this regression exercises the same rejection as newly created accounts.
+  # The compactor's summary request carries no thinking of its own, so the
+  # control attaches only where thinking rides; every body is kept so the
+  # test can check which requests bound and which did not.
   class BindingCheckedTransport
+    BINDING = { block_binding: { prefix_mismatch_behavior: "error" } }.freeze
+
+    attr_reader :bodies
+
     def initialize(transport)
       @transport = transport
+      @bodies = []
     end
 
     def stream_post(path, body:, headers:, **, &emit)
       headers = headers.merge("anthropic-beta" => "thinking-binding-controls-2026-08-01")
-      thinking = body.fetch(:thinking).merge(block_binding: { prefix_mismatch_behavior: "error" })
-      @transport.stream_post(path, body: body.merge(thinking:), headers:, **, &emit)
+      body = body.merge(thinking: body[:thinking].merge(BINDING)) if body[:thinking]
+      @bodies << body
+      @transport.stream_post(path, body:, headers:, **, &emit)
     end
 
     def close = @transport.close
@@ -32,8 +41,8 @@ class TestFableCompactionLive < Minitest::Test
     @provider = Mistri::Providers::Anthropic.new(
       api_key: ENV.fetch("ANTHROPIC_API_KEY"), model: "claude-fable-5-1", read_timeout: 120
     )
-    transport = BindingCheckedTransport.new(@provider.instance_variable_get(:@transport))
-    @provider.instance_variable_set(:@transport, transport)
+    @transport = BindingCheckedTransport.new(@provider.instance_variable_get(:@transport))
+    @provider.instance_variable_set(:@transport, @transport)
     @tools = [{ name: "lookup_checkpoint", description: "Returns the checkpoint value.",
                 input_schema: { type: "object", properties: { prime: { type: "integer" } },
                                 required: ["prime"] } }]
@@ -63,6 +72,7 @@ class TestFableCompactionLive < Minitest::Test
 
     refute_nil compaction, "the fixture must cross a real compaction boundary"
     assert_operator session.last_compaction.fetch("kept_from"), :>, 0
+    assert_summary_request_unbound(@transport.bodies)
     retained = session.messages.find { |message| message.tool_calls.include?(call) }
 
     refute_nil retained, "the signed tool-call turn must remain in the compacted tail"
@@ -82,6 +92,17 @@ class TestFableCompactionLive < Minitest::Test
   end
 
   private
+
+  # The summary request is the compactor's own: no thinking, so no binding
+  # control, while every signed-thinking turn before it stayed strictly bound.
+  def assert_summary_request_unbound(bodies)
+    summary_request = bodies.last
+
+    refute summary_request.key?(:thinking), "the summary request must not bind or think"
+    assert_equal Mistri::Compaction::DEFAULT_MAX_TOKENS, summary_request[:max_tokens]
+    assert(bodies[0...-1].all? { |body| body.dig(:thinking, :block_binding) },
+           "every signed-thinking turn must keep strict prefix binding")
+  end
 
   def checkpoint_session
     session = Mistri::Session.new(store: Mistri::Stores::Memory.new)

--- a/test/test_logger_sink.rb
+++ b/test/test_logger_sink.rb
@@ -89,6 +89,8 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
                                 tool_call: tool_call("send_gift", { "to" => "sarah" })))
     sink.call(Mistri::Event.new(type: :compacting))
     sink.call(Mistri::Event.new(type: :compaction, content: "The story so far"))
+    sink.call(Mistri::Event.new(type: :compaction_failed,
+                                error_message: "unexpected stop reason: :length"))
     sink.call(Mistri::Event.new(type: :subagent_report, agent: "Corgi",
                                 session_id: "ef56ab12-0000-4444-aaaa-000000000000",
                                 status: "done", content: "found it"))
@@ -97,6 +99,7 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
     assert_match(/INFO \[mistri\] approval needed send_gift#c1 \{"to":"sarah"\}/, io.string)
     assert_match(/INFO \[mistri\] compacting/, io.string)
     assert_match(/INFO \[mistri\] compacted "The story so far"/, io.string)
+    assert_match(/WARN \[mistri\] compaction failed: unexpected stop reason: :length/, io.string)
     assert_match(/INFO \[mistri\] worker Corgi \(ef56ab12\) done "found it"/, io.string)
   end
 
@@ -482,11 +485,14 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
                                 error_message: "token sk-secret rejected"))
     sink.call(Mistri::Event.new(type: :retry, content: "key sk-secret throttled",
                                 attempt: 1, max_attempts: 3, delay: 2.0))
+    sink.call(Mistri::Event.new(type: :compaction_failed,
+                                error_message: "summarizer rejected sk-secret"))
 
     refute_match(/hunter2|sk-secret/, io.string)
     assert_match(/crashed RuntimeError \(16B\)/, io.string)
     assert_match(/error error \(24B\)/, io.string)
     assert_match(%r{retry 1/3 in 2.0s \(23B\)}, io.string)
+    assert_match(/WARN \[mistri\] compaction failed \(29B\)/, io.string)
   end
 
   def test_argument_previews_bound_hash_keys_too


### PR DESCRIPTION
The compactor's summary request inherited whatever a host configured for its chat replies. A short Anthropic `max_tokens` truncated every summary, a large thinking budget could outsize the limit, and a rejected attempt was retried on the next eligible turn at full-context cost with nothing telling the host.

The summary is now the compactor's own request: `Compaction.new(max_tokens:)` bounds its output on every built-in provider (16,384 by default, clamped to the model's published output limit, sent as Anthropic `max_tokens`, OpenAI `max_output_tokens`, and Gemini `maxOutputTokens`) and it runs with the API's default thinking and reasoning. A rejected summary appends a `compaction_failed` entry with the reason and its trigger, emits `:compaction_failed` with the reason, and logs a warning through the built-in logger. Automatic compaction stops after three failed automatic attempts in a row until a compaction succeeds; manual attempts are recorded but do not count. Manual `compact` still raises `CompactionError`; replay and the previous checkpoint are untouched. The failure count is read only once the threshold says compaction is due, so an ordinary turn costs one history read.

No new provider calls: one stream override on the existing request and one session append on failure.

Verified with the full suite on Ruby 3.2 and 3.3, RuboCop, the live Haiku truncation regression and the live Fable prefix-binding regression on the new path, and live checks that hosts with a 256 or 1,024 token chat limit (Haiku, Fable 5.1, Sonnet 5) or a 20k thinking budget now get complete summaries, while a summary limit of 400 stops Haiku, Astra, and Gemini Flash with `:length` and is recorded.
