### PR TITLE
Let a host-chosen fallback write the summary when the primary cannot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- `Compaction.new(fallback:)` names a second summarizer, a provider or a
+  model id, that gets one try when the session's provider cannot write a
+  usable summary, a refusal included. The compaction entry records which
+  model wrote the summary, the `:compaction` event carries that reply in
+  `message`, and a failure reason now names the model.
 - The summary request has its own output limit, `Compaction.new(max_tokens:)`
   (16,384 by default, capped at the model's published output limit, sent as
   Anthropic `max_tokens`, OpenAI `max_output_tokens`, and Gemini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `Compaction.new(fallback:)` names a second summarizer, a provider or a
   model id, that gets one try when the session's provider cannot write a
-  usable summary, a refusal included. The compaction entry records which
-  model wrote the summary, the `:compaction` event carries that reply in
-  `message`, and a failure reason now names the model.
+  usable summary, a refusal included; a fallback naming the primary's own
+  model is skipped. The compaction entry records which model wrote the
+  summary, the `:compaction` event carries that reply in `message`, and a
+  failure reason now names the model. An attempt without usage counts as
+  unknown cost; a cost-budgeted agent validates the fallback's pricing at
+  construction and never dispatches it after an unpriced attempt.
 - The summary request has its own output limit, `Compaction.new(max_tokens:)`
   (16,384 by default, capped at the model's published output limit, sent as
   Anthropic `max_tokens`, OpenAI `max_output_tokens`, and Gemini

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -148,8 +148,8 @@ Loop-level events are:
 - `:tool_result` after settlement, with a required `tool_error` boolean;
 - `:approval_needed` when a prepared call parks;
 - `:compacting` before summary work, then `:compaction` with the committed
-  summary in `content` or `:compaction_failed` with the reason in
-  `error_message`;
+  summary in `content` and the summarizing reply in `message`, or
+  `:compaction_failed` with the reason in `error_message`;
 - `:retry` before provider backoff;
 - `:subagent_report` when a running background child reaches a terminal state;
   an inactive `Child#stop` persists the report without this callback because it

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -218,6 +218,7 @@ settings = Mistri::Compaction.new(
   reserve: 64_000,
   keep_recent: 24_000,
   max_tokens: 8_192,
+  fallback: "claude-sonnet-5",
   instructions: "Preserve decisions, identifiers, and unresolved risks.",
 )
 
@@ -237,6 +238,16 @@ thinking or reasoning toward the limit). The request runs with the API's
 default thinking and reasoning, so a short limit, a thinking budget, or a
 reasoning effort a host set for its own replies never shapes the summary.
 Ordinary turns keep the host's settings.
+
+`fallback:` names a second summarizer, a provider or a model id, that gets one
+try when the session's provider cannot write a usable summary for any reason,
+a refusal included; the model that failed is never asked again. The host
+chooses it, so a refusal never changes models silently. Natural pairs are a
+smaller model of the same family: Sonnet 5 behind Fable 5.1 or Opus 5, Sol
+behind Astra, Flash behind Gemini Pro. The compaction entry records which
+model wrote the summary, and the `:compaction` event carries that reply in
+`event.message`. When both fail, the one `compaction_failed` entry names each
+model with its reason, and the usage of both attempts is counted.
 
 ```ruby
 agent.context_usage

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -241,13 +241,20 @@ Ordinary turns keep the host's settings.
 
 `fallback:` names a second summarizer, a provider or a model id, that gets one
 try when the session's provider cannot write a usable summary for any reason,
-a refusal included; the model that failed is never asked again. The host
-chooses it, so a refusal never changes models silently. Natural pairs are a
-smaller model of the same family: Sonnet 5 behind Fable 5.1 or Opus 5, Sol
-behind Astra, Flash behind Gemini Pro. The compaction entry records which
-model wrote the summary, and the `:compaction` event carries that reply in
-`event.message`. When both fail, the one `compaction_failed` entry names each
-model with its reason, and the usage of both attempts is counted.
+a refusal included. The model that failed is never asked again: a fallback
+naming the primary's own model is skipped, so a second deployment of the same
+model is not a fallback. The host chooses it, so a refusal never changes
+models silently. Natural pairs are a smaller model of the same family: Sonnet
+5 behind Fable 5.1 or Opus 5, Sol behind Astra, Flash behind Gemini Pro. The
+compaction entry records which model wrote the summary, and the `:compaction`
+event carries that reply in `event.message` (so a serialized event repeats the
+summary once). When both fail, the one `compaction_failed` entry names each
+model with its reason, and the usage of both attempts is counted. An attempt
+that reports no usage counts as unknown cost. Under a cost budget an unpriced
+attempt ends compaction before the fallback can spend, and the agent validates
+the fallback's pricing at construction, so give a cost-budgeted agent an
+explicitly configured provider with a deterministic service tier rather than
+a model id.
 
 ```ruby
 agent.context_usage

--- a/lib/mistri/agent.rb
+++ b/lib/mistri/agent.rb
@@ -60,6 +60,7 @@ module Mistri
       @max_concurrency = max_concurrency
       @transform_context = Array(transform_context)
       @compaction = compaction || nil
+      @budget.validate_provider!(@compaction.fallback) if @compaction&.fallback
       @retries = retries || nil
       @before_tool = before_tool
       @after_tool = after_tool
@@ -159,7 +160,7 @@ module Mistri
     # the Compactor result, or nil when there is nothing worth compacting.
     def compact(&)
       Compactor.call(session: @session, provider: @provider,
-                     settings: @compaction || Compaction.new, &)
+                     settings: @compaction || Compaction.new, budget: @budget, &)
     end
 
     private
@@ -293,7 +294,7 @@ module Mistri
     def compact_automatically(&emit)
       delivery = EventDelivery.wrap(emit)
       Compactor.call(session: @session, provider: @provider, settings: @compaction,
-                     trigger: :automatic, &delivery)
+                     trigger: :automatic, budget: @budget, &delivery)
     rescue EventDelivery::Failure => e
       raise EventDelivery.unwrap(e, delivery)
     rescue CompactionError => e

--- a/lib/mistri/compaction.rb
+++ b/lib/mistri/compaction.rb
@@ -24,16 +24,19 @@ module Mistri
 
     SUMMARY_PREFACE = "The earlier conversation was compacted. This summary replaces it:"
 
-    attr_reader :reserve, :keep_recent, :window, :instructions, :max_tokens
+    attr_reader :reserve, :keep_recent, :window, :instructions, :max_tokens, :fallback
 
     # window overrides the model catalog's context window (required for
     # models the catalog does not know). A nil reserve selects automatic
     # headroom; a number is explicit host policy. instructions add a
     # host-specific focus to the summary prompt. max_tokens bounds the
     # summary request's output: the summary is the compactor's own request
-    # and never inherits the limit a host set for its chat replies.
-    def initialize(reserve: nil, keep_recent: DEFAULT_KEEP_RECENT,
-                   window: nil, instructions: nil, max_tokens: DEFAULT_MAX_TOKENS)
+    # and never inherits the limit a host set for its chat replies. fallback
+    # names a second summarizer, a provider or a model id, that gets one try
+    # when the session's provider cannot write a usable summary; the host
+    # chooses it, so a refusal never changes models silently.
+    def initialize(reserve: nil, keep_recent: DEFAULT_KEEP_RECENT, window: nil,
+                   instructions: nil, max_tokens: DEFAULT_MAX_TOKENS, fallback: nil)
       unless max_tokens.is_a?(Integer) && max_tokens.positive?
         raise ArgumentError, "max_tokens must be a positive Integer"
       end
@@ -44,6 +47,7 @@ module Mistri
       @window = window
       @instructions = instructions
       @max_tokens = max_tokens
+      @fallback = summarizer(fallback)
     end
 
     def automatic_reserve? = @automatic_reserve
@@ -56,6 +60,16 @@ module Mistri
     end
 
     private
+
+    # A model id resolves at construction, so a missing key fails where the
+    # setting is written rather than in the middle of a run.
+    def summarizer(fallback)
+      return fallback if fallback.nil?
+      return fallback if fallback.respond_to?(:stream) && fallback.respond_to?(:model)
+      return Mistri.provider(fallback) if fallback.is_a?(String)
+
+      raise ArgumentError, "fallback must be a provider or a model id"
+    end
 
     def effective_reserve(max_output)
       return reserve unless automatic_reserve?

--- a/lib/mistri/compactor.rb
+++ b/lib/mistri/compactor.rb
@@ -85,13 +85,13 @@ module Mistri
 
         emit&.call(Event.new(type: :compacting))
         tokens_before = session.context_tokens
-        reply = summarize(provider, head, previous, settings)
-        failure = summary_failure(reply)
-        reject(session, failure, trigger, tokens_before, reply.usage, &emit) if failure
+        prompt = prompt_for(head, previous, settings)
+        reply, usage, failures = attempt(prompt, [provider, settings.fallback].compact, settings)
+        reject(session, failures.join("; "), trigger, tokens_before, usage, &emit) unless reply
 
-        session.append("compaction", "summary" => reply.text,
+        session.append("compaction", "summary" => reply.text, "model" => reply.model,
                                      "kept_from" => cut, "tokens_before" => tokens_before)
-        finish(session, reply, tokens_before, &emit)
+        finish(session, reply, usage, tokens_before, &emit)
       end
 
       private
@@ -150,11 +150,34 @@ module Mistri
         end
       end
 
-      def summarize(provider, messages, previous, settings)
+      def prompt_for(messages, previous, settings)
         prompt = "<conversation>\n#{serialize(messages)}\n</conversation>\n\n"
         prompt << "<previous-summary>\n#{previous}\n</previous-summary>\n\n" if previous
         prompt << (previous ? UPDATE_PROMPT : CHECKPOINT_PROMPT)
         prompt << "\nAdditional focus: #{settings.instructions}\n" if settings.instructions
+        prompt
+      end
+
+      # The session's provider writes the summary; a configured fallback gets
+      # one try when that reply is unusable for any reason, a refusal
+      # included, and the model that failed is never asked again. Returns the
+      # usable reply or nil, the usage of every attempt, and each failure
+      # named by its model.
+      def attempt(prompt, summarizers, settings)
+        usage = nil
+        failures = []
+        summarizers.each do |summarizer|
+          reply = summarize(summarizer, prompt, settings)
+          usage = [usage, reply.usage].compact.reduce(:+)
+          failure = summary_failure(reply)
+          return [reply, usage, failures] unless failure
+
+          failures << "#{summarizer.model}: #{failure}"
+        end
+        [nil, usage, failures]
+      end
+
+      def summarize(provider, prompt, settings)
         provider.stream(messages: [Message.user(prompt)], system: SUMMARIZER_SYSTEM,
                         **request_overrides(provider, settings))
       end
@@ -190,11 +213,11 @@ module Mistri
         raise CompactionError.new("summarization failed: #{failure}", usage: usage)
       end
 
-      def finish(session, reply, tokens_before, &emit)
+      def finish(session, reply, usage, tokens_before, &emit)
         tokens_after = session.context_tokens
-        emit&.call(Event.new(type: :compaction, content: reply.text))
+        emit&.call(Event.new(type: :compaction, content: reply.text, message: reply))
         { summary: reply.text, tokens_before: tokens_before,
-          tokens_after: tokens_after, usage: reply.usage }
+          tokens_after: tokens_after, usage: usage }
       end
 
       # The summarizer reads a plain-text rendering: tool calls by name and

--- a/lib/mistri/compactor.rb
+++ b/lib/mistri/compactor.rb
@@ -73,7 +73,7 @@ module Mistri
       # Summarize and cut. Returns {summary:, tokens_before:, tokens_after:,
       # usage:}, or nil when there is nothing worth compacting. Emits
       # :compacting and :compaction when a block is given.
-      def call(session:, provider:, settings: Compaction.new, trigger: :manual, &emit)
+      def call(session:, provider:, settings: Compaction.new, trigger: :manual, budget: nil, &emit)
         replay = session.replay
         cut = cut_index(replay, session, settings)
         return nil unless cut
@@ -86,7 +86,7 @@ module Mistri
         emit&.call(Event.new(type: :compacting))
         tokens_before = session.context_tokens
         prompt = prompt_for(head, previous, settings)
-        reply, usage, failures = attempt(prompt, [provider, settings.fallback].compact, settings)
+        reply, usage, failures = attempt(prompt, summarizers(provider, settings), settings, budget)
         reject(session, failures.join("; "), trigger, tokens_before, usage, &emit) unless reply
 
         session.append("compaction", "summary" => reply.text, "model" => reply.model,
@@ -158,21 +158,32 @@ module Mistri
         prompt
       end
 
+      # The fallback is a different model or nothing: the same model behind a
+      # second provider is skipped, so the model that failed is never asked
+      # again within one compaction.
+      def summarizers(provider, settings)
+        [provider, settings.fallback].compact.uniq(&:model)
+      end
+
       # The session's provider writes the summary; a configured fallback gets
       # one try when that reply is unusable for any reason, a refusal
-      # included, and the model that failed is never asked again. Returns the
-      # usable reply or nil, the usage of every attempt, and each failure
-      # named by its model.
-      def attempt(prompt, summarizers, settings)
+      # included. An attempt that reports no usage counts as unknown cost, not
+      # as nothing, and under a cost budget an unpriced attempt ends the loop
+      # before another model can spend. Returns the usable reply or nil, the
+      # usage of every attempt, and each failure named by its model.
+      def attempt(prompt, summarizers, settings, budget)
         usage = nil
         failures = []
         summarizers.each do |summarizer|
           reply = summarize(summarizer, prompt, settings)
-          usage = [usage, reply.usage].compact.reduce(:+)
+          reply = reply.with(model: summarizer.model) unless reply.model
+          measured = reply.usage || Usage.new
+          usage = usage ? usage + measured : measured
           failure = summary_failure(reply)
           return [reply, usage, failures] unless failure
 
           failures << "#{summarizer.model}: #{failure}"
+          break if budget&.cost? && !usage.cost.known?
         end
         [nil, usage, failures]
       end

--- a/lib/mistri/providers/fake.rb
+++ b/lib/mistri/providers/fake.rb
@@ -128,7 +128,7 @@ module Mistri
       end
 
       def assemble(blocks, **meta)
-        Message.assistant(content: blocks, model: MODEL, provider: :fake, **meta)
+        Message.assistant(content: blocks, model: model, provider: :fake, **meta)
       end
 
       def emit_event(emit, type, blocks, **fields)

--- a/lib/mistri/sinks/logger.rb
+++ b/lib/mistri/sinks/logger.rb
@@ -208,7 +208,9 @@ module Mistri
 
       def compacting_line(_event) = "compacting"
 
-      def compaction_line(event) = "compacted #{body_of(event.content)}"
+      def compaction_line(event) = "compacted#{summarizer(event.message)} #{body_of(event.content)}"
+
+      def summarizer(message) = message&.model ? " (#{field(message.model)})" : ""
 
       def compaction_failed_line(event)
         ["#{paint("compaction failed", :yellow)}#{note(event.error_message)}", :warn]

--- a/test/test_compaction_failure.rb
+++ b/test/test_compaction_failure.rb
@@ -250,16 +250,18 @@ class TestCompactionFailure < Minitest::Test
       Mistri::Compactor.call(session:, provider:, settings: SETTINGS) { |event| events << event }
     end
 
-    assert_equal "summarization failed: #{diagnostic}", error.message
+    reason = "fake-1: #{diagnostic}"
+
+    assert_equal "summarization failed: #{reason}", error.message
     refute_includes error.message, "private unfinished summary"
     assert_same reply.usage, error.usage
     assert_equal before, session.entries.take(before.length)
-    assert_equal({ "type" => "compaction_failed", "reason" => diagnostic, "trigger" => "manual" },
+    assert_equal({ "type" => "compaction_failed", "reason" => reason, "trigger" => "manual" },
                  session.entries.last.slice("type", "reason", "trigger"))
     assert_equal 1, session.compaction_failures
     assert_equal replay, session.messages
     assert_nil session.last_compaction
     assert_equal %i[compacting compaction_failed], events.map(&:type)
-    assert_equal diagnostic, events.last.error_message
+    assert_equal reason, events.last.error_message
   end
 end

--- a/test/test_compaction_fallback.rb
+++ b/test/test_compaction_fallback.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require_relative "test_helper"
+
+# A host-chosen fallback gets one try when the session's provider cannot write
+# a usable summary; nothing else changes about what a checkpoint may replace.
+class TestCompactionFallback < Minitest::Test
+  SETTINGS = { window: 600, reserve: 550, keep_recent: 10 }.freeze
+  PRIMARY_USAGE = Mistri::Usage.new(input: 1_000, output: 48).with_cost(input: 1.0, output: 5.0)
+  FALLBACK_USAGE = Mistri::Usage.new(input: 1_100, output: 300).with_cost(input: 1.0, output: 5.0)
+
+  def test_the_fallback_is_not_asked_when_the_primary_summary_is_usable
+    fallback = fake_fallback
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "Checkpoint.", usage: PRIMARY_USAGE }])
+    session = history
+
+    result = Mistri::Compactor.call(session:, provider:, settings: settings(fallback:))
+
+    assert_equal "Checkpoint.", result[:summary]
+    assert_same PRIMARY_USAGE, result[:usage]
+    assert_empty fallback.requests
+    assert_equal "fake-1", session.last_compaction.fetch("model")
+  end
+
+  def test_the_fallback_writes_the_checkpoint_when_the_primary_cannot
+    Dir.mktmpdir do |directory|
+      store = Mistri::Stores::JSONL.new(directory)
+      session = history(store:)
+      provider = Mistri::Providers::Fake.new(turns: [incomplete_turn])
+      fallback = fake_fallback(turns: [{ text: "Fallback checkpoint.", usage: FALLBACK_USAGE }])
+      events = []
+
+      result = Mistri::Compactor.call(session:, provider:, settings: settings(fallback:)) do |event|
+        events << event
+      end
+
+      assert_equal "Fallback checkpoint.", result[:summary]
+      assert_equal PRIMARY_USAGE + FALLBACK_USAGE, result[:usage]
+      assert_equal %i[compacting compaction], events.map(&:type)
+      assert_equal "fallback-1", events.last.message.model
+      assert_equal "fallback-1", session.last_compaction.fetch("model")
+      assert_equal 0, session.compaction_failures
+      assert_equal provider.requests.first[:messages], fallback.requests.first[:messages]
+
+      reloaded = Mistri::Session.new(store:, id: session.id)
+
+      assert_equal session.messages, reloaded.messages
+      assert_includes reloaded.messages.first.text, "Fallback checkpoint."
+    end
+  end
+
+  def test_both_failures_record_one_attempt_naming_each_model
+    session = history
+    provider = Mistri::Providers::Fake.new(turns: [incomplete_turn])
+    fallback = fake_fallback(turns: [{ error: "summarizer unavailable", usage: FALLBACK_USAGE }])
+    events = []
+
+    error = assert_raises(Mistri::CompactionError) do
+      Mistri::Compactor.call(session:, provider:, settings: settings(fallback:)) do |event|
+        events << event
+      end
+    end
+
+    reason = "fake-1: unexpected stop reason: :length; fallback-1: summarizer unavailable"
+
+    assert_equal "summarization failed: #{reason}", error.message
+    assert_equal PRIMARY_USAGE + FALLBACK_USAGE, error.usage
+    assert_equal reason, session.entries.last.fetch("reason")
+    assert_equal reason, events.last.error_message
+    assert_equal 1, session.compaction_failures
+    assert_nil session.last_compaction
+  end
+
+  def test_automatic_compaction_spends_one_attempt_when_both_fail
+    session = history
+    provider = Mistri::Providers::Fake.new(turns: [incomplete_turn, { text: "done" }])
+    fallback = fake_fallback(turns: [incomplete_turn])
+    compaction = Mistri::Compaction.new(**SETTINGS, fallback:)
+
+    result = Mistri::Agent.new(provider:, session:, compaction:).run("Continue.")
+
+    assert_predicate result, :completed?
+    assert_equal PRIMARY_USAGE + PRIMARY_USAGE, result.usage
+    assert_equal 1, session.compaction_failures(trigger: :automatic)
+    assert_equal 2, provider.requests.length
+    assert_equal 1, fallback.requests.length
+  end
+
+  def test_the_setting_takes_a_provider_or_a_model_id_and_rejects_the_rest
+    provider = Mistri::Providers::Fake.new
+
+    assert_same provider, Mistri::Compaction.new(fallback: provider).fallback
+    assert_nil Mistri::Compaction.new.fallback
+    with_env("ANTHROPIC_API_KEY" => "test") do
+      resolved = Mistri::Compaction.new(fallback: "claude-haiku-4-5").fallback
+
+      assert_kind_of Mistri::Providers::Anthropic, resolved
+      assert_equal "claude-haiku-4-5", resolved.model
+    ensure
+      resolved&.close
+    end
+
+    with_env("ANTHROPIC_API_KEY" => nil) do
+      assert_raises(Mistri::ConfigurationError) { Mistri::Compaction.new(fallback: "claude-haiku-4-5") }
+    end
+    [:sonnet, 42, Object.new].each do |value|
+      error = assert_raises(ArgumentError) { Mistri::Compaction.new(fallback: value) }
+
+      assert_equal "fallback must be a provider or a model id", error.message
+    end
+  end
+
+  private
+
+  def settings(**overrides)
+    Mistri::Compaction.new(**SETTINGS, **overrides)
+  end
+
+  def history(store: Mistri::Stores::Memory.new)
+    session = Mistri::Session.new(store:)
+    session.append_message(Mistri::Message.user("Original export rules. " * 80))
+    session.append_message(Mistri::Message.assistant(content: "Source inspected. " * 80,
+                                                     stop_reason: :stop))
+    session.append_message(Mistri::Message.user("Retain this follow-up. " * 80))
+    session
+  end
+
+  def incomplete_turn
+    { text: "private unfinished summary", stop_reason: :length, usage: PRIMARY_USAGE }
+  end
+
+  def fake_fallback(turns: [])
+    fallback = Mistri::Providers::Fake.new(turns:)
+    fallback.define_singleton_method(:model) { "fallback-1" }
+    fallback
+  end
+
+  def with_env(values)
+    previous = values.keys.to_h { |key| [key, ENV.fetch(key, nil)] }
+    values.each { |key, value| ENV[key] = value }
+    yield
+  ensure
+    previous.each { |key, value| ENV[key] = value }
+  end
+end

--- a/test/test_compaction_fallback.rb
+++ b/test/test_compaction_fallback.rb
@@ -87,6 +87,84 @@ class TestCompactionFallback < Minitest::Test
     assert_equal 1, fallback.requests.length
   end
 
+  def test_an_attempt_without_usage_makes_the_combined_cost_unknown
+    [[nil, FALLBACK_USAGE], [PRIMARY_USAGE, nil]].each do |primary_usage, fallback_usage|
+      session = history
+      provider = scripted(model: "fake-1", replies: [incomplete_reply(usage: primary_usage)])
+      fallback = scripted(model: "fallback-1", replies: [checkpoint_reply(usage: fallback_usage)])
+
+      result = Mistri::Compactor.call(session:, provider:, settings: settings(fallback:))
+
+      assert_equal "Checkpoint.", result[:summary]
+      refute_predicate result[:usage].cost, :known?
+      assert_equal (primary_usage || fallback_usage).input, result[:usage].input
+    end
+  end
+
+  def test_a_cost_budget_stops_before_the_fallback_when_the_primary_is_unpriced
+    session = history
+    unpriced = incomplete_reply(usage: Mistri::Usage.new(input: 900))
+    provider = scripted(model: "fake-1", replies: [unpriced])
+    fallback = fake_fallback(turns: [{ text: "Checkpoint.", usage: FALLBACK_USAGE }])
+    compaction = Mistri::Compaction.new(**SETTINGS, fallback:)
+    budget = Mistri::Budget.new(cost_usd: 10.0)
+
+    error = assert_raises(Mistri::BudgetError) do
+      Mistri::Agent.new(provider:, session:, compaction:, budget:).run("Continue.")
+    end
+    unpriced_attempts = session.entries.count { |entry| entry["type"] == "unpriced_attempt" }
+
+    assert_includes error.message, "unpriced usage"
+    assert_empty fallback.requests
+    assert_equal 1, unpriced_attempts
+    assert_equal 1, session.compaction_failures(trigger: :automatic)
+    assert_equal "budget_cost_unknown", session.messages.last.error_message
+  end
+
+  def test_a_cost_budget_rejects_an_unpriced_fallback_at_construction
+    provider = Mistri::Providers::Fake.new(turns: [{ text: "done", usage: PRIMARY_USAGE }])
+    fallback = fake_fallback(turns: [{ text: "Checkpoint.", usage: Mistri::Usage.new(input: 1) }])
+    compaction = Mistri::Compaction.new(**SETTINGS, fallback:)
+
+    error = assert_raises(Mistri::ConfigurationError) do
+      Mistri::Agent.new(provider:, compaction:, budget: Mistri::Budget.new(cost_usd: 1.0))
+    end
+
+    assert_includes error.message, "fallback-1"
+    assert_kind_of Mistri::Agent, Mistri::Agent.new(provider:, compaction:)
+  end
+
+  def test_a_fallback_naming_the_primary_model_is_never_asked
+    twin = Mistri::Providers::Fake.new(turns: [{ text: "must not run" }])
+    provider = Mistri::Providers::Fake.new(turns: [incomplete_turn])
+
+    error = assert_raises(Mistri::CompactionError) do
+      Mistri::Compactor.call(session: history, provider:, settings: settings(fallback: twin))
+    end
+
+    assert_equal "summarization failed: fake-1: unexpected stop reason: :length", error.message
+    assert_empty twin.requests
+
+    provider = Mistri::Providers::Fake.new(turns: [incomplete_turn])
+
+    assert_raises(Mistri::CompactionError) do
+      Mistri::Compactor.call(session: history, provider:, settings: settings(fallback: provider))
+    end
+    assert_equal 1, provider.requests.length
+  end
+
+  def test_a_reply_without_a_model_is_attributed_to_the_provider_that_wrote_it
+    session = history
+    provider = Mistri::Providers::Fake.new(turns: [incomplete_turn])
+    fallback = scripted(model: "custom-1", replies: [checkpoint_reply(usage: FALLBACK_USAGE)])
+    events = []
+
+    Mistri::Compactor.call(session:, provider:, settings: settings(fallback:)) { |event| events << event }
+
+    assert_equal "custom-1", session.last_compaction.fetch("model")
+    assert_equal "custom-1", events.last.message.model
+  end
+
   def test_the_setting_takes_a_provider_or_a_model_id_and_rejects_the_rest
     provider = Mistri::Providers::Fake.new
 
@@ -134,6 +212,26 @@ class TestCompactionFallback < Minitest::Test
     fallback = Mistri::Providers::Fake.new(turns:)
     fallback.define_singleton_method(:model) { "fallback-1" }
     fallback
+  end
+
+  # The minimal custom-provider contract: stream and model, replies as given,
+  # with no model or usage metadata the provider did not put there.
+  def scripted(model:, replies:)
+    provider = Mistri::Providers::Fake.new
+    provider.define_singleton_method(:model) { model }
+    provider.define_singleton_method(:stream) do |**options|
+      requests << { options: }
+      replies.shift || raise("no scripted reply left")
+    end
+    provider
+  end
+
+  def incomplete_reply(usage:)
+    Mistri::Message.assistant(content: "private unfinished summary", stop_reason: :length, usage:)
+  end
+
+  def checkpoint_reply(usage:)
+    Mistri::Message.assistant(content: "Checkpoint.", stop_reason: :stop, usage:)
   end
 
   def with_env(values)

--- a/test/test_compaction_fallback_live.rb
+++ b/test/test_compaction_fallback_live.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "tmpdir"
+require_relative "test_helper"
+
+# A failed primary summary must not end compaction when the host named a
+# fallback: a real Haiku writes the checkpoint and a continuation on the
+# reloaded session still recalls the original requirement.
+class TestCompactionFallbackLive < Minitest::Test
+  def setup
+    skip "set MISTRI_LIVE=1 for live tests" unless ENV["MISTRI_LIVE"] == "1"
+    skip "no ANTHROPIC_API_KEY" if ENV["ANTHROPIC_API_KEY"].to_s.empty?
+
+    @fallback = Mistri::Providers::Anthropic.new(
+      api_key: ENV.fetch("ANTHROPIC_API_KEY"), model: "claude-haiku-4-5-20251001",
+      thinking: { type: "disabled" }, service_tier: "standard_only", read_timeout: 120
+    )
+  end
+
+  def teardown
+    @fallback&.close
+  end
+
+  def test_a_failed_primary_hands_the_checkpoint_to_the_fallback
+    Dir.mktmpdir do |dir|
+      filename = "export-#{SecureRandom.hex(12)}.json"
+      session = export_session(dir, filename)
+      primary = Mistri::Providers::Fake.new(turns: [{ error: "the model refused to respond" }])
+      settings = Mistri::Compaction.new(keep_recent: 20, fallback: @fallback)
+      events = []
+
+      result = Mistri::Compactor.call(session:, provider: primary, settings:) do |event|
+        events << event.type
+      end
+
+      assert_equal %i[compacting compaction], events
+      assert_equal "claude-haiku-4-5-20251001", session.last_compaction.fetch("model")
+      assert_operator result[:usage].output, :>, 0
+      assert_predicate result[:usage].cost, :known?
+      assert_equal 0, session.compaction_failures
+
+      reloaded = Mistri::Session.new(store: Mistri::Stores::JSONL.new(dir), id: session.id)
+      question = Mistri::Message.user("Which exact filename must the export use? Reply with " \
+                                      "the filename only.")
+      reply = Mistri::Test.retry_transient do
+        @fallback.stream(messages: reloaded.messages + [question], system: "Answer precisely.")
+      end
+
+      assert_equal :stop, reply.stop_reason, reply.error_message
+      assert_includes reply.text, filename
+    end
+  end
+
+  private
+
+  def export_session(dir, filename)
+    session = Mistri::Session.new(store: Mistri::Stores::JSONL.new(dir))
+    session.append_message(Mistri::Message.user(
+                             "Prepare an export of active European customers, sorted by id. " \
+                             "Use only id, company, and region fields. The exact export " \
+                             "filename must be #{filename}. Do not write the file yet."
+                           ))
+    session.append_message(Mistri::Message.assistant(
+                             content: "Preparation notes: validate the source records, retain " \
+                                      "the requested fields, and await permission to export. " * 50,
+                             stop_reason: :stop
+                           ))
+    session.append_message(Mistri::Message.user("Leave the export pending until I return."))
+    session.append_message(Mistri::Message.assistant(content: "Ready.", stop_reason: :stop))
+    session
+  end
+end

--- a/test/test_logger_sink.rb
+++ b/test/test_logger_sink.rb
@@ -89,6 +89,9 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
                                 tool_call: tool_call("send_gift", { "to" => "sarah" })))
     sink.call(Mistri::Event.new(type: :compacting))
     sink.call(Mistri::Event.new(type: :compaction, content: "The story so far"))
+    sink.call(Mistri::Event.new(type: :compaction, content: "The story again",
+                                message: Mistri::Message.assistant(content: "The story again",
+                                                                   model: "claude-sonnet-5")))
     sink.call(Mistri::Event.new(type: :compaction_failed,
                                 error_message: "unexpected stop reason: :length"))
     sink.call(Mistri::Event.new(type: :subagent_report, agent: "Corgi",
@@ -99,6 +102,7 @@ class TestLoggerSink < Minitest::Test # rubocop:disable Metrics/ClassLength -- o
     assert_match(/INFO \[mistri\] approval needed send_gift#c1 \{"to":"sarah"\}/, io.string)
     assert_match(/INFO \[mistri\] compacting/, io.string)
     assert_match(/INFO \[mistri\] compacted "The story so far"/, io.string)
+    assert_match(/INFO \[mistri\] compacted \(claude-sonnet-5\) "The story again"/, io.string)
     assert_match(/WARN \[mistri\] compaction failed: unexpected stop reason: :length/, io.string)
     assert_match(/INFO \[mistri\] worker Corgi \(ef56ab12\) done "found it"/, io.string)
   end


### PR DESCRIPTION
A summary can fail for reasons no limit fixes. In a live experiment Opus 5 refused a mundane synthetic ledger session on every attempt, in every request shape, and Fable 5.1 refused two of five at 180k tokens. Since #64 that ends in three recorded failures and a context-limit error, with no way to say which model should step in.

`Compaction.new(fallback:)` names a second summarizer, a provider or a model id resolved at construction, that gets one try when the session's provider cannot write a usable summary for any reason. The model that failed is never asked again: a fallback naming the primary's own model is skipped. The host chooses it, so a refusal never changes models silently. The compaction entry records which model wrote the summary, the `:compaction` event carries that reply in `message`, the logger shows the model, and a failure reason names each model. Both attempts' usage is counted in the Compactor result and the agent's accounting; an attempt without usage counts as unknown cost. A cost-budgeted agent validates the fallback's pricing at construction and never dispatches it after an unpriced attempt.

Nothing changes without the setting, apart from the recorded model and the model prefix on failure reasons. The Fake provider's replies now report `provider.model`, so a test can tell two fakes apart.

Verified with the full suite on Ruby 3.2 and 3.3, RuboCop, the live Haiku and Fable compaction regressions, a new opt-in live test where a failing primary hands the checkpoint to a real Haiku and the reloaded session still recalls the original filename, and a live run where a real Opus 5 refusal fell through to Sonnet 5, which wrote a complete checkpoint with every seeded fact intact.
