### PR TITLE
Compare numbers without bigdecimal in the eval grader

### DIFF
--- a/eval/compaction/grader.rb
+++ b/eval/compaction/grader.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bigdecimal"
-
 module CompactionEval
   # Deterministic grading: a probe passes when the reply carries the expected
   # value after normalization, a yes/no probe when its first word is the
@@ -47,7 +45,7 @@ module CompactionEval
     def same?(actual, expected)
       left = normalize(actual)
       right = normalize(expected)
-      return BigDecimal(left) == BigDecimal(right) if [left, right].all? { |v| v.match?(NUMBER) }
+      return left.to_r == right.to_r if [left, right].all? { |v| v.match?(NUMBER) }
 
       left == right || carries?(left, right)
     end


### PR DESCRIPTION
The eval grader required bigdecimal to compare numbers exactly. On Ruby 3.4 bigdecimal is a bundled gem, and the compaction-eval jobs install without the Gemfile groups that pulled it in transitively, so every eval and compare job failed at boot the first time the workflow was approved to run. Rational compares the same decimal strings exactly with no dependency.

The compare job deliberately grades with the base branch's code, so this has to land on main before any pull request's comparison can run.

Verified with the eval tests, RuboCop, and the eval CLI booting under Ruby 3.4 with the workflow's bundle groups.